### PR TITLE
Catch and log invalid EmailAddresses so EmailSubmissionservice stays responsive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.iml
 .DS_Store
 
+# Log files
+logs
+
 # The following files are generated/updated by vaadin-maven-plugin
 node_modules/
 frontend/generated/


### PR DESCRIPTION
**Purpose of this PR**

This PR replaces the Runtime Exception thrown in the` EmailSubmissionService` with a dedicated `ApplicationResponse `and `EmailSendException` handling the output of the `javax.mail` package. 

** How to Test**

1. Go to the reset password or registration page.
2. Trigger email submission by registering a user or resetting your password with an invalid email address(An email that has the correct format but does not exist like e.g. `Abcdefghi@Invalid3m41l.argh`).
3. Observe the message stored in `logs/datamanager-logger.log`
4. Try to trigger another email sending by resetting your password or registering a user with a valid address
5. Behold! the email is now sent!

** Improvement Possibilty **
Currently the user is always redirected from the `RegistrationView` to the `LoginView` after Registering, even if the email could not be sent to the provided email address. 
This could be addressed by introducing an `ApplicationEventPublisher` that publishes an `EmailSend` Event after successful email sending, which will be consumed to trigger the navigation of the user to the `loginView`. 