### PR TITLE
Avoid artifact repackaging during deployment of release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -63,7 +63,7 @@ jobs:
               prerelease: true
             });
       - name: Publish artefact to QBiC Nexus Repository
-        run: mvn --quiet --settings $GITHUB_WORKSPACE/.github.settings.xml deploy
+        run: mvn --quiet --settings $GITHUB_WORKSPACE/.github.settings.xml deploy:deploy
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           MAVEN_REPO_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
**What has changed**
Adds the deploy goal to mvn lifecycle deploy phase. 
If only a phase is defined, then all the phases before that phase will be redone repackaging our artifact without the specified profile.

**Additional information**
Information about maven lifecycles can be found [here:](https://baeldung-cn.com/maven-goals-phases)
