### PR TITLE
Set the hello world view as default route

### DIFF
--- a/webapp/frontend/generated/vaadin.ts
+++ b/webapp/frontend/generated/vaadin.ts
@@ -2,5 +2,7 @@ import './vaadin-featureflags.ts';
 
 import './index';
 
+import '@vaadin/flow-frontend/VaadinDevmodeGizmo.js';
+
 import { applyTheme } from './theme';
 applyTheme(document);

--- a/webapp/src/main/java/life/qbic/security/UserDetailsServiceImpl.java
+++ b/webapp/src/main/java/life/qbic/security/UserDetailsServiceImpl.java
@@ -3,6 +3,7 @@ package life.qbic.security;
 import java.util.ArrayList;
 import java.util.List;
 import life.qbic.identityaccess.domain.user.EmailAddress;
+import life.qbic.identityaccess.domain.user.EmailAddress.EmailValidationException;
 import life.qbic.identityaccess.domain.user.User;
 import life.qbic.identityaccess.domain.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +25,15 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    var user = userRepository.findByEmail(EmailAddress.from(username));
+    EmailAddress email;
+    // Check if the email address is valid
+    try {
+      email = EmailAddress.from(username);
+    } catch (EmailValidationException e) {
+      throw new UsernameNotFoundException("Cannot find user");
+    }
+    // Then search for a user with the provided email address
+    var user = userRepository.findByEmail(email);
     return new QbicUserDetails(
         user.orElseThrow(() -> new UsernameNotFoundException("Cannot find user")));
   }

--- a/webapp/src/main/java/life/qbic/views/helloworld/HelloWorldView.java
+++ b/webapp/src/main/java/life/qbic/views/helloworld/HelloWorldView.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
 import javax.annotation.security.PermitAll;
 import life.qbic.identityaccess.domain.user.FullName;
 import life.qbic.identityaccess.domain.user.User;
@@ -15,7 +16,7 @@ import life.qbic.views.MainLayout;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @PageTitle("Hello World")
-@Route(value = "hello", layout = MainLayout.class)
+@Route(value = "", layout = MainLayout.class)
 @PermitAll
 public class HelloWorldView extends VerticalLayout {
 

--- a/webapp/src/main/java/life/qbic/views/helloworld/HelloWorldView.java
+++ b/webapp/src/main/java/life/qbic/views/helloworld/HelloWorldView.java
@@ -7,7 +7,6 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouteAlias;
 import javax.annotation.security.PermitAll;
 import life.qbic.identityaccess.domain.user.FullName;
 import life.qbic.identityaccess.domain.user.User;

--- a/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
+++ b/webapp/src/main/java/life/qbic/views/login/LoginHandler.java
@@ -83,7 +83,7 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
 
   private void onLoginSucceeded() {
     clearNotifications();
-    UI.getCurrent().navigate("/hello");
+    UI.getCurrent().navigate("/");
   }
 
   @Override


### PR DESCRIPTION
Introduces a default route `@Route("")`, which is the hello page for the moment.

Since none was defined previously, this led to undesired side effects, causing Vaadin Router not to be able to resolve the default route.

In addition, I found my chance a leaking exception into the log, which happens when you enter a non-valid email address on login (not an email address for example). It is fixed by catching the EmailValidationException.