### PR TITLE
Throw RTE if sample cannot be attached to a batch

### DIFF
--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/AddSampleToBatch.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/AddSampleToBatch.java
@@ -3,6 +3,8 @@ package life.qbic.projectmanagement.application.policy.directive;
 import life.qbic.domain.concepts.DomainEvent;
 import life.qbic.domain.concepts.DomainEventSubscriber;
 import life.qbic.projectmanagement.application.batch.BatchRegistrationService;
+import life.qbic.projectmanagement.domain.project.sample.BatchId;
+import life.qbic.projectmanagement.domain.project.sample.SampleId;
 import life.qbic.projectmanagement.domain.project.sample.event.SampleRegistered;
 import org.jobrunr.scheduling.JobScheduler;
 
@@ -33,7 +35,14 @@ public class AddSampleToBatch implements DomainEventSubscriber<SampleRegistered>
 
   @Override
   public void handleEvent(SampleRegistered event) {
-    jobScheduler.enqueue(() -> batchRegistrationService.addSampleToBatch(event.registeredSample(),
-        event.assignedBatch()));
+    jobScheduler.enqueue(() -> addSampleToBatch(event.registeredSample(), event.assignedBatch()));
+  }
+
+  protected void addSampleToBatch(SampleId sample, BatchId batch) throws RuntimeException {
+    batchRegistrationService.addSampleToBatch(sample, batch).onError(responseCode -> {
+      throw new RuntimeException(
+          String.format("Adding sample %s to batch %s failed, response code was %s ", sample, batch,
+              responseCode));
+    });
   }
 }

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/CreateNewSampleStatisticsEntry.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/CreateNewSampleStatisticsEntry.java
@@ -50,7 +50,7 @@ public class CreateNewSampleStatisticsEntry implements
     jobScheduler.enqueue(() -> createSampleStatisticsEntry(event.createdProject()));
   }
 
-  public void createSampleStatisticsEntry(String projectId) {
+  public void createSampleStatisticsEntry(String projectId) throws RuntimeException {
     var id = ProjectId.parse(projectId);
     if (sampleStatisticsEntryMissing(id)) {
       Optional<Project> searchResult = projectRepository.find(id).stream()


### PR DESCRIPTION
The RTE is necessary in the directive execution so we can use the
JobRunr scheduler to trigger its retry policy.