### PR TITLE
Add jar initialization to prepare deployment in create release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -63,7 +63,7 @@ jobs:
               prerelease: true
             });
       - name: Publish artefact to QBiC Nexus Repository
-        run: mvn --quiet --settings $GITHUB_WORKSPACE/.github.settings.xml deploy:deploy
+        run: mvn --quiet --settings $GITHUB_WORKSPACE/.github.settings.xml jar:jar deploy:deploy
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           MAVEN_REPO_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
**Purpose of this PR**

Addresses [failure in release build](https://github.com/qbicsoftware/data-manager-app/runs/7519905215?check_suite_focus=true).
Add `jar:jar` goal to the deploy stage in create release github workflow to initialize the deployment requirements. 

**Additional information**
Basically the `deploy:deploy` goal needs to know, which file and filetype should be deployed. 
Originally this would be done by the previous lifecycles(e.g. mvn install), however this is not possible since the CI is packaging the artifact and then deploying it seperately. 
We can force the correct initialization by adding the `jar:jar goal` which will prepare everything for building the jar(ergo preparing the necessary deployment settings), however since we already build the jar it will not be replaced
(because this is the [default behaviour](https://maven.apache.org/plugins/maven-jar-plugin/jar-mojo.html#forceCreation) of the jar plugin if there is already a jar present). 
See [here] for more information (https://stackoverflow.com/questions/6308162/maven-the-packaging-for-this-project-did-not-assign-a-file-to-the-build-artifac/57824874#57824874)

**How to Test**
Local deployment can be tested by adapting the Url property in the DistributionManagement setting in the datamanager pom.xml to your local filesystem such as:

```
  <distributionManagement>
  <repository>
    <uniqueVersion>true</uniqueVersion>
    <id>nexus-releases</id>
    <name>QBiC Releases</name>
    <url>file:///Users/YourUser/Desktop/WhereEverYouWant/</url>
  </repository>
   </distributionManagement>
```

You can check if the deployed jar file has the correct productionMode setting as follows:

Build the data-manager application via 

`mvn -B package -Pproduction --file pom.xml`

Afterwards deploy the artifact via 

`mvn jar:jar deploy:deploy`

Finally check in the `vaadinfrontend*.jar` file, which can be unpacked via the` jar -xf *<jarfile>` command. 
For this look into `/life/qbic/vaadinfrontend/0.4.3/META-INF/VAADIN/config/flow-build-info.json`if the vaadin `productionmode` property is set. 