### PR TITLE
Add URL protocol to generated links

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,20 +12,8 @@
     <artifactId>core</artifactId>
     <name>Data Manager Core</name>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.spockframework</groupId>
-                <artifactId>spock-bom</artifactId>
-                <version>2.0-groovy-3.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>javax.persistence</groupId>
                 <artifactId>javax.persistence-api</artifactId>
@@ -53,61 +41,4 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.13.1</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>generateTestStubs</goal>
-                            <goal>compileTests</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>site</id>
-                        <phase>site</phase>
-                        <goals>
-                            <goal>generateStubs</goal>
-                            <goal>generateTestStubs</goal>
-                            <goal>groovydoc</goal>
-                            <goal>groovydocTests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs
-                    </groovyDocOutputDirectory>
-                    <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs
-                    </testGroovyDocOutputDirectory>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Spec</include>
-                    </includes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/core/src/test/groovy/life/qbic/domain/user/UserSpec.groovy
+++ b/core/src/test/groovy/life/qbic/domain/user/UserSpec.groovy
@@ -1,10 +1,6 @@
 package life.qbic.domain.user
 
-import life.qbic.identityaccess.domain.user.EmailAddress
-import life.qbic.identityaccess.domain.user.EncryptedPassword
-import life.qbic.identityaccess.domain.user.FullName
-import life.qbic.identityaccess.domain.user.PasswordReset
-import life.qbic.identityaccess.domain.user.User
+import life.qbic.identityaccess.domain.user.*
 import life.qbic.shared.domain.events.DomainEventPublisher
 import life.qbic.shared.domain.events.DomainEventSubscriber
 import spock.lang.Shared

--- a/core/src/test/groovy/life/qbic/domain/usermanagement/registration/RegistrationSpec.groovy
+++ b/core/src/test/groovy/life/qbic/domain/usermanagement/registration/RegistrationSpec.groovy
@@ -1,21 +1,14 @@
 package life.qbic.domain.usermanagement.registration
 
-import life.qbic.shared.application.notification.EventStore
-import life.qbic.shared.application.notification.MessageBusInterface
-import life.qbic.shared.application.notification.NotificationService
+import life.qbic.identityaccess.application.user.RegisterUserOutput
+import life.qbic.identityaccess.application.user.Registration
 import life.qbic.identityaccess.application.user.UserRegistrationException
 import life.qbic.identityaccess.application.user.UserRegistrationService
 import life.qbic.identityaccess.domain.DomainRegistry
-import life.qbic.identityaccess.domain.user.UserDataStorage
-import life.qbic.identityaccess.domain.user.UserRepository
-import life.qbic.identityaccess.domain.user.EmailAddress
-import life.qbic.identityaccess.domain.user.EncryptedPassword
-import life.qbic.identityaccess.domain.user.FullName
-import life.qbic.identityaccess.application.user.RegisterUserOutput
-import life.qbic.identityaccess.application.user.Registration
-import life.qbic.identityaccess.domain.user.User
-import life.qbic.identityaccess.domain.user.UserDomainService
-import life.qbic.identityaccess.domain.user.UserId
+import life.qbic.identityaccess.domain.user.*
+import life.qbic.shared.application.notification.EventStore
+import life.qbic.shared.application.notification.MessageBusInterface
+import life.qbic.shared.application.notification.NotificationService
 import spock.lang.Shared
 import spock.lang.Specification
 

--- a/core/src/test/groovy/life/qbic/domain/usermanagement/repository/UserRepositorySpec.groovy
+++ b/core/src/test/groovy/life/qbic/domain/usermanagement/repository/UserRepositorySpec.groovy
@@ -1,13 +1,6 @@
 package life.qbic.domain.usermanagement.repository
 
-
-import life.qbic.identityaccess.domain.user.EmailAddress
-import life.qbic.identityaccess.domain.user.EncryptedPassword
-import life.qbic.identityaccess.domain.user.FullName
-import life.qbic.identityaccess.domain.user.User
-import life.qbic.identityaccess.domain.user.UserDataStorage
-import life.qbic.identityaccess.domain.user.UserId
-import life.qbic.identityaccess.domain.user.UserRepository
+import life.qbic.identityaccess.domain.user.*
 import spock.lang.Specification
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
   <properties>
     <java.version>17</java.version>
     <vaadin.version>23.0.1</vaadin.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <parent>
@@ -107,4 +109,71 @@
       <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
     </snapshotRepository>
   </distributionManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+          <groupId>org.spockframework</groupId>
+          <artifactId>spock-core</artifactId>
+          <version>2.1-groovy-3.0</version>
+          <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.13.1</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>addSources</goal>
+              <goal>addTestSources</goal>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>compileTests</goal>
+              <goal>removeStubs</goal>
+              <goal>removeTestStubs</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>site</id>
+            <phase>site</phase>
+            <goals>
+              <goal>generateStubs</goal>
+              <goal>generateTestStubs</goal>
+              <goal>groovydoc</goal>
+              <goal>groovydocTests</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs
+          </groovyDocOutputDirectory>
+          <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs
+          </testGroovyDocOutputDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <includes>
+            <include>**/*Spec</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -165,12 +165,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-      <dependency>
-        <groupId>org.spockframework</groupId>
-        <artifactId>spock-core</artifactId>
-        <version>2.1-groovy-3.0</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <scope>test</scope>
+        </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-mail</artifactId>
@@ -207,51 +206,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.13.1</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>addTestSources</goal>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>generateTestStubs</goal>
-                            <goal>compileTests</goal>
-                            <goal>removeStubs</goal>
-                            <goal>removeTestStubs</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>site</id>
-                        <phase>site</phase>
-                        <goals>
-                            <goal>generateStubs</goal>
-                            <goal>generateTestStubs</goal>
-                            <goal>groovydoc</goal>
-                            <goal>groovydocTests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs
-                    </groovyDocOutputDirectory>
-                    <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs
-                    </testGroovyDocOutputDirectory>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <includes>
-                        <include>**/*Spec</include>
-                    </includes>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -208,6 +208,51 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.13.1</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
+                            <goal>generateStubs</goal>
+                            <goal>compile</goal>
+                            <goal>generateTestStubs</goal>
+                            <goal>compileTests</goal>
+                            <goal>removeStubs</goal>
+                            <goal>removeTestStubs</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>site</id>
+                        <phase>site</phase>
+                        <goals>
+                            <goal>generateStubs</goal>
+                            <goal>generateTestStubs</goal>
+                            <goal>groovydoc</goal>
+                            <goal>groovydocTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <groovyDocOutputDirectory>${project.build.directory}/site/gapidocs
+                    </groovyDocOutputDirectory>
+                    <testGroovyDocOutputDirectory>${project.build.directory}/site/testgapidocs
+                    </testGroovyDocOutputDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Spec</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
  *
  * @since 1.0.0
  */
-class PasswordResetLinkSupplier {
+public class PasswordResetLinkSupplier {
 
   private final String protocol;
 

--- a/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
@@ -1,5 +1,7 @@
 package life.qbic.usermanagement.passwordreset;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
@@ -15,7 +17,7 @@ class PasswordResetLinkSupplier {
 
   private final String host;
 
-  private final String port;
+  private int port;
 
   private final String resetEndpoint;
 
@@ -24,7 +26,7 @@ class PasswordResetLinkSupplier {
   public PasswordResetLinkSupplier(
       @Value("${service.host.protocol}") String protocol,
       @Value("${service.host.name}") String host,
-      @Value("${server.port}") String port,
+      @Value("${server.port}") int port,
       @Value("${password-reset-endpoint}") String resetEndpoint,
       @Value("${email-password-reset-parameter}") String passwordResetParameter) {
     this.protocol = protocol;
@@ -34,8 +36,9 @@ class PasswordResetLinkSupplier {
     this.passwordResetParameter = passwordResetParameter;
   }
 
-  public String passwordResetUrl(String userId) {
-    return String.format("%s://%s:%s/%s?%s=%s", protocol, host, port, resetEndpoint,
-        passwordResetParameter, userId);
+  public String passwordResetUrl(String userId) throws MalformedURLException {
+    String pathWithQuery = "/" + resetEndpoint + "?" + passwordResetParameter + "=" + userId;
+
+    return new URL(protocol, host, port, pathWithQuery).toExternalForm();
   }
 }

--- a/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
@@ -19,7 +19,7 @@ class PasswordResetLinkSupplier {
 
   private final String resetEndpoint;
 
-  private final String emailConfirmationParameter;
+  private final String passwordResetParameter;
 
   public PasswordResetLinkSupplier(
       @Value("${service.host.protocol}") String protocol,

--- a/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
@@ -11,28 +11,31 @@ import org.springframework.beans.factory.annotation.Value;
  */
 class PasswordResetLinkSupplier {
 
+  private final String protocol;
+
   private final String host;
 
   private final String port;
 
-  private final String loginEndpoint;
+  private final String resetEndpoint;
 
   private final String emailConfirmationParameter;
 
-  public PasswordResetLinkSupplier(@Value("${host.name}") String host,
+  public PasswordResetLinkSupplier(
+      @Value("${service.host.protocol}") String protocol,
+      @Value("${service.host.name}") String host,
       @Value("${server.port}") String port,
-      @Value("${login-endpoint}") String loginEndpoint,
+      @Value("${password-reset-endpoint}") String resetEndpoint,
       @Value("${email-password-reset-parameter}") String emailConfirmationParameter) {
+    this.protocol = protocol;
     this.host = host;
     this.port = port;
-    this.loginEndpoint = loginEndpoint;
+    this.resetEndpoint = resetEndpoint;
     this.emailConfirmationParameter = emailConfirmationParameter;
   }
 
   public String passwordResetUrl(String userId) {
-    String hostAddress = String.join(":", host, port);
-    String params = String.join("=", emailConfirmationParameter, userId);
-    String endpointWithParams = String.join("?", loginEndpoint, params);
-    return String.join("/", hostAddress, endpointWithParams);
+    return String.format("%s://%s:%s/%s?%s=%s", protocol, host, port, resetEndpoint,
+        emailConfirmationParameter, userId);
   }
 }

--- a/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
@@ -26,16 +26,16 @@ class PasswordResetLinkSupplier {
       @Value("${service.host.name}") String host,
       @Value("${server.port}") String port,
       @Value("${password-reset-endpoint}") String resetEndpoint,
-      @Value("${email-password-reset-parameter}") String emailConfirmationParameter) {
+      @Value("${email-password-reset-parameter}") String passwordResetParameter) {
     this.protocol = protocol;
     this.host = host;
     this.port = port;
     this.resetEndpoint = resetEndpoint;
-    this.emailConfirmationParameter = emailConfirmationParameter;
+    this.passwordResetParameter = passwordResetParameter;
   }
 
   public String passwordResetUrl(String userId) {
     return String.format("%s://%s:%s/%s?%s=%s", protocol, host, port, resetEndpoint,
-        emailConfirmationParameter, userId);
+        passwordResetParameter, userId);
   }
 }

--- a/webapp/src/main/java/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplier.java
@@ -1,5 +1,7 @@
 package life.qbic.usermanagement.registration;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -15,27 +17,28 @@ public class EmailConfirmationLinkSupplier {
 
   private final String host;
 
-  private final String port;
+  private final int port;
 
-  private final String loginEndpoint;
+  private final String emailConfirmationEndpoint;
 
   private final String emailConfirmationParameter;
 
   public EmailConfirmationLinkSupplier(
       @Value("${service.host.protocol}") String protocol,
       @Value("${service.host.name}") String host,
-      @Value("${server.port}") String port,
+      @Value("${server.port}") int port,
       @Value("${email-confirmation-endpoint}") String loginEndpoint,
       @Value("${email-confirmation-parameter}") String emailConfirmationParameter) {
     this.protocol = protocol;
     this.host = host;
     this.port = port;
-    this.loginEndpoint = loginEndpoint;
+    this.emailConfirmationEndpoint = loginEndpoint;
     this.emailConfirmationParameter = emailConfirmationParameter;
   }
 
-  public String emailConfirmationUrl(String userId) {
-    return String.format("%s://%s:%s/%s?%s=%s", protocol, host, port, loginEndpoint,
-        emailConfirmationParameter, userId);
+  public String emailConfirmationUrl(String userId) throws MalformedURLException {
+    String pathWithQuery = "/" + emailConfirmationEndpoint + "?" + emailConfirmationParameter + "=" + userId;
+
+    return new URL(protocol, host, port, pathWithQuery).toExternalForm();
   }
 }

--- a/webapp/src/main/java/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplier.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class EmailConfirmationLinkSupplier {
 
+  private final String protocol;
+
   private final String host;
 
   private final String port;
@@ -19,10 +21,13 @@ public class EmailConfirmationLinkSupplier {
 
   private final String emailConfirmationParameter;
 
-  public EmailConfirmationLinkSupplier(@Value("${host.name}") String host,
+  public EmailConfirmationLinkSupplier(
+      @Value("${service.host.protocol}") String protocol,
+      @Value("${service.host.name}") String host,
       @Value("${server.port}") String port,
-      @Value("${login-endpoint}") String loginEndpoint,
+      @Value("${email-confirmation-endpoint}") String loginEndpoint,
       @Value("${email-confirmation-parameter}") String emailConfirmationParameter) {
+    this.protocol = protocol;
     this.host = host;
     this.port = port;
     this.loginEndpoint = loginEndpoint;
@@ -30,9 +35,7 @@ public class EmailConfirmationLinkSupplier {
   }
 
   public String emailConfirmationUrl(String userId) {
-    String hostAddress = String.join(":", host, port);
-    String params = String.join("=", emailConfirmationParameter,  userId);
-    String endpointWithParams = String.join("?", loginEndpoint, params);
-    return String.join("/", hostAddress, endpointWithParams);
+    return String.format("%s://%s:%s/%s?%s=%s", protocol, host, port, loginEndpoint,
+        emailConfirmationParameter, userId);
   }
 }

--- a/webapp/src/main/resources/application.properties
+++ b/webapp/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port=${PORT:8080}
+server.port=${DM_PORT:8080}
 logging.level.org.atmosphere=warn
 spring.mustache.check-template-location=false
 # Launch the default browser when starting the application in development mode
@@ -12,14 +12,22 @@ spring.datasource.driver-class-name=${USER_DB_DRIVER:com.mysql.cj.jdbc.Driver}
 spring.datasource.username=${USER_DB_USER_NAME:myusername}
 spring.datasource.password=${USER_DB_USER_PW:astrongpassphrase!}
 spring.jpa.hibernate.ddl-auto=update
+
 # email configuration
 spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
 spring.mail.host=${MAIL_HOST:smtp.gmail.com}
 spring.mail.default-encoding=UTF-8
 spring.mail.port=${MAIL_PORT:587}
+
+# global service route configuration for email interaction requests
+service.host.name=${DM_SERVICE_HOST:localhost}
+service.host.protocol=${DM_HOST_PROTOCOL:https}
+
 # route for email confirmation consumption
-host.name=${HOST:localhost}
-login-endpoint=${LOGIN_ENDPOINT:login}
+email-confirmation-endpoint=${EMAIL_CONFIRMATION_ENDPOINT:login}
 email-confirmation-parameter=${EMAIL_CONFIRMATION_PARAMETER:confirm-email}
-email-password-reset-parameter=${EMAIL_PASSWORD_RESET_PARAMETER:reset-password}
+
+# route for password reset
+password-reset-endpoint=${PASSWORD_RESET_ENDPOINT:login}
+email-password-reset-parameter=${PASSWORD_RESET_PARAMETER:reset-password}

--- a/webapp/src/main/resources/application.properties
+++ b/webapp/src/main/resources/application.properties
@@ -30,4 +30,4 @@ email-confirmation-parameter=${EMAIL_CONFIRMATION_PARAMETER:confirm-email}
 
 # route for password reset
 password-reset-endpoint=${PASSWORD_RESET_ENDPOINT:login}
-email-password-reset-parameter=${PASSWORD_RESET_PARAMETER:reset-password}
+password-reset-parameter=${PASSWORD_RESET_PARAMETER:reset-password}

--- a/webapp/src/test/groovy/life/qbic/events/DomainEventSerializerSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/events/DomainEventSerializerSpec.groovy
@@ -1,6 +1,6 @@
 package life.qbic.events
 
-import life.qbic.events.DomainEventSerializer
+
 import life.qbic.identityaccess.domain.user.UserRegistered
 import spock.lang.Specification
 

--- a/webapp/src/test/groovy/life/qbic/events/DomainEventSerializerSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/events/DomainEventSerializerSpec.groovy
@@ -1,5 +1,6 @@
-package life.qbic.events
+package groovy.life.qbic.events
 
+import life.qbic.events.DomainEventSerializer
 import life.qbic.identityaccess.domain.user.UserRegistered
 import spock.lang.Specification
 

--- a/webapp/src/test/groovy/life/qbic/events/DomainEventSerializerSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/events/DomainEventSerializerSpec.groovy
@@ -1,4 +1,4 @@
-package groovy.life.qbic.events
+package life.qbic.events
 
 import life.qbic.events.DomainEventSerializer
 import life.qbic.identityaccess.domain.user.UserRegistered

--- a/webapp/src/test/groovy/life/qbic/events/EventStoreSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/events/EventStoreSpec.groovy
@@ -1,4 +1,4 @@
-package groovy.life.qbic.events
+package life.qbic.events
 
 import life.qbic.events.SimpleEventStore
 import life.qbic.events.TemporaryEventRepository

--- a/webapp/src/test/groovy/life/qbic/events/EventStoreSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/events/EventStoreSpec.groovy
@@ -1,7 +1,6 @@
 package life.qbic.events
 
-import life.qbic.events.SimpleEventStore
-import life.qbic.events.TemporaryEventRepository
+
 import life.qbic.identityaccess.domain.user.UserRegistered
 import spock.lang.Specification
 

--- a/webapp/src/test/groovy/life/qbic/events/EventStoreSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/events/EventStoreSpec.groovy
@@ -1,5 +1,7 @@
-package life.qbic.events
+package groovy.life.qbic.events
 
+import life.qbic.events.SimpleEventStore
+import life.qbic.events.TemporaryEventRepository
 import life.qbic.identityaccess.domain.user.UserRegistered
 import spock.lang.Specification
 

--- a/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
@@ -16,7 +16,7 @@ class PasswordResetLinkSupplierSpec extends Specification {
         given:
         def linkSupplier = new PasswordResetLinkSupplier("https", "hostname", 8080, "endpoint", "confirmation-parameter")
         expect:
-        linkSupplier.passwordResetUrl("some-user").startsWith("https://hostname:8080/endpoint?confirmation-parameter=")
+        linkSupplier.passwordResetUrl("some-user") == "https://hostname:8080/endpoint?confirmation-parameter=some-user"
     }
 
 }

--- a/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
@@ -14,9 +14,9 @@ class PasswordResetLinkSupplierSpec extends Specification {
 
     def "when a registration link is requested, the url contains the correct path and some token"() {
         given:
-        def linkSupplier = new PasswordResetLinkSupplier("https", "hostname", "0007", "endpoint", "confirmation-parameter")
+        def linkSupplier = new PasswordResetLinkSupplier("https", "hostname", 8080, "endpoint", "confirmation-parameter")
         expect:
-        linkSupplier.passwordResetUrl("some-user").startsWith("https://hostname:0007/endpoint?confirmation-parameter=")
+        linkSupplier.passwordResetUrl("some-user").startsWith("https://hostname:8080/endpoint?confirmation-parameter=")
     }
 
 }

--- a/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
@@ -1,15 +1,8 @@
 package life.qbic.usermanagement.passwordreset
 
-import life.qbic.usermanagement.registration.EmailConfirmationLinkSupplier
+
 import spock.lang.Specification
 
-/**
- * <b><class short description - 1 Line!></b>
- *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
- */
 class PasswordResetLinkSupplierSpec extends Specification {
 
     def "when a registration link is requested, the url contains the correct path and some token"() {

--- a/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplierSpec.groovy
@@ -1,0 +1,22 @@
+package life.qbic.usermanagement.passwordreset
+
+import life.qbic.usermanagement.registration.EmailConfirmationLinkSupplier
+import spock.lang.Specification
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+class PasswordResetLinkSupplierSpec extends Specification {
+
+    def "when a registration link is requested, the url contains the correct path and some token"() {
+        given:
+        def linkSupplier = new PasswordResetLinkSupplier("https", "hostname", "0007", "endpoint", "confirmation-parameter")
+        expect:
+        linkSupplier.passwordResetUrl("some-user").startsWith("https://hostname:0007/endpoint?confirmation-parameter=")
+    }
+
+}

--- a/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
@@ -1,6 +1,6 @@
 package life.qbic.usermanagement.registration
 
-import life.qbic.usermanagement.registration.EmailConfirmationLinkSupplier
+
 import spock.lang.Specification
 
 class EmailConfirmationLinkSupplierSpec extends Specification {

--- a/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
@@ -7,9 +7,9 @@ class EmailConfirmationLinkSupplierSpec extends Specification {
 
   def "when a registration link is requested, the url contains the correct path and some token"() {
     given:
-    def linkSupplier = new EmailConfirmationLinkSupplier("https", "hostname", "0007", "endpoint", "confirmation-parameter")
+    def linkSupplier = new EmailConfirmationLinkSupplier("https", "hostname", 8080, "endpoint", "confirmation-parameter")
     expect:
-    linkSupplier.emailConfirmationUrl("some-user").startsWith("https://hostname:0007/endpoint?confirmation-parameter=")
+    linkSupplier.emailConfirmationUrl("some-user").startsWith("https://hostname:8080/endpoint?confirmation-parameter=")
   }
 
 }

--- a/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
@@ -7,9 +7,9 @@ class EmailConfirmationLinkSupplierSpec extends Specification {
 
   def "when a registration link is requested, the url contains the correct path and some token"() {
     given:
-    def linkSupplier = new EmailConfirmationLinkSupplier("hostname", "0007", "endpoint", "confirmation-parameter")
+    def linkSupplier = new EmailConfirmationLinkSupplier("https", "hostname", "0007", "endpoint", "confirmation-parameter")
     expect:
-    linkSupplier.emailConfirmationUrl("some-user").startsWith("hostname:0007/endpoint?confirmation-parameter=")
+    linkSupplier.emailConfirmationUrl("some-user").startsWith("https://hostname:0007/endpoint?confirmation-parameter=")
   }
 
 }

--- a/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
@@ -1,5 +1,6 @@
-package life.qbic.usermanagement.registration
+package groovy.life.qbic.usermanagement.registration
 
+import life.qbic.usermanagement.registration.EmailConfirmationLinkSupplier
 import spock.lang.Specification
 
 class EmailConfirmationLinkSupplierSpec extends Specification {

--- a/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
@@ -1,4 +1,4 @@
-package groovy.life.qbic.usermanagement.registration
+package life.qbic.usermanagement.registration
 
 import life.qbic.usermanagement.registration.EmailConfirmationLinkSupplier
 import spock.lang.Specification

--- a/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
+++ b/webapp/src/test/groovy/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplierSpec.groovy
@@ -9,7 +9,7 @@ class EmailConfirmationLinkSupplierSpec extends Specification {
     given:
     def linkSupplier = new EmailConfirmationLinkSupplier("https", "hostname", 8080, "endpoint", "confirmation-parameter")
     expect:
-    linkSupplier.emailConfirmationUrl("some-user").startsWith("https://hostname:8080/endpoint?confirmation-parameter=")
+    linkSupplier.emailConfirmationUrl("some-user") == "https://hostname:8080/endpoint?confirmation-parameter=some-user"
   }
 
 }


### PR DESCRIPTION
Introduces a configurable URL protocol parameter, that
can be used to set the protocol to http/https for URLs
that are send via email for user interaction.