### PR TITLE
Fix project information component layout

### DIFF
--- a/vaadinfrontend/frontend/styles/views/project/project-view.css
+++ b/vaadinfrontend/frontend/styles/views/project/project-view.css
@@ -1,28 +1,34 @@
 .project-view-page {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: repeat(4, 1fr);
+  grid-template-rows: repeat(10, 1fr);
   grid-gap: 10px;
   min-height: 100%;
   padding: 50px;
 }
 
-.project-navigation-component {
+
+.title-component {
   grid-column: 1 / span 3;
   grid-row: 1 / span 1;
 }
 
+.project-navigation-component {
+  grid-column: 1 / span 3;
+  grid-row: 2 / span 2;
+}
+
 .project-details-component {
   grid-column: 1 / span 3;
-  grid-row: 2 / span 3;
+  grid-row: 4 / span 5;
 }
 
 .project-links-component {
   grid-column: 4 / span 2;
-  grid-row: 1 / span 3;
+  grid-row: 1 / span 5;
 }
 
 .experimental-design-component {
   grid-column: 1 / span 3;
-  grid-row: 2 / span 3;
+  grid-row: 3 / span 5;
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/layouts/CardLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/layouts/CardLayout.java
@@ -77,6 +77,7 @@ public class CardLayout extends VerticalLayout {
     leftLayout.setMargin(false);
     leftLayout.setAlignItems(Alignment.START);
     leftLayout.setSizeFull();
+
     rightLayout.setPadding(false);
     rightLayout.setMargin(false);
     rightLayout.setAlignItems(Alignment.END);

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/ProjectOverviewPage.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/ProjectOverviewPage.java
@@ -6,7 +6,6 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import java.io.Serial;
 import javax.annotation.security.PermitAll;
-import life.qbic.datamanager.views.AppRoutes;
 import life.qbic.datamanager.views.AppRoutes.Projects;
 import life.qbic.datamanager.views.MainLayout;
 import life.qbic.datamanager.views.project.overview.components.ProjectOverviewComponent;

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/components/ProjectOverviewComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/overview/components/ProjectOverviewComponent.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
 import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -97,6 +98,8 @@ public class ProjectOverviewComponent extends Composite<CardLayout> {
   }
 
   private void layoutComponents() {
+    getContent().addTitle("Projects");
+
     HorizontalLayout layout = new HorizontalLayout();
     create.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
     create.addClassNames("mt-s",

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewHandler.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewHandler.java
@@ -1,6 +1,7 @@
 package life.qbic.datamanager.views.project.view;
 
 import java.util.Objects;
+
 import life.qbic.datamanager.views.project.view.components.ExperimentalDesignDetailComponent;
 import life.qbic.datamanager.views.project.view.components.ProjectDetailsComponent;
 import life.qbic.datamanager.views.project.view.components.ProjectLinksComponent;

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewPage.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewPage.java
@@ -2,6 +2,7 @@ package life.qbic.datamanager.views.project.view;
 
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.ErrorParameter;
@@ -45,12 +46,18 @@ public class ProjectViewPage extends Div implements
   ProjectLinksComponent projectLinksComponent, @Autowired ExperimentalDesignDetailComponent
       experimentalDesignDetailComponent) {
 
+
     handler = new ProjectViewHandler(projectNavigationBarComponent, projectDetailsComponent,
         projectLinksComponent, experimentalDesignDetailComponent);
 
+    Span projectTitle = new Span("QABCD: "+"Some Title is here");
+    projectTitle.addClassNames("text-3xl","title-component");
+
+    addComponentAsFirst(projectTitle);
     add(projectNavigationBarComponent);
     add(projectDetailsComponent);
     add(projectLinksComponent);
+
 
     setPageStyles();
     setComponentStyles(projectNavigationBarComponent, projectDetailsComponent,

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewPage.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/ProjectViewPage.java
@@ -44,17 +44,21 @@ public class ProjectViewPage extends Div implements
       @Autowired ProjectDetailsComponent projectDetailsComponent, @Autowired
   ProjectLinksComponent projectLinksComponent, @Autowired ExperimentalDesignDetailComponent
       experimentalDesignDetailComponent) {
+
     handler = new ProjectViewHandler(projectNavigationBarComponent, projectDetailsComponent,
         projectLinksComponent, experimentalDesignDetailComponent);
+
     add(projectNavigationBarComponent);
     add(projectDetailsComponent);
     add(projectLinksComponent);
+
     setPageStyles();
     setComponentStyles(projectNavigationBarComponent, projectDetailsComponent,
         projectLinksComponent, experimentalDesignDetailComponent);
     setComponentStyles(projectNavigationBarComponent, projectDetailsComponent,
         projectLinksComponent,
         experimentalDesignDetailComponent);
+
     log.debug(
         String.format("New instance for project view (#%s) created with detail component (#%s)",
             System.identityHashCode(this), System.identityHashCode(projectDetailsComponent)));
@@ -69,10 +73,12 @@ public class ProjectViewPage extends Div implements
       ProjectLinksComponent projectLinksComponent,
       ExperimentalDesignDetailComponent
           experimentalDesignDetailComponent) {
+
     projectNavigationBarComponent.setStyles("project-navigation-component");
+
     projectDetailsComponent.setStyles("project-details-component");
     projectLinksComponent.setStyles("project-links-component");
-    //Todo Determine if we want to have seperate styles for each component
+    //Todo Determine if we want to have separate styles for each component
     experimentalDesignDetailComponent.setStyles("experimental-design-component");
   }
 

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
@@ -78,6 +79,9 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
   private ToggleDisplayEditComponent<Component, ComboBox<PersonReference>, PersonReference> responsiblePersonToggleComponent;
   private final transient Handler handler;
 
+  private final VerticalLayout verticalLayout = new VerticalLayout();
+
+
   public ProjectDetailsComponent(@Autowired ProjectInformationService projectInformationService,
       @Autowired PersonSearchService personSearchService,
       @Autowired ExperimentalDesignSearchService experimentalDesignSearchService, @Autowired
@@ -104,28 +108,40 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
 
   private void initFormLayout() {
     initFormFields();
-    formLayout.addFormItem(titleToggleComponent, "Project Title");
-    formLayout.addFormItem(projectObjectiveToggleComponent, "Project Objective");
-    formLayout.addFormItem(experimentalDesignToggleComponent, "Experimental Design");
-    formLayout.addFormItem(speciesMultiSelectComboBox, "Species");
-    formLayout.addFormItem(specimenMultiSelectComboBox, "Specimen");
-    formLayout.addFormItem(analyteMultiSelectComboBox, "Analyte");
+
+    Span experimentalDesignDescription = new Span("Experimental Design Description");
+    experimentalDesignDescription.addClassNames("text-m");
+
+    verticalLayout.add(titleToggleComponent, projectObjectiveToggleComponent,
+            experimentalDesignDescription,experimentalDesignToggleComponent);
+    verticalLayout.setSpacing(true);
+
+    VerticalLayout other = new VerticalLayout();
+    other.setSpacing(true);
+    Span span = new Span("Project Contacts");
+    span.addClassNames("text-xl","text-secondary");
+    other.add(span,formLayout);
+
     formLayout.addFormItem(principalInvestigatorToggleComponent, "Principal Investigator");
     formLayout.addFormItem(responsiblePersonToggleComponent, "Responsible Person");
     formLayout.addFormItem(projectManagerToggleComponent, "Project Manager");
     // set form layout to only have one column (for any width)
     formLayout.setResponsiveSteps(new ResponsiveStep("0", 1));
-    getContent().addFields(formLayout);
+    getContent().addFields(verticalLayout, other);
     getContent().addTitle(TITLE);
   }
 
   private void initFormFields() {
-    titleToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextField(),
+    titleToggleComponent = new ToggleDisplayEditComponent<>(c -> {
+      Span span = new Span(c);
+      span.addClassNames("text-2xl");
+      return span;}, new TextField(),
         createPlaceHolderSpan());
     projectObjectiveToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextArea(),
         createPlaceHolderSpan());
     experimentalDesignToggleComponent = new ToggleDisplayEditComponent<>(Span::new, new TextArea(),
         createPlaceHolderSpan());
+
     speciesMultiSelectComboBox = new MultiSelectComboBox<>();
     speciesMultiSelectComboBox.setClearButtonVisible(false);
     specimenMultiSelectComboBox = new MultiSelectComboBox<>();
@@ -295,14 +311,18 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
 
     private void loadProjectData(Project project) {
       this.selectedProject = project.getId();
+
       titleToggleComponent.setValue(project.getProjectIntent().projectTitle().title());
       projectObjectiveToggleComponent.setValue(project.getProjectIntent().objective().value());
       experimentalDesignToggleComponent.setValue(
           project.getProjectIntent().experimentalDesign().value());
+
       projectManagerToggleComponent.setValue(project.getProjectManager());
       principalInvestigatorToggleComponent.setValue(project.getPrincipalInvestigator());
       responsiblePersonToggleComponent.setValue(project.getResponsiblePerson().orElse(null));
+
       activeExperimentId = project.activeExperiment();
+
       analyteMultiSelectComboBox.setValue(
           experimentInformationService.getAnalytesOfExperiment(activeExperimentId));
       speciesMultiSelectComboBox.setValue(

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -10,6 +10,8 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
@@ -67,7 +69,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
   @Serial
   private static final long serialVersionUID = -5781313306040217724L;
   private static final String TITLE = "Project Information";
-  private final FormLayout formLayout;
+  private final VerticalLayout formLayout;
   private ToggleDisplayEditComponent<Span, TextField, String> titleToggleComponent;
   private ToggleDisplayEditComponent<Span, TextArea, String> projectObjectiveToggleComponent;
   private ToggleDisplayEditComponent<Span, TextArea, String> experimentalDesignToggleComponent;
@@ -90,7 +92,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     Objects.requireNonNull(personSearchService);
     Objects.requireNonNull(experimentalDesignSearchService);
     Objects.requireNonNull(experimentInformationService);
-    formLayout = new FormLayout();
+    formLayout = new VerticalLayout();
     initFormLayout();
     setComponentStyles();
     this.handler = new Handler(projectInformationService, personSearchService,
@@ -122,11 +124,20 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     span.addClassNames("text-xl","text-secondary");
     other.add(span,formLayout);
 
-    formLayout.addFormItem(principalInvestigatorToggleComponent, "Principal Investigator");
-    formLayout.addFormItem(responsiblePersonToggleComponent, "Responsible Person");
-    formLayout.addFormItem(projectManagerToggleComponent, "Project Manager");
-    // set form layout to only have one column (for any width)
-    formLayout.setResponsiveSteps(new ResponsiveStep("0", 1));
+    Label label = new Label("Principal Investigator");
+    label.addClassName("font-semibold");
+
+    Label label2 = new Label("Responsible Person");
+    label2.addClassName("font-semibold");
+
+    Label label3 = new Label("Project Manager");
+    label3.addClassName("font-semibold");
+
+    formLayout.add(new Div(label, principalInvestigatorToggleComponent));
+    formLayout.add(new Div(label2, responsiblePersonToggleComponent));
+    formLayout.add(new Div(label3, projectManagerToggleComponent));
+    formLayout.setPadding(false);
+
     getContent().addFields(verticalLayout, other);
     getContent().addTitle(TITLE);
   }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/project/view/components/ProjectDetailsComponent.java
@@ -8,8 +8,6 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
-import com.vaadin.flow.component.formlayout.FormLayout;
-import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.Span;
@@ -69,7 +67,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
   @Serial
   private static final long serialVersionUID = -5781313306040217724L;
   private static final String TITLE = "Project Information";
-  private final VerticalLayout formLayout;
+  private final VerticalLayout contactPersonsLayout;
   private ToggleDisplayEditComponent<Span, TextField, String> titleToggleComponent;
   private ToggleDisplayEditComponent<Span, TextArea, String> projectObjectiveToggleComponent;
   private ToggleDisplayEditComponent<Span, TextArea, String> experimentalDesignToggleComponent;
@@ -81,7 +79,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
   private ToggleDisplayEditComponent<Component, ComboBox<PersonReference>, PersonReference> responsiblePersonToggleComponent;
   private final transient Handler handler;
 
-  private final VerticalLayout verticalLayout = new VerticalLayout();
+  private final VerticalLayout projectDescriptionLayout;
 
 
   public ProjectDetailsComponent(@Autowired ProjectInformationService projectInformationService,
@@ -92,7 +90,10 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     Objects.requireNonNull(personSearchService);
     Objects.requireNonNull(experimentalDesignSearchService);
     Objects.requireNonNull(experimentInformationService);
-    formLayout = new VerticalLayout();
+
+    contactPersonsLayout = new VerticalLayout();
+    projectDescriptionLayout = new VerticalLayout();
+
     initFormLayout();
     setComponentStyles();
     this.handler = new Handler(projectInformationService, personSearchService,
@@ -114,32 +115,29 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     Span experimentalDesignDescription = new Span("Experimental Design Description");
     experimentalDesignDescription.addClassNames("text-m");
 
-    verticalLayout.add(titleToggleComponent, projectObjectiveToggleComponent,
+    projectDescriptionLayout.add(titleToggleComponent, projectObjectiveToggleComponent,
             experimentalDesignDescription,experimentalDesignToggleComponent);
-    verticalLayout.setSpacing(true);
 
-    VerticalLayout other = new VerticalLayout();
-    other.setSpacing(true);
-    Span span = new Span("Project Contacts");
-    span.addClassNames("text-xl","text-secondary");
-    other.add(span,formLayout);
+    Span contactTitleSpan = new Span("Project Contacts");
+    contactTitleSpan.addClassNames("text-xl","text-secondary");
+    contactPersonsLayout.add(contactTitleSpan);
 
-    Label label = new Label("Principal Investigator");
-    label.addClassName("font-semibold");
+    contactPersonsLayout.add(getDiv("Principal Investigator", principalInvestigatorToggleComponent));
+    contactPersonsLayout.add(getDiv("Responsible Person", responsiblePersonToggleComponent));
+    contactPersonsLayout.add(getDiv("Project Manager", projectManagerToggleComponent));
 
-    Label label2 = new Label("Responsible Person");
-    label2.addClassName("font-semibold");
+    projectDescriptionLayout.setSpacing(true);
+    contactPersonsLayout.setSpacing(true);
 
-    Label label3 = new Label("Project Manager");
-    label3.addClassName("font-semibold");
-
-    formLayout.add(new Div(label, principalInvestigatorToggleComponent));
-    formLayout.add(new Div(label2, responsiblePersonToggleComponent));
-    formLayout.add(new Div(label3, projectManagerToggleComponent));
-    formLayout.setPadding(false);
-
-    getContent().addFields(verticalLayout, other);
+    getContent().addFields(projectDescriptionLayout, contactPersonsLayout);
     getContent().addTitle(TITLE);
+  }
+
+  private Div getDiv(String labelName, Component component) {
+    Label label = new Label(labelName);
+    label.addClassNames("font-semibold", "mb-l","mt-m");
+
+    return new Div(label, component);
   }
 
   private void initFormFields() {
@@ -185,7 +183,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     titleToggleComponent.setWidthFull();
     projectObjectiveToggleComponent.setWidthFull();
     experimentalDesignToggleComponent.setWidthFull();
-    formLayout.setClassName("create-project-form");
+    contactPersonsLayout.setClassName("create-project-form");
     projectManagerToggleComponent.getInputComponent().getStyle()
         .set("--vaadin-combo-box-overlay-width", "16em");
     projectManagerToggleComponent.getInputComponent().getStyle()
@@ -209,7 +207,7 @@ public class ProjectDetailsComponent extends Composite<CardLayout> {
     speciesMultiSelectComboBox.setWidth(50, Unit.VW);
     specimenMultiSelectComboBox.setWidth(50, Unit.VW);
     analyteMultiSelectComboBox.setWidth(50, Unit.VW);
-    formLayout.setClassName("create-project-form");
+    contactPersonsLayout.setClassName("create-project-form");
     speciesMultiSelectComboBox.addClassName("chip-badge");
     specimenMultiSelectComboBox.addClassName("chip-badge");
     analyteMultiSelectComboBox.addClassName("chip-badge");


### PR DESCRIPTION
Attempts to fix discrepancy between prototype and implementation:

- Adds 'Projects' title to list of projects (as unrelated quick fix)
- Reorganise the layouts of the project information view (remove unnecessary lables, move labels above fields)
- Add project title to page (only a dummy as of now)


Todo:
Adjust project title to the actual title and code