### PR TITLE
Introduce correctly styled successMessage and informationMessage

### DIFF
--- a/webapp/src/main/java/life/qbic/views/components/InformationMessage.java
+++ b/webapp/src/main/java/life/qbic/views/components/InformationMessage.java
@@ -1,0 +1,29 @@
+package life.qbic.views.components;
+
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+
+/**
+ * <b> A InformationMessage component which shows a primarily styled information message with a title and a detailed
+ * description. </b>
+ *
+ * @since 1.0.0
+ */
+public class InformationMessage extends DisplayMessage {
+
+  public InformationMessage(String titleText, String descriptionText) {
+    super(titleText, descriptionText);
+  }
+
+  @Override
+  protected void configureIcon() {
+    messageIcon = new Icon(VaadinIcon.INFO_CIRCLE_O);
+    messageIcon.addClassName("icon-s");
+  }
+
+  @Override
+  protected void styleSpecificLayout() {
+    getContent()
+        .addClassNames("p-s", "text-primary", "bg-primary-10", "rounded-l", "gap-y-s");
+  }
+}

--- a/webapp/src/main/java/life/qbic/views/components/SuccessMessage.java
+++ b/webapp/src/main/java/life/qbic/views/components/SuccessMessage.java
@@ -4,7 +4,7 @@ import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 
 /**
- * <b> A SuccessMessage component which shows a successful message with a title and a detailed
+ * <b> A SuccessMessage component which shows a success message with a title and a detailed
  * description. </b>
  *
  * @since 1.0.0
@@ -17,13 +17,11 @@ public class SuccessMessage extends DisplayMessage {
 
   @Override
   protected void configureIcon() {
-    messageIcon = new Icon(VaadinIcon.CHECK_CIRCLE);
+    messageIcon = new Icon(VaadinIcon.CHECK_CIRCLE_O);
     messageIcon.addClassName("icon-s");
   }
-
   @Override
   protected void styleSpecificLayout() {
-    getContent()
-        .addClassNames("p-s", "text-secondary", "bg-primary-10", "rounded-l", "gap-y-s");
+    super.getContent().addClassNames("p-s", "text-success", "bg-success-10", "rounded-l", "gap-y-s");
   }
 }

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -2,14 +2,12 @@ package life.qbic.views.login;
 
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.router.BeforeEvent;
-import com.vaadin.flow.router.RouterLink;
 import java.util.List;
 import java.util.Map;
 import life.qbic.domain.usermanagement.User;
 import life.qbic.domain.usermanagement.registration.ConfirmEmailInput;
 import life.qbic.domain.usermanagement.registration.ConfirmEmailOutput;
 import life.qbic.usermanagement.persistence.UserJpaRepository;
-import life.qbic.views.helloworld.HelloWorldView;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -39,14 +37,9 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
       registeredLoginView = loginView;
     }
     initFields();
-    setupVisibility();
+    resetMessages();
     addListener();
   }
-
-  private void setupVisibility() {
-    registeredLoginView.confirmationSuccessMessage.setVisible(false);
-  }
-
   private void initFields() {
     registeredLoginView.password.setHelperText("A password must be at least 8 characters");
     registeredLoginView.password.setPattern(".{8,}");
@@ -105,7 +98,7 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
 
   private void resetMessages() {
     registeredLoginView.errorMessage.setVisible(false);
-    registeredLoginView.confirmationSuccessMessage.setVisible(false);
+    registeredLoginView.confirmationInformationMessage.setVisible(false);
   }
 
   private void resetComponentErrors() {
@@ -116,9 +109,9 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   @Override
   public void onEmailConfirmationSuccess() {
     resetMessages();
-    registeredLoginView.confirmationSuccessMessage.titleTextSpan.setText("Email address confirmed");
-    registeredLoginView.confirmationSuccessMessage.descriptionTextSpan.setText("You can now login with your credentials.");
-    registeredLoginView.confirmationSuccessMessage.setVisible(true);
+    registeredLoginView.confirmationInformationMessage.titleTextSpan.setText("Email address confirmed");
+    registeredLoginView.confirmationInformationMessage.descriptionTextSpan.setText("You can now login with your credentials.");
+    registeredLoginView.confirmationInformationMessage.setVisible(true);
   }
 
   @Override

--- a/webapp/src/main/java/life/qbic/views/login/LoginLayout.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginLayout.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import java.util.stream.Stream;
 import life.qbic.views.components.ErrorMessage;
-import life.qbic.views.components.SuccessMessage;
+import life.qbic.views.components.InformationMessage;
 import life.qbic.views.landing.LandingPageLayout;
 import life.qbic.views.register.UserRegistrationLayout;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +50,8 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
   private H2 layoutTitle;
  private transient LoginHandlerInterface loginHandlerInterface;
 
-  public SuccessMessage confirmationSuccessMessage;
+  public InformationMessage confirmationInformationMessage;
+
   public ErrorMessage errorMessage;
 
   public ErrorMessage invalidEmailMessage;
@@ -105,7 +106,7 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
 
   private void createDivs() {
     createErrorDivs();
-    createSuccessDivs();
+    createInformationDivs();
   }
 
   private void createErrorDivs() {
@@ -122,10 +123,10 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
     emailConfirmationFailedMessage.setVisible(false);
   }
 
-  private void createSuccessDivs() {
-    confirmationSuccessMessage = new SuccessMessage("What a success!",
-        "I don't know what you want to show here");
-    confirmationSuccessMessage.setVisible(false);
+  private void createInformationDivs() {
+    confirmationInformationMessage = new InformationMessage("What an information!",
+        "so much information");
+    confirmationInformationMessage.setVisible(false);
   }
 
   private void styleFormLayout() {
@@ -145,7 +146,7 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
     contentLayout.add(
         layoutTitle,
         errorMessage,
-        confirmationSuccessMessage,
+        confirmationInformationMessage,
         email,
         password,
         loginButton,

--- a/webapp/src/main/java/life/qbic/views/register/UserRegistrationLayout.java
+++ b/webapp/src/main/java/life/qbic/views/register/UserRegistrationLayout.java
@@ -18,7 +18,7 @@ import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import java.util.stream.Stream;
 import life.qbic.views.components.ErrorMessage;
-import life.qbic.views.components.SuccessMessage;
+import life.qbic.views.components.InformationMessage;
 import life.qbic.views.landing.LandingPageLayout;
 import life.qbic.views.login.LoginLayout;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +48,7 @@ public class UserRegistrationLayout extends VerticalLayout {
   public ErrorMessage passwordTooShortMessage;
   public ErrorMessage errorMessage;
 
-  public SuccessMessage confirmationSuccessMessage;
+  public InformationMessage confirmationInformationMessage;
 
   private final VerticalLayout contentLayout;
   private H2 layoutTitle;
@@ -97,7 +97,7 @@ public class UserRegistrationLayout extends VerticalLayout {
 
   private void createDivs() {
     createErrorDivs();
-    createSuccessDivs();
+    createInformationDivs();
   }
 
   private void createErrorDivs() {
@@ -115,10 +115,10 @@ public class UserRegistrationLayout extends VerticalLayout {
     errorMessage.setVisible(false);
   }
 
-  private void createSuccessDivs() {
-    confirmationSuccessMessage = new SuccessMessage("Confirmation successful",
+  private void createInformationDivs() {
+    confirmationInformationMessage = new InformationMessage("Confirmation successful",
         "You can now login with your credentials");
-    confirmationSuccessMessage.setVisible(false);
+    confirmationInformationMessage.setVisible(false);
   }
 
   private void styleNameField() {
@@ -144,7 +144,7 @@ public class UserRegistrationLayout extends VerticalLayout {
         errorMessage,
         alreadyUsedEmailMessage,
         passwordTooShortMessage,
-        confirmationSuccessMessage,
+        confirmationInformationMessage,
         fullName,
         email,
         password,


### PR DESCRIPTION
Replaces the wrongly titled successmessage with an information message used for email confirmation. 
Additionally introduces a correctly styled SuccessMessage. 
Style adheres to the notification prototypes in [Figma](https://www.figma.com/file/mYcW5viu5GpPZ852VHYBrV/Start-Page?node-id=0%3A1) 
Demo of the new Notifications: 
![Success and Information Notification](https://user-images.githubusercontent.com/29627977/171375599-4e90f049-2e94-4925-bfd0-b7fa7ed6cd9a.png)

