### PR TITLE
Remove german exception messages as vaadin always uses machine not client locale

### DIFF
--- a/vaadinfrontend/src/main/resources/messages_de.properties
+++ b/vaadinfrontend/src/main/resources/messages_de.properties
@@ -1,2 +1,0 @@
-GENERAL=Ein Fehler is aufgetreten! -> Es ist etwas schief gegangen! Wir haben diesen Fehler dokumentiert. Falls der Fehler weiterhin besteht, kontaktieren Sie uns bitte über support@qbic.zendesk.com.
-DUPLICATE_PROJECT_CODE=Der Projectcode {0} ist bereits vergeben.


### PR DESCRIPTION
Removes the messages_de.properties file which provides german translations for error messages. As vaadin currently only supplies the HTTPRequest with the server locale, this does not take effect and leads to confusion.