### PR TITLE
Introduce ProjectNavigationBarComponent with styling

### DIFF
--- a/vaadinfrontend/frontend/styles/views/project/project-view.css
+++ b/vaadinfrontend/frontend/styles/views/project/project-view.css
@@ -1,17 +1,23 @@
 .project-view-page {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0px, 1fr));
-  grid-template-rows: repeat(2, minmax(0px, 1fr));
-  grid-gap: 50px;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  grid-gap: 10px;
   min-height: 100%;
+  padding: 50px;
+}
+
+.project-navigation-component {
+  grid-column: 1 / span 3;
+  grid-row: 1 / span 1;
 }
 
 .project-details-component {
-  grid-row: 1 / span 2 ;
-  grid-column: 1 / span 2;
+  grid-column: 1 / span 3;
+  grid-row: 2 / span 4;
 }
 
 .project-links-component {
-  grid-column: 3 / span 1;
-  grid-row: 2 / span 1;
+  grid-column: 4 / span 2;
+  grid-row: 1 / span 3;
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewHandler.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewHandler.java
@@ -3,6 +3,7 @@ package life.qbic.datamanager.views.project.view;
 import java.util.Objects;
 import life.qbic.datamanager.views.project.view.components.ProjectDetailsComponent;
 import life.qbic.datamanager.views.project.view.components.ProjectLinksComponent;
+import life.qbic.datamanager.views.project.view.components.ProjectNavigationBarComponent;
 import life.qbic.logging.api.Logger;
 import life.qbic.logging.service.LoggerFactory;
 
@@ -15,14 +16,16 @@ class ProjectViewHandler {
 
   private static final Logger log = LoggerFactory.logger(ProjectViewHandler.class);
   private final ProjectLinksComponent projectLinksComponent;
-
+  private final ProjectNavigationBarComponent projectNavigationBarComponent;
   private final ProjectDetailsComponent projectDetailsComponent;
 
-  public ProjectViewHandler(ProjectDetailsComponent projectDetailsComponent,
+  public ProjectViewHandler(ProjectNavigationBarComponent projectNavigationBarComponent,
+      ProjectDetailsComponent projectDetailsComponent,
       ProjectLinksComponent projectLinksComponent) {
     Objects.requireNonNull(projectDetailsComponent);
     Objects.requireNonNull(projectLinksComponent);
-
+    Objects.requireNonNull(projectNavigationBarComponent);
+    this.projectNavigationBarComponent = projectNavigationBarComponent;
     this.projectLinksComponent = projectLinksComponent;
     this.projectDetailsComponent = projectDetailsComponent;
   }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewPage.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewPage.java
@@ -10,6 +10,7 @@ import javax.annotation.security.PermitAll;
 import life.qbic.datamanager.views.MainLayout;
 import life.qbic.datamanager.views.project.view.components.ProjectDetailsComponent;
 import life.qbic.datamanager.views.project.view.components.ProjectLinksComponent;
+import life.qbic.datamanager.views.project.view.components.ProjectNavigationBarComponent;
 import life.qbic.logging.api.Logger;
 import life.qbic.logging.service.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,13 +36,16 @@ public class ProjectViewPage extends Div implements
 
   private final transient ProjectViewHandler handler;
 
-  public ProjectViewPage(@Autowired ProjectDetailsComponent projectDetailsComponent, @Autowired
-      ProjectLinksComponent projectLinksComponent) {
-    handler = new ProjectViewHandler(projectDetailsComponent, projectLinksComponent);
+  public ProjectViewPage(@Autowired ProjectNavigationBarComponent projectNavigationBarComponent,
+      @Autowired ProjectDetailsComponent projectDetailsComponent, @Autowired
+  ProjectLinksComponent projectLinksComponent) {
+    handler = new ProjectViewHandler(projectNavigationBarComponent, projectDetailsComponent,
+        projectLinksComponent);
     add(projectDetailsComponent);
     add(projectLinksComponent);
     setPageStyles();
-    setComponentStyles(projectDetailsComponent, projectLinksComponent);
+    setComponentStyles(projectNavigationBarComponent, projectDetailsComponent,
+        projectLinksComponent);
     log.debug(
         String.format("New instance for project view (#%s) created with detail component (#%s)",
             System.identityHashCode(this), System.identityHashCode(projectDetailsComponent)));
@@ -53,10 +57,15 @@ public class ProjectViewPage extends Div implements
 
     log.debug("Route '" + ROUTE + "' called with parameter '" + s + "'");
   }
-  public void setPageStyles(){
+
+  public void setPageStyles() {
     addClassNames("project-view-page");
   }
-  public void setComponentStyles(ProjectDetailsComponent projectDetailsComponent, ProjectLinksComponent projectLinksComponent){
+
+  public void setComponentStyles(ProjectNavigationBarComponent projectNavigationBarComponent,
+      ProjectDetailsComponent projectDetailsComponent,
+      ProjectLinksComponent projectLinksComponent) {
+    projectNavigationBarComponent.setStyles("project-navigation-component");
     projectDetailsComponent.setStyles("project-details-component");
     projectLinksComponent.setStyles("project-links-component");
   }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectNavigationBarComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectNavigationBarComponent.java
@@ -1,0 +1,94 @@
+package life.qbic.datamanager.views.project.view.components;
+
+import com.vaadin.flow.component.Composite;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
+import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.spring.annotation.SpringComponent;
+import com.vaadin.flow.spring.annotation.UIScope;
+import java.io.Serial;
+import life.qbic.datamanager.views.layouts.CardLayout;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+@SpringComponent
+@UIScope
+public class ProjectNavigationBarComponent extends Composite<CardLayout> {
+
+  @Serial
+  private static final long serialVersionUID = 2246439877362853798L;
+  private final transient Handler handler;
+  private HorizontalLayout navigationBarLayout;
+  private Button projectInformationButton;
+  private Button experimentalDesignButton;
+  private Button samplesButton;
+  private Button rawDataButton;
+  private Button resultsButton;
+
+  public ProjectNavigationBarComponent() {
+    this.handler = new Handler();
+    initNavigationBar();
+  }
+
+  private void initNavigationBar() {
+
+    navigationBarLayout = new HorizontalLayout();
+    //Todo Generate Custom Component containing Button, statusIndicator and label
+    VerticalLayout projectInformationLayout = new VerticalLayout();
+    projectInformationButton = new Button(VaadinIcon.CLIPBOARD_CHECK.create());
+    Label projectInformationLabel = new Label("Project Information");
+    projectInformationLayout.add(projectInformationButton, projectInformationLabel);
+    projectInformationLayout.setAlignItems(Alignment.CENTER);
+
+    VerticalLayout experimentalDesignLayout = new VerticalLayout();
+    Label experimentalDesignLabel = new Label("Experimental Design");
+    experimentalDesignButton = new Button(VaadinIcon.SITEMAP.create());
+    experimentalDesignLayout.add(experimentalDesignButton, experimentalDesignLabel);
+    experimentalDesignLayout.setAlignItems(Alignment.CENTER);
+
+    VerticalLayout samplesLayout = new VerticalLayout();
+    samplesButton = new Button(VaadinIcon.FILE_TABLE.create());
+    Label samplesLabel = new Label("Samples");
+    samplesLayout.add(samplesButton, samplesLabel);
+    samplesLayout.setAlignItems(Alignment.CENTER);
+
+    VerticalLayout rawDataLayout = new VerticalLayout();
+    rawDataButton = new Button(VaadinIcon.CLOUD_DOWNLOAD.create());
+    Label rawDataLabel = new Label("Raw Data");
+    rawDataLayout.add(rawDataButton, rawDataLabel);
+    rawDataLayout.setAlignItems(Alignment.CENTER);
+
+    VerticalLayout resultsLayout = new VerticalLayout();
+    resultsButton = new Button(VaadinIcon.SEARCH.create());
+    Label resultsLabel = new Label("Results");
+    resultsLayout.add(resultsButton, resultsLabel);
+    resultsLayout.setAlignItems(Alignment.CENTER);
+
+    navigationBarLayout.add(projectInformationLayout, experimentalDesignLayout, samplesLayout,
+        rawDataLayout, resultsLayout);
+    navigationBarLayout.setWidthFull();
+    navigationBarLayout.setHeightFull();
+    navigationBarLayout.setJustifyContentMode(JustifyContentMode.EVENLY);
+    navigationBarLayout.setAlignItems(Alignment.CENTER);
+    getContent().addFields(navigationBarLayout);
+  }
+
+  public void setStyles(String... componentStyles) {
+    getContent().addClassNames(componentStyles);
+  }
+
+
+  //Todo Initialize Transition between Different Subpages of ProjectViewPage
+  private final class Handler {
+
+  }
+}


### PR DESCRIPTION
**What was changed** 
Introduces the UI for a dedicated ProjectNavigationBarComponent which can be used to switch between the individual components within the ProjectPage. 
This PR is waiting for the rounting logic introduced in #175 