### PR TITLE
Move Notification Logic from each Layout to their respective Handler

### DIFF
--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -83,8 +83,7 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   public void showInformation(InformationMessage message) {
-    registeredLoginView.notificationLayout.add(
-        new InformationMessage(message.title(), message.message()));
+    registeredLoginView.notificationLayout.add(message);
     registeredLoginView.notificationLayout.setVisible(true);
   }
 

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -78,8 +78,7 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   public void showError(ErrorMessage errorMessage) {
-    registeredLoginView.notificationLayout.add(
-        new ErrorMessage(errorMessage.title(), errorMessage.message()));
+    registeredLoginView.notificationLayout.add(errorMessage);
     registeredLoginView.notificationLayout.setVisible(true);
   }
 

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -25,20 +25,6 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   private final ConfirmEmailInput confirmEmailInput;
 
   private final String emailConfirmationParameter;
-  private static final ErrorMessage INCORRECT_USERNAME_OR_PASSWORD = new ErrorMessage(
-      "Incorrect username or password",
-      "Please try again."
-  );
-
-  private static final InformationMessage EMAIL_CONFIRMATION_SUCCESS = new InformationMessage(
-      "Email address confirmed",
-      "You can now login with your credentials."
-  );
-
-  private static final InformationMessage EMAIL_CONFIRMATION_REMINDER = new InformationMessage(
-      "Registration email sent",
-      "Please check your email inbox to confirm your registration"
-  );
 
   @Autowired
   LoginHandler(ConfirmEmailInput confirmEmailInput,
@@ -61,15 +47,17 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   private void showInvalidCredentialsError() {
-    showError(INCORRECT_USERNAME_OR_PASSWORD);
+    showError(new ErrorMessage("Incorrect username or password", "Please try again."));
   }
 
   private void showEmailConfirmationInformation() {
-    showInformation(EMAIL_CONFIRMATION_SUCCESS);
+    showInformation(new InformationMessage("Email address confirmed",
+        "You can now login with your credentials."));
   }
 
   private void showEmailConfirmationReminder() {
-    showInformation(EMAIL_CONFIRMATION_REMINDER);
+    showInformation(new InformationMessage("Registration email sent",
+        "Please check your email inbox to confirm your registration"));
   }
 
   public void clearNotifications() {
@@ -77,10 +65,12 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   public void showError(ErrorMessage errorMessage) {
+    clearNotifications();
     registeredLoginView.notificationLayout.add(errorMessage);
   }
 
   public void showInformation(InformationMessage message) {
+    clearNotifications();
     registeredLoginView.notificationLayout.add(message);
   }
 
@@ -112,7 +102,6 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
 
   @Override
   public void onEmailConfirmationSuccess() {
-    clearNotifications();
     showEmailConfirmationInformation();
   }
 

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -47,31 +47,32 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   private void showInvalidCredentialsError() {
-    showError(new ErrorMessage("Incorrect username or password", "Please try again."));
+    showError("Incorrect username or password", "Please try again.");
   }
 
   private void showEmailConfirmationInformation() {
-    showInformation(new InformationMessage("Email address confirmed",
-        "You can now login with your credentials."));
+    showInformation("Email address confirmed", "You can now login with your credentials.");
   }
 
   private void showEmailConfirmationReminder() {
-    showInformation(new InformationMessage("Registration email sent",
-        "Please check your email inbox to confirm your registration"));
+    showInformation("Registration email sent",
+        "Please check your email inbox to confirm your registration");
   }
 
   public void clearNotifications() {
     registeredLoginView.notificationLayout.removeAll();
   }
 
-  public void showError(ErrorMessage errorMessage) {
+  public void showError(String title, String description) {
     clearNotifications();
+    ErrorMessage errorMessage = new ErrorMessage(title, description);
     registeredLoginView.notificationLayout.add(errorMessage);
   }
 
-  public void showInformation(InformationMessage message) {
+  public void showInformation(String title, String description) {
     clearNotifications();
-    registeredLoginView.notificationLayout.add(message);
+    InformationMessage informationMessage = new InformationMessage(title, description);
+    registeredLoginView.notificationLayout.add(informationMessage);
   }
 
   private void addListener() {
@@ -107,6 +108,6 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
 
   @Override
   public void onEmailConfirmationFailure(String reason) {
-    showError(new ErrorMessage("Email confirmation failed", reason));
+    showError("Email confirmation failed", reason);
   }
 }

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -73,18 +73,15 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   public void clearNotifications() {
-    registeredLoginView.notificationLayout.setVisible(false);
     registeredLoginView.notificationLayout.removeAll();
   }
 
   public void showError(ErrorMessage errorMessage) {
     registeredLoginView.notificationLayout.add(errorMessage);
-    registeredLoginView.notificationLayout.setVisible(true);
   }
 
   public void showInformation(InformationMessage message) {
     registeredLoginView.notificationLayout.add(message);
-    registeredLoginView.notificationLayout.setVisible(true);
   }
 
   private void addListener() {

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -57,24 +57,36 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   private void initFields() {
-    clearMessages();
-  }
-
-  private void clearMessages() {
-    registeredLoginView.clearErrors();
-    registeredLoginView.clearInformation();
+    clearNotifications();
   }
 
   private void showInvalidCredentialsError() {
-    registeredLoginView.showError(INCORRECT_USERNAME_OR_PASSWORD);
+    showError(INCORRECT_USERNAME_OR_PASSWORD);
   }
 
   private void showEmailConfirmationInformation() {
-    registeredLoginView.showInformation(EMAIL_CONFIRMATION_SUCCESS);
+    showInformation(EMAIL_CONFIRMATION_SUCCESS);
   }
 
   private void showEmailConfirmationReminder() {
-    registeredLoginView.showInformation(EMAIL_CONFIRMATION_REMINDER);
+    showInformation(EMAIL_CONFIRMATION_REMINDER);
+  }
+
+  public void clearNotifications() {
+    registeredLoginView.notificationLayout.setVisible(false);
+    registeredLoginView.notificationLayout.removeAll();
+  }
+
+  public void showError(ErrorMessage errorMessage) {
+    registeredLoginView.notificationLayout.add(
+        new ErrorMessage(errorMessage.title(), errorMessage.message()));
+    registeredLoginView.notificationLayout.setVisible(true);
+  }
+
+  public void showInformation(InformationMessage message) {
+    registeredLoginView.notificationLayout.add(
+        new InformationMessage(message.title(), message.message()));
+    registeredLoginView.notificationLayout.setVisible(true);
   }
 
   private void addListener() {
@@ -83,7 +95,7 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   private void onLoginSucceeded() {
-    clearMessages();
+    clearNotifications();
     UI.getCurrent().navigate("/hello");
   }
 
@@ -98,20 +110,19 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
       String userId = queryParams.get(emailConfirmationParameter).iterator().next();
       confirmEmailInput.confirmEmailAddress(userId);
     }
-    if (queryParams.containsKey("userRegistered")){
-     showEmailConfirmationReminder();
+    if (queryParams.containsKey("userRegistered")) {
+      showEmailConfirmationReminder();
     }
   }
 
   @Override
   public void onEmailConfirmationSuccess() {
-    clearMessages();
+    clearNotifications();
     showEmailConfirmationInformation();
-
   }
 
   @Override
   public void onEmailConfirmationFailure(String reason) {
-    registeredLoginView.showError(new ErrorMessage("Email confirmation failed", reason));
+    showError(new ErrorMessage("Email confirmation failed", reason));
   }
 }

--- a/webapp/src/main/java/life/qbic/views/login/LoginLayout.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginLayout.java
@@ -53,17 +53,11 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
 
   private void initLayout() {
     contentLayout = new VerticalLayout();
-    this.loginForm = new ConfigurableLoginForm();
-    loginForm.setAction("login");
-
-    notificationLayout = new VerticalLayout();
-
+    createNotificationLayout();
+    createLoginForm();
     this.registrationSection = initRegistrationSection();
-
     title = new H2("Log in");
-
     contentLayout.add(title, notificationLayout, loginForm, registrationSection);
-
     add(contentLayout);
   }
 
@@ -72,12 +66,11 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
   }
 
   private void styleLayout() {
+    styleNotificationLayout();
     styleFormLayout();
     setSizeFull();
     setAlignItems(FlexComponent.Alignment.CENTER);
     setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
-    notificationLayout.setPadding(false);
-    loginForm.setUsernameText("Email");
   }
 
   private void styleFormLayout() {
@@ -101,9 +94,23 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
         "pl-l");
   }
 
+  private void createNotificationLayout() {
+    notificationLayout = new VerticalLayout();
+  }
+
+  private void createLoginForm() {
+    this.loginForm = new ConfigurableLoginForm();
+    loginForm.setAction("login");
+    loginForm.setUsernameText("Email");
+  }
+
   private Div initRegistrationSection() {
     RouterLink routerLink = new RouterLink("REGISTER", UserRegistrationLayout.class);
     return new Div(new Text("Need an account? "), routerLink);
+  }
+
+  private void styleNotificationLayout() {
+    notificationLayout.setPadding(false);
   }
 
   public void addLoginListener(ComponentEventListener<LoginEvent> loginListener) {

--- a/webapp/src/main/java/life/qbic/views/login/LoginLayout.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginLayout.java
@@ -16,8 +16,6 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
-import life.qbic.views.components.ErrorMessage;
-import life.qbic.views.components.InformationMessage;
 import life.qbic.views.landing.LandingPageLayout;
 import life.qbic.views.register.UserRegistrationLayout;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,9 +33,7 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
 
   private VerticalLayout contentLayout;
 
-  private VerticalLayout informationContainer;
-
-  private VerticalLayout errorContainer;
+  public VerticalLayout notificationLayout;
   private H2 title;
 
   private ConfigurableLoginForm loginForm;
@@ -60,14 +56,13 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
     this.loginForm = new ConfigurableLoginForm();
     loginForm.setAction("login");
 
-    this.registrationSection = initRegistrationSection();
+    notificationLayout = new VerticalLayout();
 
-    informationContainer = new VerticalLayout();
-    errorContainer = new VerticalLayout();
+    this.registrationSection = initRegistrationSection();
 
     title = new H2("Log in");
 
-    contentLayout.add(title, informationContainer, errorContainer, loginForm, registrationSection);
+    contentLayout.add(title, notificationLayout, loginForm, registrationSection);
 
     add(contentLayout);
   }
@@ -81,8 +76,7 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
     setSizeFull();
     setAlignItems(FlexComponent.Alignment.CENTER);
     setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
-    informationContainer.setPadding(false);
-    errorContainer.setPadding(false);
+    notificationLayout.setPadding(false);
     loginForm.setUsernameText("Email");
   }
 
@@ -110,26 +104,6 @@ public class LoginLayout extends VerticalLayout implements HasUrlParameter<Strin
   private Div initRegistrationSection() {
     RouterLink routerLink = new RouterLink("REGISTER", UserRegistrationLayout.class);
     return new Div(new Text("Need an account? "), routerLink);
-  }
-
-  public void clearErrors() {
-    errorContainer.setVisible(false);
-    errorContainer.removeAll();
-  }
-
-  public void showError(ErrorMessage errorMessage) {
-    errorContainer.add(new ErrorMessage(errorMessage.title(), errorMessage.message()));
-    errorContainer.setVisible(true);
-  }
-
-  public void showInformation(InformationMessage message) {
-    informationContainer.add(new InformationMessage(message.title(), message.message()));
-    informationContainer.setVisible(true);
-  }
-
-  public void clearInformation() {
-    informationContainer.setVisible(false);
-    informationContainer.removeAll();
   }
 
   public void addLoginListener(ComponentEventListener<LoginEvent> loginListener) {

--- a/webapp/src/main/java/life/qbic/views/register/UserRegistrationHandler.java
+++ b/webapp/src/main/java/life/qbic/views/register/UserRegistrationHandler.java
@@ -8,7 +8,6 @@ import life.qbic.identityaccess.application.user.UserRegistrationException;
 import com.vaadin.flow.router.QueryParameters;
 import java.util.Map;
 import life.qbic.views.components.ErrorMessage;
-import life.qbic.views.components.InformationMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -74,14 +73,11 @@ public class UserRegistrationHandler
   }
 
   private void clearNotifications() {
-    userRegistrationLayout.notificationLayout.setVisible(false);
     userRegistrationLayout.notificationLayout.removeAll();
   }
 
   private void showError(ErrorMessage errorMessage) {
-    userRegistrationLayout.notificationLayout.add(
-        new ErrorMessage(errorMessage.title(), errorMessage.message()));
-    userRegistrationLayout.notificationLayout.setVisible(true);
+    userRegistrationLayout.notificationLayout.add(errorMessage);
   }
 
   @Override

--- a/webapp/src/main/java/life/qbic/views/register/UserRegistrationHandler.java
+++ b/webapp/src/main/java/life/qbic/views/register/UserRegistrationHandler.java
@@ -26,14 +26,6 @@ public class UserRegistrationHandler
   private UserRegistrationLayout userRegistrationLayout;
   private final RegisterUserInput registrationUseCase;
 
-  private static final ErrorMessage alreadyUsedEmailMessage =
-      new ErrorMessage(
-          "Email address already in use",
-          "If you have difficulties with your password you can reset it.");
-
-  private static final ErrorMessage errorMessage = new ErrorMessage("Registration failed",
-      "Please try again.");
-
   @Autowired
   UserRegistrationHandler(RegisterUserInput registrationUseCase) {
     this.registrationUseCase = registrationUseCase;
@@ -77,7 +69,19 @@ public class UserRegistrationHandler
   }
 
   private void showError(ErrorMessage errorMessage) {
+    clearNotifications();
     userRegistrationLayout.notificationLayout.add(errorMessage);
+  }
+
+  private void showAlreadyUsedEmailError() {
+    showError(new ErrorMessage(
+        "Email address already in use",
+        "If you have difficulties with your password you can reset it."));
+  }
+
+  private void showUnexpectedError() {
+    showError(new ErrorMessage("Registration failed",
+        "Please try again."));
   }
 
   @Override
@@ -93,7 +97,7 @@ public class UserRegistrationHandler
 
   @Override
   public void onUnexpectedFailure(String reason) {
-    showError(errorMessage);
+    showUnexpectedError();
   }
 
   private void handleRegistrationFailure(UserRegistrationException userRegistrationException) {
@@ -107,10 +111,10 @@ public class UserRegistrationHandler
       userRegistrationLayout.email.setInvalid(true);
     }
     if (userRegistrationException.userExistsException().isPresent()) {
-      showError(alreadyUsedEmailMessage);
+      showAlreadyUsedEmailError();
     }
     if (userRegistrationException.unexpectedException().isPresent()) {
-      showError(errorMessage);
+      showUnexpectedError();
     }
   }
 }

--- a/webapp/src/main/java/life/qbic/views/register/UserRegistrationHandler.java
+++ b/webapp/src/main/java/life/qbic/views/register/UserRegistrationHandler.java
@@ -68,20 +68,19 @@ public class UserRegistrationHandler
     userRegistrationLayout.notificationLayout.removeAll();
   }
 
-  private void showError(ErrorMessage errorMessage) {
+  private void showError(String title, String description) {
     clearNotifications();
+    ErrorMessage errorMessage = new ErrorMessage(title, description);
     userRegistrationLayout.notificationLayout.add(errorMessage);
   }
 
   private void showAlreadyUsedEmailError() {
-    showError(new ErrorMessage(
-        "Email address already in use",
-        "If you have difficulties with your password you can reset it."));
+    showError("Email address already in use",
+        "If you have difficulties with your password you can reset it.");
   }
 
   private void showUnexpectedError() {
-    showError(new ErrorMessage("Registration failed",
-        "Please try again."));
+    showError("Registration failed", "Please try again.");
   }
 
   @Override

--- a/webapp/src/main/java/life/qbic/views/register/UserRegistrationLayout.java
+++ b/webapp/src/main/java/life/qbic/views/register/UserRegistrationLayout.java
@@ -17,8 +17,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import java.util.stream.Stream;
-import life.qbic.views.components.ErrorMessage;
-import life.qbic.views.components.InformationMessage;
 import life.qbic.views.landing.LandingPageLayout;
 import life.qbic.views.login.LoginLayout;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,11 +41,8 @@ public class UserRegistrationLayout extends VerticalLayout {
   public Button registerButton;
 
   public Span loginSpan;
-  public ErrorMessage alreadyUsedEmailMessage;
-  public ErrorMessage errorMessage;
 
-  public InformationMessage confirmationInformationMessage;
-
+  public VerticalLayout notificationLayout;
   private VerticalLayout fieldLayout;
   private final VerticalLayout contentLayout;
   private H2 layoutTitle;
@@ -68,9 +63,8 @@ public class UserRegistrationLayout extends VerticalLayout {
 
   private void initLayout() {
     layoutTitle = new H2("Register");
-
+    notificationLayout = new VerticalLayout();
     fieldLayout = new VerticalLayout();
-    createDivs();
     createEmailField();
     createNameField();
     createPasswordField();
@@ -88,27 +82,6 @@ public class UserRegistrationLayout extends VerticalLayout {
     setSizeFull();
     setAlignItems(FlexComponent.Alignment.CENTER);
     setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
-  }
-
-  private void createDivs() {
-    createErrorDivs();
-    createInformationDivs();
-  }
-
-  private void createErrorDivs() {
-    alreadyUsedEmailMessage =
-        new ErrorMessage(
-            "Email address already in use",
-            "If you have difficulties with your password you can reset it.");
-    alreadyUsedEmailMessage.setVisible(false);
-    errorMessage = new ErrorMessage("Registration failed", "Please try again.");
-    errorMessage.setVisible(false);
-  }
-
-  private void createInformationDivs() {
-    confirmationInformationMessage = new InformationMessage("Confirmation successful",
-        "You can now login with your credentials");
-    confirmationInformationMessage.setVisible(false);
   }
 
   private void createSpan() {
@@ -135,30 +108,10 @@ public class UserRegistrationLayout extends VerticalLayout {
   private void styleFormLayout() {
     contentLayout.setPadding(false);
     contentLayout.setMargin(false);
-    contentLayout.addClassNames(
-        "bg-base",
-        "border",
-        "rounded-m",
-        "border-contrast-10",
-        "box-border",
-        "flex",
-        "flex-col",
-        "w-full",
-        "text-s",
-        "shadow-l",
-        "min-width-300px",
-        "max-width-15vw",
-        "pb-l",
-        "pr-l",
-        "pl-l");
-    contentLayout.add(
-        layoutTitle,
-        errorMessage,
-        alreadyUsedEmailMessage,
-        confirmationInformationMessage,
-        fieldLayout,
-        registerButton,
-        loginSpan);
+    contentLayout.addClassNames("bg-base", "border", "rounded-m", "border-contrast-10",
+        "box-border", "flex", "flex-col", "w-full", "text-s", "shadow-l", "min-width-300px",
+        "max-width-15vw", "pb-l", "pr-l", "pl-l");
+    contentLayout.add(layoutTitle, notificationLayout, fieldLayout, registerButton, loginSpan);
   }
 
   private void styleFieldLayout() {

--- a/webapp/src/main/java/life/qbic/views/register/UserRegistrationLayout.java
+++ b/webapp/src/main/java/life/qbic/views/register/UserRegistrationLayout.java
@@ -63,25 +63,34 @@ public class UserRegistrationLayout extends VerticalLayout {
 
   private void initLayout() {
     layoutTitle = new H2("Register");
-    notificationLayout = new VerticalLayout();
-    fieldLayout = new VerticalLayout();
-    createEmailField();
-    createNameField();
-    createPasswordField();
+    createNotificationLayout();
+    createFieldLayout();
     createRegisterButton();
     createSpan();
-
     add(contentLayout);
+    contentLayout.add(layoutTitle, notificationLayout, fieldLayout, registerButton, loginSpan);
   }
 
   private void styleLayout() {
-
     styleFieldLayout();
+    styleNotificationLayout();
     styleRegisterButton();
     styleFormLayout();
     setSizeFull();
     setAlignItems(FlexComponent.Alignment.CENTER);
     setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+  }
+
+  private void createNotificationLayout() {
+    notificationLayout = new VerticalLayout();
+  }
+
+  private void createFieldLayout() {
+    fieldLayout = new VerticalLayout();
+    createEmailField();
+    createNameField();
+    createPasswordField();
+    fieldLayout.add(fullName, email, password);
   }
 
   private void createSpan() {
@@ -105,17 +114,19 @@ public class UserRegistrationLayout extends VerticalLayout {
     password = new PasswordField("Password");
   }
 
+  private void styleNotificationLayout() {
+    notificationLayout.setPadding(false);
+  }
+
   private void styleFormLayout() {
     contentLayout.setPadding(false);
     contentLayout.setMargin(false);
     contentLayout.addClassNames("bg-base", "border", "rounded-m", "border-contrast-10",
         "box-border", "flex", "flex-col", "w-full", "text-s", "shadow-l", "min-width-300px",
         "max-width-15vw", "pb-l", "pr-l", "pl-l");
-    contentLayout.add(layoutTitle, notificationLayout, fieldLayout, registerButton, loginSpan);
   }
 
   private void styleFieldLayout() {
-    fieldLayout.add(fullName, email, password);
     password.setWidthFull();
     email.setWidthFull();
     fullName.setWidthFull();


### PR DESCRIPTION
**Purpose of this PR**

This PR moves the notification Logic from the loginlayout and registrationlayout to their respective handler.
Additionally it cleans up the initlayout method by introducing dedicated methods to create and style the individual components. 