### PR TITLE
Fix Spacing of ProjectDetailsComponent

### DIFF
--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -155,12 +155,9 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     experimentalDesignToggleComponent.setRequiredIndicatorVisible(true);
     projectManagerToggleComponent.setRequiredIndicatorVisible(true);
     principalInvestigatorToggleComponent.setRequiredIndicatorVisible(true);
-    organismMultiSelectComboBox.setMinWidth(60, Unit.VW);
-    specimenMultiSelectComboBox.setMinWidth(60, Unit.VW);
-    analyteMultiSelectComboBox.setMinWidth(60, Unit.VW);
-    organismMultiSelectComboBox.setMaxWidth(60, Unit.VW);
-    specimenMultiSelectComboBox.setMaxWidth(60, Unit.VW);
-    analyteMultiSelectComboBox.setMaxWidth(60, Unit.VW);
+    organismMultiSelectComboBox.setWidth(50, Unit.VW);
+    specimenMultiSelectComboBox.setWidth(50, Unit.VW);
+    analyteMultiSelectComboBox.setWidth(50, Unit.VW);
     formLayout.setClassName("create-project-form");
     organismMultiSelectComboBox.addClassName("chip-badge");
     specimenMultiSelectComboBox.addClassName("chip-badge");


### PR DESCRIPTION
**What was changed** 
Adjusts the width of the multiselect-comboboxes to stay within the boundaries of the outer projectdetailscomponent.

**Why it was changed**
Because the Viewpoint width was set to high, the projectdetailscomponent got pushed outside of the right side of the screen 