### PR TITLE
Allow specification for responsible person during project creation and project update

### DIFF
--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
@@ -41,11 +41,11 @@ public class ProjectCreationService {
    */
   public Result<Project, ApplicationException> createProject(String title, String objective,
       String experimentalDesign, String sourceOffer, PersonReference projectManager,
-      PersonReference principalInvestigator) {
+      PersonReference principalInvestigator, PersonReference responsiblePerson) {
     try {
       Project project;
       project = createProject(title, objective, experimentalDesign,
-          projectManager, principalInvestigator);
+          projectManager, principalInvestigator, responsiblePerson);
       Optional.ofNullable(sourceOffer)
           .flatMap(it -> it.isBlank() ? Optional.empty() : Optional.of(it))
           .ifPresent(offerIdentifier -> project.linkOffer(OfferIdentifier.of(offerIdentifier)));
@@ -72,7 +72,7 @@ public class ProjectCreationService {
   private Project createProject(String title,
       String objective,
       String experimentalDesign, PersonReference projectManager,
-      PersonReference principalInvestigator) {
+      PersonReference principalInvestigator, PersonReference responsiblePerson) {
 
     ExperimentalDesignDescription experimentalDesignDescription;
     try {
@@ -84,7 +84,8 @@ public class ProjectCreationService {
     }
 
     ProjectIntent intent = getProjectIntent(title, objective).with(experimentalDesignDescription);
-    return Project.create(intent, createRandomCode(), projectManager, principalInvestigator);
+    return Project.create(intent, createRandomCode(), projectManager, principalInvestigator,
+        responsiblePerson);
   }
 
   private static ProjectIntent getProjectIntent(String title, String objective) {

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
@@ -92,6 +92,15 @@ public class ProjectInformationService {
     });
   }
 
+  public void setResponsibility(String projectId, PersonReference personReference) {
+    ProjectId projectIdentifier = ProjectId.of(UUID.fromString(projectId));
+    Optional<Project> project = projectRepository.find(projectIdentifier);
+    project.ifPresent(p -> {
+      p.setResponsiblePerson(personReference);
+      projectRepository.update(p);
+    });
+  }
+
   public void describeExperimentalDesign(String projectId, String experimentalDesign) {
     ProjectId projectIdentifier = ProjectId.of(UUID.fromString(projectId));
     ExperimentalDesignDescription experimentalDesignDescription = ExperimentalDesignDescription.create(

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/Project.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/Project.java
@@ -55,8 +55,13 @@ public class Project {
   @JoinColumn(name = "principalInvestigatorRef")
   private PersonReference principalInvestigator;
 
+  @OneToOne(targetEntity = PersonReference.class, cascade = CascadeType.ALL)
+  @JoinColumn(name = "responsiblePersonRef")
+  private PersonReference responsiblePerson;
+
   private Project(ProjectId projectId, ProjectIntent projectIntent, ProjectCode projectCode,
-      PersonReference projectManager, PersonReference principalInvestigator) {
+      PersonReference projectManager, PersonReference principalInvestigator,
+      PersonReference responsiblePerson) {
     requireNonNull(principalInvestigator);
     requireNonNull(projectCode);
     requireNonNull(projectId);
@@ -67,6 +72,7 @@ public class Project {
     setProjectId(projectId);
     setProjectIntent(projectIntent);
     setProjectManager(projectManager);
+    setResponsiblePerson(responsiblePerson);
     linkedOffers = new ArrayList<>();
   }
 
@@ -77,6 +83,11 @@ public class Project {
 
   public void setPrincipalInvestigator(PersonReference principalInvestigator) {
     this.principalInvestigator = principalInvestigator;
+    this.lastModified = Instant.now();
+  }
+
+  public void setResponsiblePerson(PersonReference responsiblePerson) {
+    this.responsiblePerson = responsiblePerson;
     this.lastModified = Instant.now();
   }
 
@@ -149,12 +160,14 @@ public class Project {
    * @param projectIntent         the intent of the project
    * @param projectManager        the assigned project manager
    * @param principalInvestigator the principal investigator
+   * @param responsiblePerson     the person who should be contacted
    * @return a new project instance
    */
   public static Project create(ProjectIntent projectIntent, ProjectCode projectCode,
-      PersonReference projectManager, PersonReference principalInvestigator) {
+      PersonReference projectManager, PersonReference principalInvestigator,
+      PersonReference responsiblePerson) {
     return new Project(ProjectId.create(), projectIntent, projectCode, projectManager,
-        principalInvestigator);
+        principalInvestigator, responsiblePerson);
   }
 
   /**
@@ -164,13 +177,14 @@ public class Project {
    * @param projectIntent         the project intent
    * @param projectManager        the assigned project manager
    * @param principalInvestigator the principal investigator
+   * @param responsiblePerson     the person who should be contacted
    * @return a project with the given identity and project intent
    */
   public static Project of(ProjectId projectId, ProjectIntent projectIntent,
       ProjectCode projectCode, PersonReference projectManager,
-      PersonReference principalInvestigator) {
+      PersonReference principalInvestigator, PersonReference responsiblePerson) {
     return new Project(projectId, projectIntent, projectCode, projectManager,
-        principalInvestigator);
+        principalInvestigator, responsiblePerson);
   }
 
   public ProjectId getId() {
@@ -187,6 +201,10 @@ public class Project {
 
   public PersonReference getPrincipalInvestigator() {
     return principalInvestigator;
+  }
+
+  public PersonReference getResponsiblePerson() {
+    return responsiblePerson;
   }
 
   @Override

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/ProjectInformationDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/create/ProjectInformationDialog.java
@@ -43,10 +43,9 @@ public class ProjectInformationDialog extends Dialog {
 
   private final TextArea experimentalDesignField;
   private final TextArea projectObjective;
-
-  public final ComboBox<PersonReference> projectManager;
-
   public final ComboBox<PersonReference> principalInvestigator;
+  public final ComboBox<PersonReference> responsiblePerson;
+  public final ComboBox<PersonReference> projectManager;
 
   public ProjectInformationDialog() {
     searchField = new ComboBox<>("Offer");
@@ -60,10 +59,17 @@ public class ProjectInformationDialog extends Dialog {
     projectObjective = new TextArea("Objective");
     projectObjective.setRequired(true);
 
-    projectManager = new ComboBox<>("Project Manager");
-    projectManager.setPlaceholder("Select a project manager");
     principalInvestigator = new ComboBox<>("Principal Investigator");
     principalInvestigator.setPlaceholder("Select a principal investigator");
+
+    responsiblePerson = new ComboBox<>("Project Responsible (optional)");
+    responsiblePerson.setPlaceholder("Select Project Responsible");
+    responsiblePerson.setHelperText("Should be contacted about project related questions");
+    //Workaround since combobox does not allow empty selection https://github.com/vaadin/flow-components/issues/1998
+    responsiblePerson.setClearButtonVisible(true);
+
+    projectManager = new ComboBox<>("Project Manager (optional)");
+    projectManager.setPlaceholder("Select a project manager");
 
     createButton = new Button("Create");
     cancelButton = new Button("Cancel");
@@ -98,8 +104,9 @@ public class ProjectInformationDialog extends Dialog {
     formLayout.add(titleField);
     formLayout.add(projectObjective);
     formLayout.add(experimentalDesignField);
-    formLayout.add(projectManager);
     formLayout.add(principalInvestigator);
+    formLayout.add(responsiblePerson);
+    formLayout.add(projectManager);
     // set form layout to only have one column (for any width)
     formLayout.setResponsiveSteps(new ResponsiveStep("0", 1));
   }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/components/ProjectOverviewComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/components/ProjectOverviewComponent.java
@@ -186,8 +186,9 @@ public class ProjectOverviewComponent extends Composite<CardLayout> {
       loadOfferPreview();
       setProjectsToGrid();
       setupSearchBar();
-      setUpProjectManagerSearch();
       setUpPrincipalInvestigatorSearch();
+      setUpResponsiblePersonSearch();
+      setUpProjectManagerSearch();
     }
 
     private void setupSearchBar() {
@@ -241,9 +242,13 @@ public class ProjectOverviewComponent extends Composite<CardLayout> {
               ? projectInformationDialog.searchField.getValue().offerId()
               .id() : null;
 
+      PersonReference responsiblePerson =
+          projectInformationDialog.responsiblePerson.getValue() != null
+              ? projectInformationDialog.responsiblePerson.getValue() : null;
+
       Result<Project, ApplicationException> project = projectCreationService.createProject(
           titleFieldValue, objectiveFieldValue, experimentalDesignDescription, loadedOfferId,
-          projectManager, principalInvestigator);
+          projectManager, principalInvestigator, responsiblePerson);
 
       project.ifSuccessOrElse(
           result -> {
@@ -303,6 +308,10 @@ public class ProjectOverviewComponent extends Composite<CardLayout> {
 
     private void setUpPrincipalInvestigatorSearch() {
       setUpPersonSearch(projectInformationDialog.principalInvestigator);
+    }
+
+    private void setUpResponsiblePersonSearch() {
+      setUpPersonSearch(projectInformationDialog.responsiblePerson);
     }
 
     private void preloadContentFromOffer(String offerId) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -52,6 +52,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
   private ToggleDisplayEditComponent<Span, TextArea, String> experimentalDesignToggleComponent;
   private ToggleDisplayEditComponent<Component, ComboBox<PersonReference>, PersonReference> projectManagerToggleComponent;
   private ToggleDisplayEditComponent<Component, ComboBox<PersonReference>, PersonReference> principalInvestigatorToggleComponent;
+  private ToggleDisplayEditComponent<Component, ComboBox<PersonReference>, PersonReference> responsiblePersonToggleComponent;
   private final transient Handler handler;
 
   public ProjectDetailsComponent(@Autowired ProjectInformationService projectInformationService,
@@ -78,8 +79,9 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     formLayout.addFormItem(titleToggleComponent, "Project Title");
     formLayout.addFormItem(projectObjectiveToggleComponent, "Project Objective");
     formLayout.addFormItem(experimentalDesignToggleComponent, "Experimental Design");
-    formLayout.addFormItem(projectManagerToggleComponent, "Project Manager");
     formLayout.addFormItem(principalInvestigatorToggleComponent, "Principal Investigator");
+    formLayout.addFormItem(responsiblePersonToggleComponent, "Responsible Person");
+    formLayout.addFormItem(projectManagerToggleComponent, "Project Manager");
     // set form layout to only have one column (for any width)
     formLayout.setResponsiveSteps(new ResponsiveStep("0", 1));
     getContent().addFields(formLayout);
@@ -93,12 +95,15 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
         createPlaceHolderSpan("Project Objective"));
     experimentalDesignToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextArea(),
         createPlaceHolderSpan("Experimental Design"));
-    projectManagerToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
-        initPersonReferenceCombobox("Project Manager"),
-        createPlaceHolderSpan("Project Manager"));
     principalInvestigatorToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
         initPersonReferenceCombobox("Principal Investigator"),
         createPlaceHolderSpan("Principal Investigator"));
+    responsiblePersonToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
+        initPersonReferenceCombobox("Responsible Person"),
+        createPlaceHolderSpan("Responsible Person"));
+    projectManagerToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
+        initPersonReferenceCombobox("Project Manager"),
+        createPlaceHolderSpan("Project Manager"));
   }
 
   private Span createPlaceHolderSpan(String projectDetail) {
@@ -126,8 +131,10 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
         .set("--vaadin-combo-box-width", "16em");
     principalInvestigatorToggleComponent.getInputComponent().getStyle()
         .set("--vaadin-combo-box-overlay-width", "16em");
-    principalInvestigatorToggleComponent.getInputComponent().getStyle()
+    responsiblePersonToggleComponent.getInputComponent().getStyle()
         .set("--vaadin-combo-box-width", "16em");
+    //Workaround since combobox does not allow empty selection https://github.com/vaadin/flow-components/issues/1998
+    responsiblePersonToggleComponent.getInputComponent().setClearButtonVisible(true);
     titleToggleComponent.getInputComponent().setRequired(true);
     projectObjectiveToggleComponent.getInputComponent().setRequired(true);
     experimentalDesignToggleComponent.getInputComponent().setRequired(true);
@@ -169,6 +176,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
       restrictInputLength();
       setUpPersonSearch(projectManagerToggleComponent.getInputComponent());
       setUpPersonSearch(principalInvestigatorToggleComponent.getInputComponent());
+      setUpPersonSearch(responsiblePersonToggleComponent.getInputComponent());
     }
 
     public void projectId(String projectId) {
@@ -225,6 +233,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
           project.getProjectIntent().experimentalDesign().value());
       projectManagerToggleComponent.setValue(project.getProjectManager());
       principalInvestigatorToggleComponent.setValue(project.getPrincipalInvestigator());
+      responsiblePersonToggleComponent.setValue(project.getResponsiblePerson());
     }
 
     private void setUpPersonSearch(ComboBox<PersonReference> comboBox) {
@@ -255,6 +264,9 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
       ProjectDetailsComponent.Handler.submitOnValueChange(principalInvestigatorToggleComponent,
           value ->
               projectInformationService.investigateProject(selectedProject.value(), value));
+      ProjectDetailsComponent.Handler.submitOnValueChange(responsiblePersonToggleComponent,
+          value ->
+              projectInformationService.setResponsibility(selectedProject.value(), value));
     }
 
     private static <V, T extends HasValue<?, V>> void submitOnValueChange(T element,

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -3,19 +3,17 @@ package life.qbic.datamanager.views.project.view.components;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.HasValue;
-import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.icon.Icon;
-import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.spring.annotation.SpringComponent;
 import com.vaadin.flow.spring.annotation.UIScope;
+import com.vaadin.flow.theme.lumo.LumoUtility.TextColor;
 import java.io.Serial;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -90,30 +88,25 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
 
   private void initFormFields() {
     titleToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextField(),
-        createPlaceHolderSpan("Project Title"));
+        createPlaceHolderSpan());
     projectObjectiveToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextArea(),
-        createPlaceHolderSpan("Project Objective"));
+        createPlaceHolderSpan());
     experimentalDesignToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextArea(),
-        createPlaceHolderSpan("Experimental Design"));
+        createPlaceHolderSpan());
     principalInvestigatorToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
         initPersonReferenceCombobox("Principal Investigator"),
-        createPlaceHolderSpan("Principal Investigator"));
+        createPlaceHolderSpan());
     responsiblePersonToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
         initPersonReferenceCombobox("Responsible Person"),
-        createPlaceHolderSpan("Responsible Person"));
+        createPlaceHolderSpan());
     projectManagerToggleComponent = new ToggleDisplayEditComponent<>(ContactElement::from,
         initPersonReferenceCombobox("Project Manager"),
-        createPlaceHolderSpan("Project Manager"));
+        createPlaceHolderSpan());
   }
 
-  private Span createPlaceHolderSpan(String projectDetail) {
-    Span placeholderSpan = new Span();
-    Icon placeholderIcon = new Icon(VaadinIcon.PLUS_CIRCLE);
-    Text placeholderText = new Text("Add %s".formatted(projectDetail));
-    placeholderSpan.add(placeholderIcon, placeholderText);
-    placeholderSpan.getElement().getThemeList().add("badge");
-    placeholderIcon.getElement().getStyle().set("padding", "var(--lumo-space-xs");
-    placeholderIcon.getElement().getStyle().set("margin-right", "var(--lumo-space-xs");
+  private Span createPlaceHolderSpan() {
+    Span placeholderSpan = new Span("None");
+    placeholderSpan.addClassName(TextColor.SECONDARY);
     return placeholderSpan;
   }
 


### PR DESCRIPTION
**What was changed** 
Adds the possibility to optionally add a responsible person during the project creation and update process

**Nice to know** 
Vaadin 23 flow does not provide the possiblity of empty selection during selection in the combobox component. 
The current workaround uses the clear button provided by the combobox to allow empty selection after a responsible person was specified

**Details**
Ordering and implementation according to prototype: [DM-655](https://qbicsoftware.atlassian.net/browse/DM-655)
Added a new column to store the responsible person information in the `project_datamanager` table called `responsiblePersonDef`

[DM-655]: https://qbicsoftware.atlassian.net/browse/DM-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ