### PR TITLE
Make experimental design required during project creation and update

### DIFF
--- a/finances/src/main/java/life/qbic/projectmanagement/domain/finances/offer/ExperimentalDesignDescription.java
+++ b/finances/src/main/java/life/qbic/projectmanagement/domain/finances/offer/ExperimentalDesignDescription.java
@@ -1,6 +1,5 @@
 package life.qbic.projectmanagement.domain.finances.offer;
 
-import java.util.Objects;
 import javax.persistence.AttributeConverter;
 
 /**
@@ -21,17 +20,11 @@ public record ExperimentalDesignDescription(String description) {
     @Override
     public String convertToDatabaseColumn(
         ExperimentalDesignDescription experimentalDesignDescription) {
-      if (Objects.isNull(experimentalDesignDescription)) {
-        return "";
-      }
       return experimentalDesignDescription.description();
     }
 
     @Override
     public ExperimentalDesignDescription convertToEntityAttribute(String dbData) {
-      if (Objects.isNull(dbData) || dbData.isEmpty()) {
-        return null;
-      }
       return ExperimentalDesignDescription.from(dbData);
     }
   }

--- a/finances/src/main/java/life/qbic/projectmanagement/domain/finances/offer/Offer.java
+++ b/finances/src/main/java/life/qbic/projectmanagement/domain/finances/offer/Offer.java
@@ -1,6 +1,5 @@
 package life.qbic.projectmanagement.domain.finances.offer;
 
-import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -70,8 +69,8 @@ public class Offer {
     this.projectObjective = projectObjective;
   }
 
-  public Optional<ExperimentalDesignDescription> experimentalDesignDescription() {
-    return Optional.ofNullable(experimentalDesignDescription);
+  public ExperimentalDesignDescription experimentalDesignDescription() {
+    return experimentalDesignDescription;
   }
 
   private void setExperimentalDesignDescription(

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
@@ -2,7 +2,6 @@ package life.qbic.projectmanagement.application;
 
 import static life.qbic.logging.service.LoggerFactory.logger;
 
-import java.util.Objects;
 import java.util.Optional;
 import life.qbic.application.commons.ApplicationException;
 import life.qbic.application.commons.ApplicationException.ErrorCode;
@@ -33,8 +32,7 @@ public class ProjectCreationService {
   }
 
   /**
-   * Create a new project based on the information provided. If an empty experimental design
-   * description is provided, the project will not have an experimental design described.
+   * Create a new project based on the information provided.
    *
    * @param title              the title of the project.
    * @param objective          the objective of the project
@@ -46,13 +44,8 @@ public class ProjectCreationService {
       PersonReference principalInvestigator) {
     try {
       Project project;
-      if (Objects.isNull(experimentalDesign) || experimentalDesign.isEmpty()) {
-        project = createProjectWithoutExperimentalDesign(title, objective, projectManager,
-            principalInvestigator);
-      } else {
-        project = createProjectWithExperimentalDesign(title, objective, experimentalDesign,
-            projectManager, principalInvestigator);
-      }
+      project = createProject(title, objective, experimentalDesign,
+          projectManager, principalInvestigator);
       Optional.ofNullable(sourceOffer)
           .flatMap(it -> it.isBlank() ? Optional.empty() : Optional.of(it))
           .ifPresent(offerIdentifier -> project.linkOffer(OfferIdentifier.of(offerIdentifier)));
@@ -76,14 +69,7 @@ public class ProjectCreationService {
     return code;
   }
 
-  private Project createProjectWithoutExperimentalDesign(String title, String objective,
-      PersonReference projectManager,
-      PersonReference principalInvestigator) {
-    ProjectIntent intent = getProjectIntent(title, objective);
-    return Project.create(intent, createRandomCode(), projectManager, principalInvestigator);
-  }
-
-  private Project createProjectWithExperimentalDesign(String title,
+  private Project createProject(String title,
       String objective,
       String experimentalDesign, PersonReference projectManager,
       PersonReference principalInvestigator) {

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/ExperimentalDesignDescription.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/ExperimentalDesignDescription.java
@@ -13,8 +13,9 @@ public record ExperimentalDesignDescription(String value) {
 
 
   public ExperimentalDesignDescription {
-    if (Objects.isNull(value)) {
-      throw new IllegalArgumentException("experimental design cannot be created from null");
+    Objects.requireNonNull(value);
+    if (value.isEmpty()) {
+      throw new ProjectManagementDomainException("Experimental design is empty.");
     }
     if (value.length() > MAX_LENGTH) {
       throw new IllegalArgumentException(
@@ -22,7 +23,6 @@ public record ExperimentalDesignDescription(String value) {
               + "). The maximal length for experimental design descriptions is "
               + MAX_LENGTH);
     }
-    Objects.requireNonNull(value);
   }
 
   public static ExperimentalDesignDescription create(String value) {

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/Project.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/Project.java
@@ -98,8 +98,7 @@ public class Project {
 
   public void describeExperimentalDesign(
       ExperimentalDesignDescription experimentalDesignDescription) {
-    if (projectIntent.experimentalDesign().isPresent()
-        && projectIntent.experimentalDesign().get().equals(experimentalDesignDescription)) {
+    if (projectIntent.experimentalDesign().equals(experimentalDesignDescription)) {
       return;
     }
     projectIntent.experimentalDesign(experimentalDesignDescription);

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/ProjectIntent.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/ProjectIntent.java
@@ -3,7 +3,6 @@ package life.qbic.projectmanagement.domain.project;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
-import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embeddable;
@@ -64,8 +63,9 @@ public class ProjectIntent {
     this.projectTitle = projectTitle;
   }
 
-  public Optional<ExperimentalDesignDescription> experimentalDesign() {
-    return Optional.ofNullable(experimentalDesignDescription);
+  public ExperimentalDesignDescription experimentalDesign() {
+    Objects.requireNonNull(experimentalDesignDescription);
+    return experimentalDesignDescription;
   }
 
   public void experimentalDesign(ExperimentalDesignDescription experimentalDesignDescription) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/ProjectInformationDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/ProjectInformationDialog.java
@@ -56,6 +56,7 @@ public class ProjectInformationDialog extends Dialog {
     titleField = new TextField("Title");
     titleField.setRequired(true);
     experimentalDesignField = new TextArea("Experimental Design");
+    experimentalDesignField.setRequired(true);
     projectObjective = new TextArea("Objective");
     projectObjective.setRequired(true);
 
@@ -151,9 +152,8 @@ public class ProjectInformationDialog extends Dialog {
     public void loadOfferContent(Offer offer) {
       titleField.setValue(offer.projectTitle().title());
       projectObjective.setValue(offer.projectObjective().objective());
-      offer.experimentalDesignDescription()
-          .ifPresentOrElse(it -> experimentalDesignField.setValue(it.description()),
-              experimentalDesignField::clear);
+      experimentalDesignField.setValue(offer.experimentalDesignDescription().description());
+
     }
 
     private void restrictInputLength() {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/components/ProjectOverviewComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/components/ProjectOverviewComponent.java
@@ -246,11 +246,12 @@ public class ProjectOverviewComponent extends Composite<CardLayout> {
           projectManager, principalInvestigator);
 
       project.ifSuccessOrElse(
-          result -> displaySuccessfulProjectCreationNotification(),
+          result -> {
+            displaySuccessfulProjectCreationNotification();
+            projectInformationDialog.close();
+            projectGrid.getDataProvider().refreshAll();
+          },
           applicationException -> exceptionHandler.handle(UI.getCurrent(), applicationException));
-
-      projectInformationDialog.close();
-      projectGrid.getDataProvider().refreshAll();
     }
 
     private void displaySuccessfulProjectCreationNotification() {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -130,10 +130,12 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
         .set("--vaadin-combo-box-width", "16em");
     titleToggleComponent.getInputComponent().setRequired(true);
     projectObjectiveToggleComponent.getInputComponent().setRequired(true);
+    experimentalDesignToggleComponent.getInputComponent().setRequired(true);
     projectManagerToggleComponent.getInputComponent().setRequired(true);
     principalInvestigatorToggleComponent.getInputComponent().setRequired(true);
     titleToggleComponent.setRequiredIndicatorVisible(true);
     projectObjectiveToggleComponent.setRequiredIndicatorVisible(true);
+    experimentalDesignToggleComponent.setRequiredIndicatorVisible(true);
     projectManagerToggleComponent.setRequiredIndicatorVisible(true);
     principalInvestigatorToggleComponent.setRequiredIndicatorVisible(true);
   }
@@ -219,9 +221,8 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
       this.selectedProject = project.getId();
       titleToggleComponent.setValue(project.getProjectIntent().projectTitle().title());
       projectObjectiveToggleComponent.setValue(project.getProjectIntent().objective().value());
-      project.getProjectIntent().experimentalDesign().ifPresentOrElse(
-          experimentalDesignDescription -> experimentalDesignToggleComponent.setValue(
-              experimentalDesignDescription.value()), experimentalDesignToggleComponent::clear);
+      experimentalDesignToggleComponent.setValue(
+          project.getProjectIntent().experimentalDesign().value());
       projectManagerToggleComponent.setValue(project.getProjectManager());
       principalInvestigatorToggleComponent.setValue(project.getPrincipalInvestigator());
     }

--- a/vaadinfrontend/src/main/resources/messages.properties
+++ b/vaadinfrontend/src/main/resources/messages.properties
@@ -1,4 +1,4 @@
 GENERAL=Ooooooops! Sorry! -> Please contact support@qbic.zendesk.com.
 INVALID_PROJECT_TITLE=The project title {1} is invalid. -> A valid project title is not empty and is shorter than {0} characters.
-INVALID_EXPERIMENTAL_DESIGN=The experimental design description is too long. -> A description of an experimental design must contain at most {0} characters.
+INVALID_EXPERIMENTAL_DESIGN=The experimental design description is invalid -> A vaild description of an experimental design must not be empty and contain at most {0} characters.
 INVALID_PROJECT_OBJECTIVE=The project objective {0} is invalid. -> A valid objective is not empty.


### PR DESCRIPTION
**What was changed** 
Removes the optional wrapping of the experimentaldesigndescription in the domain and application logic since it's a mandatory field now. 

**Additional changes**
Also updated the database by filling in the empty experimental design fields for all currently created projects. 

**More Information**
Addresses DM-635