### PR TITLE
Update design of Create Project UI

### DIFF
--- a/vaadinfrontend/frontend/styles/components/card-layout.css
+++ b/vaadinfrontend/frontend/styles/components/card-layout.css
@@ -1,0 +1,4 @@
+.min-size-to-content{
+  min-width: fit-content;
+  min-height: fit-content;
+}

--- a/vaadinfrontend/frontend/styles/components/create-project.css
+++ b/vaadinfrontend/frontend/styles/components/create-project.css
@@ -1,0 +1,4 @@
+.create-project-form vaadin-form-item::part(label){
+    font-weight: bold;
+    color:black;
+}

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/components/CardLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/components/CardLayout.java
@@ -1,0 +1,136 @@
+package life.qbic.datamanager.views.components;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Unit;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+
+/**
+ * <b>Card Layout</b>
+ *
+ * <p>A card with a shadow containing a title, description, a layout for fields, a layout for buttons and a span to add links.
+ * Furthermore, the description text can be toggled visible or invisible
+ *
+ * @since 1.0.0
+ */
+public class CardLayout extends VerticalLayout {
+
+  private Label layoutTitle;
+  private HorizontalLayout headerLayout;
+  private HorizontalLayout buttonLayout;
+  private final VerticalLayout contentLayout;
+  private VerticalLayout fieldLayout;
+
+  public CardLayout() {
+    contentLayout = new VerticalLayout();
+    initLayout();
+    styleLayout();
+  }
+
+  private void initLayout() {
+    layoutTitle = new Label("Set Title");
+    headerLayout = new HorizontalLayout();
+    buttonLayout = new HorizontalLayout();
+    headerLayout.add(layoutTitle, buttonLayout);
+    fieldLayout = new VerticalLayout();
+    add(contentLayout);
+  }
+
+  private void styleLayout() {
+    styleCardLayout();
+    styleHeaderLayout();
+    styleLayoutTitle();
+    styleButtonLayout();
+    styleFieldLayout();
+    setAlignItems(FlexComponent.Alignment.CENTER);
+    setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+  }
+
+  private void styleCardLayout() {
+    contentLayout.setPadding(false);
+    contentLayout.setMargin(false);
+    contentLayout.setWidthFull();
+    contentLayout.setHeightFull();
+    contentLayout.addClassNames(
+        "bg-base",
+        "border",
+        "rounded-m",
+        "border-contrast-10",
+        "box-border",
+        "flex",
+        "flex-col",
+        "text-s",
+        "shadow-l",
+        "pb-l",
+        "pr-l",
+        "pl-l");
+    contentLayout.add(headerLayout, fieldLayout);
+  }
+
+  //ToDo rename styling methods to setDefaultStyling method
+  private void styleLayoutTitle(){
+    layoutTitle.addClassNames(
+        "text-2xl",
+        "text-header",
+        "font-bold"
+        );
+  }
+
+  private void styleHeaderLayout(){
+    headerLayout.setSpacing(false);
+    headerLayout.setMargin(false);
+    headerLayout.setPadding(false);
+    headerLayout.addClassNames(
+        "mt-m",
+        "mb-s"
+    );
+    headerLayout.setWidthFull();
+    headerLayout.setJustifyContentMode(JustifyContentMode.BETWEEN);
+  }
+
+  private void styleButtonLayout(){
+    buttonLayout.setMargin(false);
+    buttonLayout.setPadding(false);
+    buttonLayout.setSpacing(false);
+    buttonLayout.setClassName("gap-s");
+  }
+
+  private void styleFieldLayout() {
+    fieldLayout.setSpacing(false);
+    fieldLayout.setMargin(false);
+    fieldLayout.setPadding(false);
+    fieldLayout.setHeightFull();
+  }
+
+  /**
+   * Sets the title text
+   * @param text The text for the title
+   */
+  public void setTitleText(String text) {
+    layoutTitle.setText(text);
+  }
+
+  /**
+   * Adds the field components to the field layout
+   * @param fields The fields could be TextFields, EmailFields, PasswordFields
+   */
+  public void addFields(Component... fields) {
+    fieldLayout.add(fields);
+  }
+
+  /**
+   * Adds buttons to the button layout
+   * @param buttons The buttons that need to be part of the layout
+   */
+  public void addButtons(Button... buttons) {
+    buttonLayout.add(buttons);
+  }
+
+  /**
+   * Removes all DisplayMessage {@link DisplayMessage} based Notifications from the BoxLayout
+   */
+  //Todo Add methods to allow styling of components in card
+}

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/components/CardLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/components/CardLayout.java
@@ -1,8 +1,8 @@
 package life.qbic.datamanager.views.components;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -11,94 +11,94 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 /**
  * <b>Card Layout</b>
  *
- * <p>A card with a shadow containing a title, description, a layout for fields, a layout for buttons and a span to add links.
+ * <p>A card with a shadow containing a title, description, a layout for fields, a layout for
+ * buttons and a span to add links.
  * Furthermore, the description text can be toggled visible or invisible
  *
  * @since 1.0.0
  */
+@CssImport("./styles/components/card-layout.css")
 public class CardLayout extends VerticalLayout {
 
   private Label layoutTitle;
-  private HorizontalLayout headerLayout;
+
+  private VerticalLayout contentLayout;
+  private VerticalLayout leftLayout;
+  private VerticalLayout rightLayout;
   private HorizontalLayout buttonLayout;
-  private final VerticalLayout contentLayout;
   private VerticalLayout fieldLayout;
 
   public CardLayout() {
-    contentLayout = new VerticalLayout();
     initLayout();
     styleLayout();
   }
 
   private void initLayout() {
     layoutTitle = new Label("Set Title");
-    headerLayout = new HorizontalLayout();
+    contentLayout = new VerticalLayout();
     buttonLayout = new HorizontalLayout();
-    headerLayout.add(layoutTitle, buttonLayout);
     fieldLayout = new VerticalLayout();
+    leftLayout = new VerticalLayout();
+    rightLayout = new VerticalLayout();
+    leftLayout.add(layoutTitle, fieldLayout);
+    rightLayout.add(buttonLayout);
+    contentLayout.add(leftLayout, rightLayout);
     add(contentLayout);
   }
 
   private void styleLayout() {
-    styleCardLayout();
-    styleHeaderLayout();
-    styleLayoutTitle();
-    styleButtonLayout();
-    styleFieldLayout();
+    setDefaultCardLayoutStyle();
+    setDefaultTitleStyle();
+    setDefaultButtonLayoutStyle();
+    setDefaultFieldLayoutStyle();
     setAlignItems(FlexComponent.Alignment.CENTER);
     setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
   }
 
-  private void styleCardLayout() {
-    contentLayout.setPadding(false);
-    contentLayout.setMargin(false);
-    contentLayout.setWidthFull();
-    contentLayout.setHeightFull();
+  private void setDefaultCardLayoutStyle() {
+    this.setSizeFull();
+    contentLayout.setSizeFull();
     contentLayout.addClassNames(
+        "min-size-to-content",
         "bg-base",
         "border",
         "rounded-m",
         "border-contrast-10",
         "box-border",
+        "rounded-m",
         "flex",
-        "flex-col",
+        "flex-row",
         "text-s",
         "shadow-l",
-        "pb-l",
-        "pr-l",
-        "pl-l");
-    contentLayout.add(headerLayout, fieldLayout);
+        "p-xl",
+        "m-xl"
+    );
+    leftLayout.setPadding(false);
+    leftLayout.setMargin(false);
+    leftLayout.setAlignItems(Alignment.START);
+    leftLayout.setSizeFull();
+    rightLayout.setPadding(false);
+    rightLayout.setMargin(false);
+    rightLayout.setAlignItems(Alignment.END);
+    rightLayout.setSizeUndefined();
   }
 
-  //ToDo rename styling methods to setDefaultStyling method
-  private void styleLayoutTitle(){
+  private void setDefaultTitleStyle() {
     layoutTitle.addClassNames(
         "text-2xl",
-        "text-header",
-        "font-bold"
-        );
-  }
-
-  private void styleHeaderLayout(){
-    headerLayout.setSpacing(false);
-    headerLayout.setMargin(false);
-    headerLayout.setPadding(false);
-    headerLayout.addClassNames(
-        "mt-m",
-        "mb-s"
+        "font-bold",
+        "text-secondary"
     );
-    headerLayout.setWidthFull();
-    headerLayout.setJustifyContentMode(JustifyContentMode.BETWEEN);
   }
 
-  private void styleButtonLayout(){
+  private void setDefaultButtonLayoutStyle() {
     buttonLayout.setMargin(false);
     buttonLayout.setPadding(false);
     buttonLayout.setSpacing(false);
     buttonLayout.setClassName("gap-s");
   }
 
-  private void styleFieldLayout() {
+  private void setDefaultFieldLayoutStyle() {
     fieldLayout.setSpacing(false);
     fieldLayout.setMargin(false);
     fieldLayout.setPadding(false);
@@ -107,6 +107,7 @@ public class CardLayout extends VerticalLayout {
 
   /**
    * Sets the title text
+   *
    * @param text The text for the title
    */
   public void setTitleText(String text) {
@@ -115,6 +116,7 @@ public class CardLayout extends VerticalLayout {
 
   /**
    * Adds the field components to the field layout
+   *
    * @param fields The fields could be TextFields, EmailFields, PasswordFields
    */
   public void addFields(Component... fields) {
@@ -123,6 +125,7 @@ public class CardLayout extends VerticalLayout {
 
   /**
    * Adds buttons to the button layout
+   *
    * @param buttons The buttons that need to be part of the layout
    */
   public void addButtons(Button... buttons) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/components/CardLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/components/CardLayout.java
@@ -11,9 +11,8 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 /**
  * <b>Card Layout</b>
  *
- * <p>A card with a shadow containing a title, description, a layout for fields, a layout for
- * buttons and a span to add links.
- * Furthermore, the description text can be toggled visible or invisible
+ * <p>A card Component with a shadow containing customizable components such as a title, a layout
+ * for fields and a layout for buttons.
  *
  * @since 1.0.0
  */
@@ -21,10 +20,10 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 public class CardLayout extends VerticalLayout {
 
   private Label layoutTitle;
-
   private VerticalLayout contentLayout;
   private VerticalLayout leftLayout;
   private VerticalLayout rightLayout;
+  private HorizontalLayout titleLayout;
   private HorizontalLayout buttonLayout;
   private VerticalLayout fieldLayout;
 
@@ -34,20 +33,22 @@ public class CardLayout extends VerticalLayout {
   }
 
   private void initLayout() {
-    layoutTitle = new Label("Set Title");
     contentLayout = new VerticalLayout();
-    buttonLayout = new HorizontalLayout();
-    fieldLayout = new VerticalLayout();
     leftLayout = new VerticalLayout();
     rightLayout = new VerticalLayout();
-    leftLayout.add(layoutTitle, fieldLayout);
+    buttonLayout = new HorizontalLayout();
+    fieldLayout = new VerticalLayout();
+    titleLayout = new HorizontalLayout();
+    layoutTitle = new Label("");
+    titleLayout.add(layoutTitle);
+    leftLayout.add(titleLayout, fieldLayout);
     rightLayout.add(buttonLayout);
     contentLayout.add(leftLayout, rightLayout);
     add(contentLayout);
   }
 
   private void styleLayout() {
-    setDefaultCardLayoutStyle();
+    setCardLayoutStyle();
     setDefaultTitleStyle();
     setDefaultButtonLayoutStyle();
     setDefaultFieldLayoutStyle();
@@ -55,7 +56,7 @@ public class CardLayout extends VerticalLayout {
     setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
   }
 
-  private void setDefaultCardLayoutStyle() {
+  private void setCardLayoutStyle() {
     this.setSizeFull();
     contentLayout.setSizeFull();
     contentLayout.addClassNames(
@@ -70,8 +71,7 @@ public class CardLayout extends VerticalLayout {
         "flex-row",
         "text-s",
         "shadow-l",
-        "p-xl",
-        "m-xl"
+        "p-l"
     );
     leftLayout.setPadding(false);
     leftLayout.setMargin(false);
@@ -84,7 +84,7 @@ public class CardLayout extends VerticalLayout {
   }
 
   private void setDefaultTitleStyle() {
-    layoutTitle.addClassNames(
+    titleLayout.addClassNames(
         "text-2xl",
         "font-bold",
         "text-secondary"
@@ -106,25 +106,7 @@ public class CardLayout extends VerticalLayout {
   }
 
   /**
-   * Sets the title text
-   *
-   * @param text The text for the title
-   */
-  public void setTitleText(String text) {
-    layoutTitle.setText(text);
-  }
-
-  /**
-   * Adds the field components to the field layout
-   *
-   * @param fields The fields could be TextFields, EmailFields, PasswordFields
-   */
-  public void addFields(Component... fields) {
-    fieldLayout.add(fields);
-  }
-
-  /**
-   * Adds buttons to the button layout
+   * Adds buttons to the button layout within the CardLayout
    *
    * @param buttons The buttons that need to be part of the layout
    */
@@ -133,7 +115,129 @@ public class CardLayout extends VerticalLayout {
   }
 
   /**
-   * Removes all DisplayMessage {@link DisplayMessage} based Notifications from the BoxLayout
+   * Adds the field components to the field layout within the CardLayout
+   *
+   * @param fields The fields could be a collection of vaadin components
    */
-  //Todo Add methods to allow styling of components in card
+  public void addFields(Component... fields) {
+    fieldLayout.add(fields);
+  }
+
+  /**
+   * Adds a title with a specified text to the card
+   *
+   * @param text The text for the title
+   */
+  public void addTitle(String text) {
+    if (!titleLayout.getChildren().toList().contains(layoutTitle)) {
+      titleLayout.add(layoutTitle);
+    }
+    layoutTitle.setText(text);
+  }
+
+  /**
+   * Removes specified buttons from the CardLayout
+   */
+  public void removeButtons(Button... buttons) {
+    buttonLayout.remove(buttons);
+  }
+
+  /**
+   * Removes specified fields from the CardLayout
+   */
+  public void removeFields(Component... components) {
+    fieldLayout.remove(components);
+  }
+
+  /**
+   * Removes the title from the CardLayout
+   */
+  public void removeTitle() {
+    titleLayout.removeAll();
+  }
+
+  /**
+   * Adds custom css styling to the ButtonLayout within the CardLayout
+   *
+   * @param buttonStyles String representations of vaadin css classNames that will be added to the
+   *                     buttonLayout
+   */
+  public void addButtonStyles(String... buttonStyles) {
+    buttonLayout.addClassNames(buttonStyles);
+  }
+
+  /**
+   * Adds custom css styling to the fieldLayout within the CardLayout
+   *
+   * @param fieldStyles String representations of vaadin css classNames that will be added to the
+   *                    fieldLayout
+   */
+  public void addFieldStyles(String... fieldStyles) {
+    fieldLayout.addClassNames(fieldStyles);
+  }
+
+  /**
+   * Adds custom css styling to the fieldLayout within the CardLayout
+   *
+   * @param titleStyles String representations of vaadin css classNames that will be removed from
+   *                    the titleLayout
+   */
+  public void addTitleStyles(String... titleStyles) {
+    titleLayout.addClassNames(titleStyles);
+  }
+
+  /**
+   * Removes specified css styling of the buttonLayout within the CardLayout
+   *
+   * @param buttonStyles String representations of vaadin css classNames that will be removed from
+   *                     the buttonLayout
+   */
+  public void removeButtonStyles(String... buttonStyles) {
+    buttonLayout.removeClassNames(buttonStyles);
+  }
+
+  /**
+   * Removes specified css styling of the fieldLayout within the CardLayout
+   *
+   * @param fieldStyles String representations of vaadin css classNames that will be removed from
+   *                    the fieldLayout
+   */
+  public void removeFieldStyles(String... fieldStyles) {
+    fieldLayout.removeClassNames(fieldStyles);
+  }
+
+  /**
+   * Removes specified css styling of the titleLayout within the CardLayout
+   *
+   * @param titleStyles String representations of vaadin css classNames that will be added to the
+   *                    titleLayout
+   */
+  public void removeTitleStyles(String... titleStyles) {
+    titleLayout.removeClassNames(titleStyles);
+  }
+
+  /**
+   * Removes all styling of the buttonLayout within the CardLayout
+   */
+  public void removeAllButtonStyles() {
+    String[] currentButtonLayoutStyles = buttonLayout.getClassNames().toArray(String[]::new);
+    buttonLayout.removeClassNames(currentButtonLayoutStyles);
+  }
+
+  /**
+   * Removes all styling of the fieldLayout within the CardLayout
+   */
+  public void removeAllFieldStyles() {
+    String[] currentFieldLayoutStyles = fieldLayout.getClassNames().toArray(String[]::new);
+    fieldLayout.removeClassNames(currentFieldLayoutStyles);
+  }
+
+  /**
+   * Removes all styling of the titleLayout within the CardLayout
+   */
+  public void removeAllTitleStyles() {
+    String[] currentTitleLayoutStyles = titleLayout.getClassNames().toArray(String[]::new);
+    titleLayout.removeClassNames(currentTitleLayoutStyles);
+  }
+
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
@@ -2,15 +2,15 @@ package life.qbic.datamanager.views.project.create;
 
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
-import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.BeforeEvent;
@@ -21,15 +21,16 @@ import com.vaadin.flow.router.Route;
 import java.util.Objects;
 import javax.annotation.security.PermitAll;
 import life.qbic.datamanager.views.MainLayout;
+import life.qbic.datamanager.views.components.CardLayout;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @PageTitle("Create Project")
 @Route(value = "projects/create", layout = MainLayout.class)
 @PermitAll
 @Tag("create-project")
-public class CreateProjectLayout extends Composite<VerticalLayout> implements HasUrlParameter<String> {
+public class CreateProjectLayout extends Composite<CardLayout> implements HasUrlParameter<String> {
 
-  final H2 layoutTitle = new H2();
+  final Label layoutTitle = new Label();
   final TextField titleField = new TextField();
   final Button saveButton = new Button("Save");
   final Button cancelButton = new Button("Cancel");
@@ -46,7 +47,7 @@ public class CreateProjectLayout extends Composite<VerticalLayout> implements Ha
   }
 
   @Override
-  protected VerticalLayout initContent() {
+  protected CardLayout initContent() {
     layoutTitle.setText("Project Information");
 
     FormLayout formLayout = new FormLayout();
@@ -65,8 +66,15 @@ public class CreateProjectLayout extends Composite<VerticalLayout> implements Ha
     headerBar.setVerticalComponentAlignment(Alignment.START, layoutTitle);
     headerBar.setVerticalComponentAlignment(Alignment.END, formButtons);
     headerBar.setWidthFull();
-
-    return new VerticalLayout(headerBar, formLayout);
+    CardLayout cardLayout = new CardLayout();
+    cardLayout.addButtons(cancelButton, saveButton);
+    cardLayout.addFields(formLayout);
+    cardLayout.setTitleText("Project Information");
+    cardLayout.setAlignItems(Alignment.START);
+    //ToDo should this be a fixed width and height or a max width and height?
+    cardLayout.setHeight(90, Unit.PERCENTAGE);
+    cardLayout.setWidth(60,Unit.PERCENTAGE);
+    return cardLayout;
   }
 
   private void registerToHandler(CreateProjectHandlerInterface handler) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
@@ -2,15 +2,11 @@ package life.qbic.datamanager.views.project.create;
 
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
-import com.vaadin.flow.component.html.Label;
-import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
-import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.BeforeEvent;
@@ -28,17 +24,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Route(value = "projects/create", layout = MainLayout.class)
 @PermitAll
 @Tag("create-project")
+@CssImport("./styles/components/create-project.css")
 public class CreateProjectLayout extends Composite<CardLayout> implements HasUrlParameter<String> {
 
-  final Label layoutTitle = new Label();
   final TextField titleField = new TextField();
   final Button saveButton = new Button("Save");
   final Button cancelButton = new Button("Cancel");
-
+  final FormLayout formLayout = new FormLayout();
   final TextArea projectObjective = new TextArea();
-
+  private final CardLayout cardLayout = new CardLayout();
   final CreateProjectHandlerInterface handler;
-
 
   public CreateProjectLayout(@Autowired CreateProjectHandlerInterface handler) {
     Objects.requireNonNull(handler);
@@ -48,30 +43,29 @@ public class CreateProjectLayout extends Composite<CardLayout> implements HasUrl
 
   @Override
   protected CardLayout initContent() {
-    layoutTitle.setText("Project Information");
+    initFormLayout();
+    initCardLayout();
+    setComponentStyles();
+    return cardLayout;
+  }
 
-    FormLayout formLayout = new FormLayout();
+  private void initFormLayout() {
     formLayout.addFormItem(titleField, "Project Title");
     formLayout.addFormItem(projectObjective, "Project Objective");
     formLayout.setResponsiveSteps(new ResponsiveStep("0", 1));
-    titleField.setSizeFull();
-    projectObjective.setWidthFull();
+  }
 
-    saveButton.setText("Save");
-    saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-
-    HorizontalLayout formButtons = new HorizontalLayout(cancelButton, saveButton);
-    HorizontalLayout headerBar = new HorizontalLayout(layoutTitle, formButtons);
-    headerBar.setJustifyContentMode(JustifyContentMode.BETWEEN);
-    headerBar.setVerticalComponentAlignment(Alignment.START, layoutTitle);
-    headerBar.setVerticalComponentAlignment(Alignment.END, formButtons);
-    headerBar.setWidthFull();
-    CardLayout cardLayout = new CardLayout();
+  private void initCardLayout() {
     cardLayout.addButtons(cancelButton, saveButton);
     cardLayout.addFields(formLayout);
-    cardLayout.setTitleText("Project Information");
-    cardLayout.setAlignItems(Alignment.START);
-    return cardLayout;
+    cardLayout.addTitle("Create Project");
+  }
+
+  private void setComponentStyles() {
+    titleField.setSizeFull();
+    projectObjective.setWidthFull();
+    saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+    formLayout.setClassName("create-project-form");
   }
 
   private void registerToHandler(CreateProjectHandlerInterface handler) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
@@ -71,9 +71,6 @@ public class CreateProjectLayout extends Composite<CardLayout> implements HasUrl
     cardLayout.addFields(formLayout);
     cardLayout.setTitleText("Project Information");
     cardLayout.setAlignItems(Alignment.START);
-    //ToDo should this be a fixed width and height or a max width and height?
-    cardLayout.setHeight(90, Unit.PERCENTAGE);
-    cardLayout.setWidth(60,Unit.PERCENTAGE);
     return cardLayout;
   }
 

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/CreateProjectLayout.java
@@ -68,6 +68,7 @@ public class CreateProjectLayout extends Composite<CardLayout> implements HasUrl
   private void setComponentStyles() {
     titleField.setSizeFull();
     projectObjective.setWidthFull();
+    experimentalDesignField.setWidthFull();
     saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
     formLayout.setClassName("create-project-form");
   }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projectOverview/components/CreationModeDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projectOverview/components/CreationModeDialog.java
@@ -47,7 +47,7 @@ public class CreationModeDialog extends Dialog {
 
     private void setupContent(){
         createCreationModeButtons();
-        Label blankLabel = new Label("From Offer");
+        Label blankLabel = new Label("Blank");
         blankLabel.addClassName("dialogue-button-label");
         VerticalLayout blankLayout = new VerticalLayout(blankButton, blankLabel);
         blankLayout.setAlignItems(FlexComponent.Alignment.CENTER);


### PR DESCRIPTION
**What was changed** 
This PR updates the UI to fit the [figma ](https://www.figma.com/file/mYcW5viu5GpPZ852VHYBrV/Start-Page?node-id=861%3A20351)prototype outlined in [DM-530](https://qbicsoftware.atlassian.net/browse/DM-530).

**Technical Information** 
This PR aims to achieve multiple things: 
1.) Introduce a reusable CardLayout with an immutable card design
2.) The CardLayout allows for adding components into its individual sublayouts as desired by the user. 
3.) The CardLayout allows for style changes to its Sublayouts as required. 
4.) CSS definition seperation between the basic CardLayout and the styling of the added components by the CreateProjectLayout

**How to Test**  
1.) Login to the data-manager-app
2.) Click the Create Button on the top left
3.) Click the "blank" button in the dialogue window
4) Observe the new fancy card design layout 

**Possible Review Questions** 
Should CSS stylings be imported on a global level(import directly into styles.css)or as done in this PR via the Cssimporter selector in the component? 
Are the individual style change methods(e.g. removeTitleStyles) really necessary for the CardLayout?

<img width="1440" alt="Data-manager-application-project-creation-picture " src="https://user-images.githubusercontent.com/29627977/193001995-d184326a-e87d-4f32-8d94-f375eaa10f30.png">

 