### PR TITLE
Fixes Subscription service provider 

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -73,4 +73,5 @@
     <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
+
 </project>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -55,11 +55,5 @@
       <version>0.4.3</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>life.qbic.logging</groupId>
-      <artifactId>subscription-provider</artifactId>
-      <version>0.4.3</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/subscription-provider/pom.xml
+++ b/subscription-provider/pom.xml
@@ -11,6 +11,7 @@
 
   <groupId>life.qbic.logging</groupId>
   <artifactId>subscription-provider</artifactId>
+
   <dependencies>
     <dependency>
       <groupId>life.qbic.logging</groupId>

--- a/subscription-provider/src/main/java/life/qbic/logging/subscription/provider/mail/EMailService.java
+++ b/subscription-provider/src/main/java/life/qbic/logging/subscription/provider/mail/EMailService.java
@@ -51,7 +51,7 @@ public class EMailService implements MailService {
   }
 
   private EMailService(Properties props) {
-    session = Session.getDefaultInstance(props, new Authenticator() {
+    session = Session.getInstance(props, new Authenticator() {
       @Override
       protected PasswordAuthentication getPasswordAuthentication() {
         return new PasswordAuthentication(props.getProperty(MAIL_SMTP_USERNAME),

--- a/subscription-provider/src/main/resources/META-INF/services/life.qbic.logging.subscription.api.Subscriber
+++ b/subscription-provider/src/main/resources/META-INF/services/life.qbic.logging.subscription.api.Subscriber
@@ -1,0 +1,1 @@
+life.qbic.logging.subscription.provider.MailOnErrorSubscriber

--- a/vaadinfrontend/pom.xml
+++ b/vaadinfrontend/pom.xml
@@ -205,6 +205,11 @@
             <version>0.4.3</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>life.qbic.logging</groupId>
+            <artifactId>subscription-provider</artifactId>
+            <version>0.4.3</version>
+        </dependency>
 
 
     </dependencies>

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/Application.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/Application.java
@@ -82,6 +82,7 @@ public class Application extends SpringBootServletInitializer implements AppShel
     messageBus.subscribe(whenPasswordResetRequestSendEmail(appContext), PASSWORD_RESET);
 
     setupUseCases(appContext);
+    logger.error("Oh oh");
   }
 
   private static void setupUseCases(ConfigurableApplicationContext context) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/Application.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/Application.java
@@ -82,7 +82,6 @@ public class Application extends SpringBootServletInitializer implements AppShel
     messageBus.subscribe(whenPasswordResetRequestSendEmail(appContext), PASSWORD_RESET);
 
     setupUseCases(appContext);
-    logger.error("Oh oh");
   }
 
   private static void setupUseCases(ConfigurableApplicationContext context) {

--- a/vaadinfrontend/src/main/resources/application.properties
+++ b/vaadinfrontend/src/main/resources/application.properties
@@ -20,10 +20,6 @@ spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.Im
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 
-spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-
-
 # mail configuration
 spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}


### PR DESCRIPTION
After the removal of Java modules support, the Subscription provider implementation broke. 

This enables the findability of the service via the legacy `META-INF/services` approach to expose service providers.