### PR TITLE
Hotfix 0.15.1

### DIFF
--- a/vaadinfrontend/src/main/resources/application.properties
+++ b/vaadinfrontend/src/main/resources/application.properties
@@ -2,7 +2,6 @@ server.port=${DM_PORT:8080}
 logging.level.org.atmosphere=warn
 spring.mustache.check-template-location=false
 # Launch the default browser when starting the application in development mode
-vaadin.productionMode=false
 vaadin.launch-browser=true
 # To improve the performance during development.
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters
@@ -44,4 +43,3 @@ openbis.datasource.url=${OPENBIS_DATASOURCE_URL:openbis-url}
 # JobRunr configuration for background tasks. Default port is 8000
 org.jobrunr.background-job-server.enabled=true
 org.jobrunr.dashboard.enabled=true
-


### PR DESCRIPTION
**What was changed**
Removes the set property `vaadin.productionMode=false` from the `application.properties `since it leads to a RuntimeException on qPylon since Vaadin 24. 