### PR TITLE
Update/dm 659 bump vaadin version to latest release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <vaadin.version>23.1.3</vaadin.version>
+    <vaadin.version>23.2.11</vaadin.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>
@@ -34,7 +34,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.5</version>
+    <version>2.7.6</version>
   </parent>
 
   <repositories>
@@ -122,10 +122,17 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-          <groupId>org.spockframework</groupId>
-          <artifactId>spock-core</artifactId>
-          <version>2.2-M3-groovy-4.0</version>
-          <scope>test</scope>
+        <groupId>org.spockframework</groupId>
+        <artifactId>spock-core</artifactId>
+        <version>2.2-M3-groovy-4.0</version>
+        <scope>test</scope>
+      </dependency>
+      <!--If not specified, the 2.7.6 spring-boot-starter-parent dependency will introduce transitively the 1.30 version of snakeyaml, for which a multitude of security concerns are reported
+      See https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.30 for details. -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.33</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/projectmanagement/pom.xml
+++ b/projectmanagement/pom.xml
@@ -21,10 +21,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -58,8 +54,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>5.7.2</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/vaadinfrontend/pom.xml
+++ b/vaadinfrontend/pom.xml
@@ -114,14 +114,6 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>2.1.212</version>
-      <scope>runtime</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/security/SecurityConfiguration.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/security/SecurityConfiguration.java
@@ -10,7 +10,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @EnableWebSecurity
 @Configuration
@@ -26,6 +25,7 @@ public class SecurityConfiguration extends VaadinWebSecurity {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
+    http.authorizeRequests().antMatchers("/images/*.png").permitAll();
     super.configure(http);
     setLoginView(http, LoginLayout.class, LOGOUT_URL);
   }
@@ -33,6 +33,5 @@ public class SecurityConfiguration extends VaadinWebSecurity {
   @Override
   public void configure(WebSecurity web) throws Exception {
     super.configure(web);
-    web.ignoring().requestMatchers(new AntPathRequestMatcher("/images/*.png"));
   }
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/security/SecurityConfiguration.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/security/SecurityConfiguration.java
@@ -1,6 +1,6 @@
 package life.qbic.datamanager.security;
 
-import com.vaadin.flow.spring.security.VaadinWebSecurityConfigurerAdapter;
+import com.vaadin.flow.spring.security.VaadinWebSecurity;
 import life.qbic.authorization.security.QBiCPasswordEncoder;
 import life.qbic.datamanager.views.login.LoginLayout;
 import org.springframework.context.annotation.Bean;
@@ -10,11 +10,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @EnableWebSecurity
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-public class SecurityConfiguration extends VaadinWebSecurityConfigurerAdapter {
+public class SecurityConfiguration extends VaadinWebSecurity {
 
   public static final String LOGOUT_URL = "/";
 
@@ -32,6 +33,6 @@ public class SecurityConfiguration extends VaadinWebSecurityConfigurerAdapter {
   @Override
   public void configure(WebSecurity web) throws Exception {
     super.configure(web);
-    web.ignoring().antMatchers("/images/*.png");
+    web.ignoring().requestMatchers(new AntPathRequestMatcher("/images/*.png"));
   }
 }

--- a/vaadinfrontend/src/main/resources/application.properties
+++ b/vaadinfrontend/src/main/resources/application.properties
@@ -15,10 +15,10 @@ spring.jpa.hibernate.ddl-auto=none
 # Can be enabled for debugging purposes, not recommended in production
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
-
+# Set explicitly to true instead of default assumption to avoid warning during startup
+spring.jpa.open-in-view=true
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-
 # mail configuration
 spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}


### PR DESCRIPTION
**What was changed** 

1.) Update vaadin version 

Sets vaadin to latest vaadin 23.2 release replacing webpack with Vite. 
Note you need to delete all webpack files manually and rebuild the project once. 

2.) Update pom.xml versions 

a) vaadin 23.2.11
b) spring-boot-starter-parent 2.7.6 
b) explictily set transitive dependency of snakeyaml to 1.33.0 (LINK CVE)

3.) Clean up pom.xml 

a) duplicate javax.persistence definition in projectmanagement pom.xml 
b) unused com.h2database definition in frontend pom.xml (Link CVE)  

4.) Address issues outlined in current startup warnings 

a) explictily set spring.jpa.open-in-view to true instead in application.properties instead of reyling on default setting to true 
b) Move Image.png antmatcher in security service to http request with explicit permission (Link Vaadin Issue)