### PR TITLE
Set projects overview as root route

### DIFF
--- a/database-connector/src/main/java/life/qbic/projectmanagement/persistence/repository/OpenbisConnector.java
+++ b/database-connector/src/main/java/life/qbic/projectmanagement/persistence/repository/OpenbisConnector.java
@@ -12,6 +12,7 @@ import ch.ethz.sis.openbis.generic.asapi.v3.dto.project.search.ProjectSearchCrit
 import ch.ethz.sis.openbis.generic.asapi.v3.dto.space.id.SpacePermId;
 import ch.ethz.sis.openbis.generic.asapi.v3.dto.vocabulary.fetchoptions.VocabularyTermFetchOptions;
 import ch.ethz.sis.openbis.generic.asapi.v3.dto.vocabulary.search.VocabularyTermSearchCriteria;
+import java.util.Objects;
 import life.qbic.logging.api.Logger;
 import life.qbic.openbis.openbisclient.OpenBisClient;
 import life.qbic.projectmanagement.domain.project.ProjectCode;
@@ -45,11 +46,40 @@ public class OpenbisConnector implements ExperimentalDesignVocabularyRepository,
 
   // used by spring to wire it up
   private OpenbisConnector(@Value("${openbis.user.name}") String userName,
-                           @Value("${openbis.user.password}") String password,
-                           @Value("${openbis.datasource.url}") String url) {
+      @Value("${openbis.user.password}") String password,
+      @Value("${openbis.datasource.url}") String url) {
     openBisClient = new OpenBisClient(
-            userName, password, url);
-    openBisClient.login();
+        userName, password, url);
+    try {
+      login();
+    } catch (RuntimeException e) {
+      if (!(e instanceof ConnectionException)) {
+        log.error("Unexpected runtime exception", e);
+      }
+      throw new RuntimeException("Could not establish a connection to a data connector.");
+    }
+  }
+
+  private void login() throws RuntimeException {
+    try {
+      openBisClient.login();
+    } catch (Exception e) {
+      // login must not throw any exceptions.
+      // so if we log it and return a more generic exception to not expose
+      // implementation details
+      log.error("Connection to openBIS was not established", e);
+      throw new ConnectionException();
+    }
+    // If the connection is not active, fail early
+    if (isNotConnected()) {
+      log.error("Login to openBIS was not successful, correct credentials?");
+      throw new ConnectionException();
+    }
+  }
+
+  private boolean isNotConnected() {
+    return Objects.isNull(openBisClient.getSessionToken()) || openBisClient.getSessionToken()
+        .isEmpty();
   }
 
   private List<VocabularyTerm> getVocabularyTermsForCode(VocabularyCode vocabularyCode) {
@@ -132,6 +162,10 @@ public class OpenbisConnector implements ExperimentalDesignVocabularyRepository,
   @Override
   public boolean projectExists(ProjectCode projectCode) {
     return !searchProjectsByCode(projectCode.toString()).isEmpty();
+  }
+
+  // Convenience RTE to describe connection issues
+  class ConnectionException extends RuntimeException {
   }
 
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/AppRoutes.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/AppRoutes.java
@@ -1,16 +1,24 @@
 package life.qbic.datamanager.views;
 
 /**
- * <b><class short description - 1 Line!></b>
+ * Defines the data manager's public application routes, that
+ * shall be visible by all components within the app.
  *
- * <p><More detailed description - When to use, what it solves, etc.></p>
+ * Local routes of components should be listed here with care!
  *
- * @since <version tag>
+ * @since 1.0.0
  */
 public class AppRoutes {
 
+  /**
+   * The "Main" page of the data manager app. Location, where you want the user to be
+   * directed to, if no explicit path has been provided.
+   */
   public static final String MAIN = "";
 
+  /**
+   * The alias name for the MAIN route.
+   */
   public static final String MAIN_ALIAS = "projects";
 
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/AppRoutes.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/AppRoutes.java
@@ -1,0 +1,16 @@
+package life.qbic.datamanager.views;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public class AppRoutes {
+
+  public static final String MAIN = "";
+
+  public static final String MAIN_ALIAS = "projects";
+
+}

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/MainLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/MainLayout.java
@@ -4,6 +4,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import javax.annotation.security.PermitAll;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -12,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @since 1.0.0
  */
 @PageTitle("Data Manager")
-@Route(value = "data")
 public class MainLayout extends DataManagerLayout {
   public Button logout;
 

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/login/LoginHandler.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/login/LoginHandler.java
@@ -4,10 +4,14 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.BeforeEvent;
 import java.util.List;
 import java.util.Map;
+import life.qbic.application.commons.ApplicationException;
 import life.qbic.authentication.application.user.registration.ConfirmEmailInput;
 import life.qbic.authentication.application.user.registration.ConfirmEmailOutput;
+import life.qbic.datamanager.Application;
 import life.qbic.datamanager.views.notifications.ErrorMessage;
 import life.qbic.datamanager.views.notifications.InformationMessage;
+import life.qbic.logging.api.Logger;
+import life.qbic.logging.service.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,6 +23,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
+
+  private static final Logger logger = LoggerFactory.logger(Application.class.getName());
 
   private LoginLayout registeredLoginView;
 
@@ -82,8 +88,12 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   private void onLoginSucceeded() {
+    logger.info("Login event fired");
     clearNotifications();
-    UI.getCurrent().navigate("/projects");
+    registeredLoginView.getUI().ifPresentOrElse(ui -> {
+      ui.navigate("");
+      logger.info("Routing to projects");
+    }, () -> logger.info("no UI found!"));
   }
 
   @Override

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/login/LoginHandler.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/login/LoginHandler.java
@@ -8,6 +8,7 @@ import life.qbic.application.commons.ApplicationException;
 import life.qbic.authentication.application.user.registration.ConfirmEmailInput;
 import life.qbic.authentication.application.user.registration.ConfirmEmailOutput;
 import life.qbic.datamanager.Application;
+import life.qbic.datamanager.views.AppRoutes;
 import life.qbic.datamanager.views.notifications.ErrorMessage;
 import life.qbic.datamanager.views.notifications.InformationMessage;
 import life.qbic.logging.api.Logger;
@@ -88,12 +89,10 @@ public class LoginHandler implements LoginHandlerInterface, ConfirmEmailOutput {
   }
 
   private void onLoginSucceeded() {
-    logger.info("Login event fired");
     clearNotifications();
     registeredLoginView.getUI().ifPresentOrElse(ui -> {
-      ui.navigate("");
-      logger.info("Routing to projects");
-    }, () -> logger.info("no UI found!"));
+      ui.navigate(AppRoutes.MAIN);
+    }, () -> logger.error("No UI found!"));
   }
 
   @Override

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/ProjectOverviewPage.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/ProjectOverviewPage.java
@@ -3,6 +3,7 @@ package life.qbic.datamanager.views.project.overview;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
 import java.io.Serial;
 import javax.annotation.security.PermitAll;
 import life.qbic.datamanager.views.MainLayout;
@@ -18,7 +19,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @since 1.0.0
  */
 @PageTitle("Project Overview")
-@Route(value = "projects", layout = MainLayout.class)
+@Route(value = "", layout = MainLayout.class)
+@RouteAlias(value = "projects")
 @PermitAll
 public class ProjectOverviewPage extends Div {
   @Serial

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/ProjectOverviewPage.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/ProjectOverviewPage.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import java.io.Serial;
 import javax.annotation.security.PermitAll;
+import life.qbic.datamanager.views.AppRoutes;
 import life.qbic.datamanager.views.MainLayout;
 import life.qbic.datamanager.views.project.overview.components.ProjectOverviewComponent;
 import life.qbic.logging.api.Logger;
@@ -19,8 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @since 1.0.0
  */
 @PageTitle("Project Overview")
-@Route(value = "", layout = MainLayout.class)
-@RouteAlias(value = "projects")
+@Route(value = AppRoutes.MAIN, layout = MainLayout.class)
+@RouteAlias(value = AppRoutes.MAIN_ALIAS)
 @PermitAll
 public class ProjectOverviewPage extends Div {
   @Serial


### PR DESCRIPTION
A parent layout should not be the root route, since tthis will show the navigation page after login in development mode, and not work at all in production mode (route cannot be found!).

Every Vaadin App should have a defined root route, that represents the default entry page for a user.