### PR TITLE
Introduce error notification for failure of password reset 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ error-screenshots/
 webapp/webpack.generated.js
 /webapp/frontend/generated/theme.d.ts
 /target/
+/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ webapp/webpack.generated.js
 /webapp/frontend/generated/theme.d.ts
 /target/
 /package-lock.json
+/logs/

--- a/core/src/main/java/life/qbic/identityaccess/application/user/PasswordResetOutput.java
+++ b/core/src/main/java/life/qbic/identityaccess/application/user/PasswordResetOutput.java
@@ -1,5 +1,7 @@
 package life.qbic.identityaccess.application.user;
 
+import life.qbic.shared.application.ApplicationResponse;
+
 /**
  * <b>Password Reset Use Case Output</b>
  *
@@ -21,5 +23,5 @@ public interface PasswordResetOutput {
    *
    * @since 1.0.0
    */
-  void onPasswordResetFailed();
+  void onPasswordResetFailed(ApplicationResponse response);
 }

--- a/core/src/main/java/life/qbic/identityaccess/application/user/PasswordResetRequest.java
+++ b/core/src/main/java/life/qbic/identityaccess/application/user/PasswordResetRequest.java
@@ -26,12 +26,10 @@ public class PasswordResetRequest implements PasswordResetInput {
     Objects.requireNonNull(output, "No use case output was set");
     ApplicationResponse response = registrationService.requestPasswordReset(emailAddress);
     response.ifSuccessOrElse(success -> output.onPasswordResetSucceeded(),
-        failure -> output.onPasswordResetFailed());
+        failure -> output.onPasswordResetFailed(failure));
   }
 
   public void setUseCaseOutput(PasswordResetOutput output) {
     this.output = output;
   }
-
-
 }

--- a/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
+++ b/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
@@ -305,15 +305,8 @@ public final class UserRegistrationService {
     @Serial
     private static final long serialVersionUID = -4253849498611530692L;
 
-    private final String userNotActive;
-
-    UserNotActivatedException(String userNotActive) {
-      super();
-      this.userNotActive = userNotActive;
-    }
-
-    public String getMessage() {
-      return userNotActive;
+    UserNotActivatedException(String message) {
+      super(message);
     }
   }
 }

--- a/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
+++ b/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
@@ -171,7 +171,7 @@ public final class UserRegistrationService {
 
     // We only allow password reset for users with confirmed email address
     if (!user.isActive()) {
-      return ApplicationResponse.failureResponse(new ServiceException("User not active"));
+      return ApplicationResponse.failureResponse(new UserNotActivatedException("User not active"));
     }
     DomainEventPublisher.instance().subscribe(new DomainEventSubscriber<PasswordReset>() {
       @Override
@@ -299,5 +299,21 @@ public final class UserRegistrationService {
     }, () -> {
       throw new UserNotFoundException("Unknown user. Could not confirm the email address.");
     });
+  }
+
+  public class UserNotActivatedException extends ApplicationException {
+    @Serial
+    private static final long serialVersionUID = -4253849498611530692L;
+
+    private final String userNotActive;
+
+    UserNotActivatedException(String userNotActive) {
+      super();
+      this.userNotActive = userNotActive;
+    }
+
+    public String getMessage() {
+      return userNotActive;
+    }
   }
 }

--- a/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
+++ b/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
@@ -301,6 +301,12 @@ public final class UserRegistrationService {
     });
   }
 
+  /**
+   * <p>
+   * An exception to be thrown if an user is not activated.
+   * This implies that the user cannot login into the application
+   * </p>
+   */
   public class UserNotActivatedException extends ApplicationException {
     @Serial
     private static final long serialVersionUID = -4253849498611530692L;

--- a/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
+++ b/core/src/main/java/life/qbic/identityaccess/application/user/UserRegistrationService.java
@@ -163,7 +163,7 @@ public final class UserRegistrationService {
     // fetch user
     var optionalUser = userRepository.findByEmail(emailAddress);
     if (optionalUser.isEmpty()) {
-      return ApplicationResponse.failureResponse(new UserNotFoundException());
+      return ApplicationResponse.failureResponse(new UserNotFoundException("User not found"));
     }
 
     // get user

--- a/core/src/main/java/life/qbic/identityaccess/domain/user/EmailAddress.java
+++ b/core/src/main/java/life/qbic/identityaccess/domain/user/EmailAddress.java
@@ -38,7 +38,7 @@ public class EmailAddress implements Serializable {
   public static EmailAddress from(String s) throws EmailValidationException {
     PolicyCheckReport policyCheckReport = EmailFormatPolicy.instance().validate(s);
     if (policyCheckReport.status() == PolicyStatus.FAILED) {
-      throw new EmailValidationException(policyCheckReport, s);
+      throw new EmailValidationException(policyCheckReport, s, "Invalid email address format");
     }
     return new EmailAddress(s);
   }
@@ -95,8 +95,8 @@ public class EmailAddress implements Serializable {
     private final transient PolicyCheckReport emailPolicyCheckReport;
 
     EmailValidationException(PolicyCheckReport emailAddressCheckReport,
-        String invalidEmailAddress) {
-      super();
+        String invalidEmailAddress, String message) {
+      super(message);
       this.emailPolicyCheckReport = emailAddressCheckReport;
       this.invalidEmailAddress = invalidEmailAddress;
     }

--- a/webapp/src/main/java/life/qbic/views/components/BoxLayout.java
+++ b/webapp/src/main/java/life/qbic/views/components/BoxLayout.java
@@ -20,6 +20,7 @@ public class BoxLayout extends VerticalLayout {
 
   private H2 layoutTitle;
   private Text descriptionText;
+  private VerticalLayout notificationLayout;
   private VerticalLayout fieldLayout;
   private VerticalLayout textLayout;
   private VerticalLayout buttonLayout;
@@ -41,7 +42,7 @@ public class BoxLayout extends VerticalLayout {
     textLayout = new VerticalLayout();
     descriptionText = new Text("Enter description text");
     textLayout.add(descriptionText);
-
+    notificationLayout = new VerticalLayout();
     fieldLayout = new VerticalLayout();
     buttonLayout = new VerticalLayout();
 
@@ -50,6 +51,7 @@ public class BoxLayout extends VerticalLayout {
   }
 
   private void styleLayout() {
+    styleNotificationLayout();
     styleFieldLayout();
     styleFormLayout();
     styleButtonLayout();
@@ -79,7 +81,7 @@ public class BoxLayout extends VerticalLayout {
         "pb-l",
         "pr-l",
         "pl-l");
-    contentLayout.add(layoutTitle, descriptionText, fieldLayout, buttonLayout, linkSpan);
+    contentLayout.add(layoutTitle, notificationLayout, descriptionText, fieldLayout, buttonLayout, linkSpan);
   }
 
   private void styleFieldLayout() {
@@ -92,6 +94,12 @@ public class BoxLayout extends VerticalLayout {
     buttonLayout.setSpacing(false);
     buttonLayout.setMargin(false);
     buttonLayout.setPadding(false);
+  }
+
+  private void styleNotificationLayout(){
+    notificationLayout.setSpacing(false);
+    notificationLayout.setMargin(false);
+    notificationLayout.setPadding(false);
   }
 
   private void styleDescriptionText(){
@@ -128,6 +136,20 @@ public class BoxLayout extends VerticalLayout {
    */
   public void setDescriptionText(String text){
     descriptionText.setText(text);
+  }
+
+  /**
+   * Adds a DisplayMessage {@link DisplayMessage} based notification to the BoxLayout
+   * @param displayMessage The notification to be shown to the viewer.
+   */
+  public void setNotification(DisplayMessage displayMessage) {
+    notificationLayout.add(displayMessage);
+  }
+  /**
+   * Removes all DisplayMessage {@link DisplayMessage} based Notifications from the BoxLayout
+   */
+  public void removeNotifications(){
+    notificationLayout.removeAll();
   }
 
   /**

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -81,14 +81,14 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
         showPasswordResetFailedError(failure.getMessage(), "Please provide a valid email address.");
       }
       else if (failure instanceof UserNotFoundException) {
-        showPasswordResetFailedError(failure.getMessage(), "No user registered for the email.");
+        showPasswordResetFailedError(failure.getMessage(), "No user registered for the provided email.");
       }
       else if (failure instanceof UserRegistrationService.UserNotActivatedException) {
         showPasswordResetFailedError(
-            failure.getMessage(), "The account needs to be active to reset the password.");
+            failure.getMessage(), "Activate your account to reset the password.");
       } else {
         showPasswordResetFailedError(
-            "An error occurred", "Please contact support@qbic.zendesk.com for help.");
+            "An unexpected error occurred", "Please contact support@qbic.zendesk.com for help.");
       }
     }
   }

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -87,8 +87,6 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
         showPasswordResetFailedError(
             failure.getMessage(), "The account needs to be active to reset the password.");
       } else {
-        System.out.println(failure.getMessage());
-        System.out.println(failure.getClass());
         showPasswordResetFailedError(
             "An error occurred", "Please contact support@qbic.zendesk.com for help.");
       }

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -78,14 +78,14 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
   public void onPasswordResetFailed(ApplicationResponse response) {
     for (RuntimeException failure : response.failures()) {
       if (failure instanceof EmailAddress.EmailValidationException) {
-        showPasswordResetFailedError(failure.getMessage(), "Please provide a valid email address.");
+        showPasswordResetFailedError("Invalid email address format", "Please provide a valid email address.");
       }
       else if (failure instanceof UserNotFoundException) {
-        showPasswordResetFailedError(failure.getMessage(), "No user with the provided email address is known.");
+        showPasswordResetFailedError(
+            "User not found", "No user with the provided email address is known.");
       }
       else if (failure instanceof UserRegistrationService.UserNotActivatedException) {
-        showPasswordResetFailedError(
-            failure.getMessage(), "Please activate your account first to reset the password.");
+        showPasswordResetFailedError("User not active", "Please activate your account first to reset the password.");
       } else {
         showPasswordResetFailedError(
             "An unexpected error occurred", "Please contact support@qbic.zendesk.com for help.");

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -35,8 +35,10 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
     }
 
     private void addClickListeners() {
-        registeredPasswordResetLayout.sendButton.addClickListener(buttonClickEvent ->
-            passwordReset.resetPassword(registeredPasswordResetLayout.email.getValue()));
+        registeredPasswordResetLayout.sendButton.addClickListener(buttonClickEvent -> {
+            clearNotifications();
+            passwordReset.resetPassword(registeredPasswordResetLayout.email.getValue());
+            });
         registeredPasswordResetLayout.sendButton.addClickShortcut(Key.ENTER);
 
         registeredPasswordResetLayout.linkSentLayout.loginButton.addClickListener(buttonClickEvent ->

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -3,6 +3,10 @@ package life.qbic.views.login.passwordreset;
 import com.vaadin.flow.component.Key;
 import life.qbic.identityaccess.application.user.PasswordResetInput;
 import life.qbic.identityaccess.application.user.PasswordResetOutput;
+import life.qbic.identityaccess.application.user.UserRegistrationService;
+import life.qbic.identityaccess.domain.user.EmailAddress;
+import life.qbic.identityaccess.domain.user.UserNotFoundException;
+import life.qbic.shared.application.ApplicationResponse;
 import life.qbic.views.components.ErrorMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -10,62 +14,84 @@ import org.springframework.stereotype.Component;
 /**
  * <b>Handles the password reset</b>
  *
- * <p>When a password reset is triggered the handler starts the use case. On success the view is toggled
- * and the user can login again. On failure the user sees an error notification</p>
+ * <p>When a password reset is triggered the handler starts the use case. On success the view is
+ * toggled and the user can login again. On failure the user sees an error notification
  *
  * @since 1.0.0
  */
 @Component
 public class PasswordResetHandler implements PasswordResetHandlerInterface, PasswordResetOutput {
 
-    private ResetPasswordLayout registeredPasswordResetLayout;
-    private final PasswordResetInput passwordReset;
+  private ResetPasswordLayout registeredPasswordResetLayout;
+  private final PasswordResetInput passwordReset;
 
-    @Autowired
-    PasswordResetHandler(PasswordResetInput passwordReset){
-        this.passwordReset = passwordReset;
-    }
+  @Autowired
+  PasswordResetHandler(PasswordResetInput passwordReset) {
+    this.passwordReset = passwordReset;
+  }
 
-    @Override
-    public void handle(ResetPasswordLayout layout) {
-        if (registeredPasswordResetLayout != layout) {
-            this.registeredPasswordResetLayout = layout;
-            addClickListeners();
-        }
+  @Override
+  public void handle(ResetPasswordLayout layout) {
+    if (registeredPasswordResetLayout != layout) {
+      this.registeredPasswordResetLayout = layout;
+      addClickListeners();
     }
+  }
 
-    private void addClickListeners() {
-        registeredPasswordResetLayout.sendButton.addClickListener(buttonClickEvent -> {
-            clearNotifications();
-            passwordReset.resetPassword(registeredPasswordResetLayout.email.getValue());
-            });
-        registeredPasswordResetLayout.sendButton.addClickShortcut(Key.ENTER);
+  private void addClickListeners() {
+    registeredPasswordResetLayout.sendButton.addClickListener(
+        buttonClickEvent -> {
+          clearNotifications();
+          passwordReset.resetPassword(registeredPasswordResetLayout.email.getValue());
+        });
+    registeredPasswordResetLayout.sendButton.addClickShortcut(Key.ENTER);
 
-        registeredPasswordResetLayout.linkSentLayout.loginButton.addClickListener(buttonClickEvent ->
-                registeredPasswordResetLayout.linkSentLayout.getUI().ifPresent(ui -> ui.navigate("login")));
-    }
-    public void clearNotifications() {
-        registeredPasswordResetLayout.enterEmailLayout.removeNotifications();
-    }
+    registeredPasswordResetLayout.linkSentLayout.loginButton.addClickListener(
+        buttonClickEvent ->
+            registeredPasswordResetLayout
+                .linkSentLayout
+                .getUI()
+                .ifPresent(ui -> ui.navigate("login")));
+  }
 
-    public void showError(String title, String description) {
-        clearNotifications();
-        ErrorMessage errorMessage = new ErrorMessage(title, description);
-        registeredPasswordResetLayout.enterEmailLayout.setNotification(errorMessage);
-    }
+  public void clearNotifications() {
+    registeredPasswordResetLayout.enterEmailLayout.removeNotifications();
+  }
 
-    private void showPasswordResetFailedError() {
-        showError("The Password Reset has failed", "Please try again.");
-    }
+  public void showError(String title, String description) {
+    clearNotifications();
+    ErrorMessage errorMessage = new ErrorMessage(title, description);
+    registeredPasswordResetLayout.enterEmailLayout.setNotification(errorMessage);
+  }
 
-    @Override
-    public void onPasswordResetSucceeded() {
-        registeredPasswordResetLayout.linkSentLayout.setVisible(true);
-        registeredPasswordResetLayout.enterEmailLayout.setVisible(false);
-    }
+  private void showPasswordResetFailedError(String error, String description) {
+    showError(error, description);
+  }
 
-    @Override
-    public void onPasswordResetFailed() {
-        showPasswordResetFailedError();
+  @Override
+  public void onPasswordResetSucceeded() {
+    registeredPasswordResetLayout.linkSentLayout.setVisible(true);
+    registeredPasswordResetLayout.enterEmailLayout.setVisible(false);
+  }
+
+  @Override
+  public void onPasswordResetFailed(ApplicationResponse response) {
+    for (RuntimeException failure : response.failures()) {
+      if (failure instanceof EmailAddress.EmailValidationException) {
+        showPasswordResetFailedError(failure.getMessage(), "Please provide a valid email address.");
+      }
+      if (failure instanceof UserNotFoundException) {
+        showPasswordResetFailedError(failure.getMessage(), "No user registered for the email.");
+      }
+      if (failure instanceof UserRegistrationService.UserNotActivatedException) {
+        showPasswordResetFailedError(
+            failure.getMessage(), "The account needs to be active to reset the password.");
+      } else {
+        System.out.println(failure.getMessage());
+        System.out.println(failure.getClass());
+        showPasswordResetFailedError(
+            "An error occurred", "Please contact support@qbic.zendesk.com for help.");
+      }
     }
+  }
 }

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -3,7 +3,7 @@ package life.qbic.views.login.passwordreset;
 import com.vaadin.flow.component.Key;
 import life.qbic.identityaccess.application.user.PasswordResetInput;
 import life.qbic.identityaccess.application.user.PasswordResetOutput;
-import org.apache.commons.lang3.NotImplementedException;
+import life.qbic.views.components.ErrorMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -42,6 +42,19 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
         registeredPasswordResetLayout.linkSentLayout.loginButton.addClickListener(buttonClickEvent ->
                 registeredPasswordResetLayout.linkSentLayout.getUI().ifPresent(ui -> ui.navigate("login")));
     }
+    public void clearNotifications() {
+        registeredPasswordResetLayout.enterEmailLayout.removeNotifications();
+    }
+
+    public void showError(String title, String description) {
+        clearNotifications();
+        ErrorMessage errorMessage = new ErrorMessage(title, description);
+        registeredPasswordResetLayout.enterEmailLayout.setNotification(errorMessage);
+    }
+
+    private void showPasswordResetFailedError() {
+        showError("The Password Reset has failed", "Please try again.");
+    }
 
     @Override
     public void onPasswordResetSucceeded() {
@@ -51,7 +64,6 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
 
     @Override
     public void onPasswordResetFailed() {
-        //todo
-        throw new NotImplementedException();
+        showPasswordResetFailedError();
     }
 }

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -81,11 +81,11 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
         showPasswordResetFailedError(failure.getMessage(), "Please provide a valid email address.");
       }
       else if (failure instanceof UserNotFoundException) {
-        showPasswordResetFailedError(failure.getMessage(), "No user registered for the provided email.");
+        showPasswordResetFailedError(failure.getMessage(), "No user with the provided email address is known.");
       }
       else if (failure instanceof UserRegistrationService.UserNotActivatedException) {
         showPasswordResetFailedError(
-            failure.getMessage(), "Activate your account to reset the password.");
+            failure.getMessage(), "Please activate your account first to reset the password.");
       } else {
         showPasswordResetFailedError(
             "An unexpected error occurred", "Please contact support@qbic.zendesk.com for help.");

--- a/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/passwordreset/PasswordResetHandler.java
@@ -80,10 +80,10 @@ public class PasswordResetHandler implements PasswordResetHandlerInterface, Pass
       if (failure instanceof EmailAddress.EmailValidationException) {
         showPasswordResetFailedError(failure.getMessage(), "Please provide a valid email address.");
       }
-      if (failure instanceof UserNotFoundException) {
+      else if (failure instanceof UserNotFoundException) {
         showPasswordResetFailedError(failure.getMessage(), "No user registered for the email.");
       }
-      if (failure instanceof UserRegistrationService.UserNotActivatedException) {
+      else if (failure instanceof UserRegistrationService.UserNotActivatedException) {
         showPasswordResetFailedError(
             failure.getMessage(), "The account needs to be active to reset the password.");
       } else {


### PR DESCRIPTION
**Purpose of this PR**
This PR introduces an error notification shown to the user if the password reset fails

**How to Test**
In the Password Reset View, input an email address not stored in the database and click the submit button. 
The Password Reset

**Possible Improvements**
The Handler could try to distinct between a password reset failure caused by a domain error a passwort reset failure caused by an invalid email input reset. 
To do so we would need to introduce a dedicated PasswortResetException similiar to the UserRegistrationException which can then be parsed from the ApplicationResponse via the output interface to the Handler