### PR TITLE
Add service port configuration parameter

### DIFF
--- a/webapp/frontend/generated/vaadin.ts
+++ b/webapp/frontend/generated/vaadin.ts
@@ -2,5 +2,7 @@ import './vaadin-featureflags.ts';
 
 import './index';
 
+import '@vaadin/flow-frontend/VaadinDevmodeGizmo.js';
+
 import { applyTheme } from './theme';
 applyTheme(document);

--- a/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/passwordreset/PasswordResetLinkSupplier.java
@@ -28,7 +28,7 @@ public class PasswordResetLinkSupplier {
   public PasswordResetLinkSupplier(
       @Value("${service.host.protocol}") String protocol,
       @Value("${service.host.name}") String host,
-      @Value("${server.port}") int port,
+      @Value("${service.host.port}") int port,
       @Value("${password-reset-endpoint}") String resetEndpoint,
       @Value("${password-reset-parameter}") String passwordResetParameter) {
     this.protocol = protocol;

--- a/webapp/src/main/java/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplier.java
+++ b/webapp/src/main/java/life/qbic/usermanagement/registration/EmailConfirmationLinkSupplier.java
@@ -26,7 +26,7 @@ public class EmailConfirmationLinkSupplier {
   public EmailConfirmationLinkSupplier(
       @Value("${service.host.protocol}") String protocol,
       @Value("${service.host.name}") String host,
-      @Value("${server.port}") int port,
+      @Value("${service.host.port}") int port,
       @Value("${email-confirmation-endpoint}") String loginEndpoint,
       @Value("${email-confirmation-parameter}") String emailConfirmationParameter) {
     this.protocol = protocol;

--- a/webapp/src/main/resources/application.properties
+++ b/webapp/src/main/resources/application.properties
@@ -23,6 +23,7 @@ spring.mail.port=${MAIL_PORT:587}
 # global service route configuration for email interaction requests
 service.host.name=${DM_SERVICE_HOST:localhost}
 service.host.protocol=${DM_HOST_PROTOCOL:https}
+service.host.port=${DM_SERVICE_PORT:-1}
 
 # route for email confirmation consumption
 email-confirmation-endpoint=${EMAIL_CONFIRMATION_ENDPOINT:login}


### PR DESCRIPTION
Enables the port configuration for the URLs
that are generated when user interaction
is requested via email.

The default -1 means, that the default port for the selected protocol is used.