### PR TITLE
Open field access for public response type

### DIFF
--- a/commons/src/main/java/life/qbic/application/commons/ApplicationResponse.java
+++ b/commons/src/main/java/life/qbic/application/commons/ApplicationResponse.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
  */
 public class ApplicationResponse {
 
-  private enum Type {SUCCESSFUL, FAILED}
+  public enum Type {SUCCESSFUL, FAILED}
 
   private ApplicationResponse.Type type;
 


### PR DESCRIPTION
Opens the ApplicationResponse.Type enum, since it is a return type of the public API.