### PR TITLE
Allow specification of Jobrunr port via application properties

### DIFF
--- a/vaadinfrontend/src/main/resources/application.properties
+++ b/vaadinfrontend/src/main/resources/application.properties
@@ -43,3 +43,4 @@ openbis.datasource.url=${OPENBIS_DATASOURCE_URL:openbis-url}
 # JobRunr configuration for background tasks. Default port is 8000
 org.jobrunr.background-job-server.enabled=true
 org.jobrunr.dashboard.enabled=true
+org.jobrunr.dashboard.port=${DM_JR_PORT:8000}


### PR DESCRIPTION
**What was changed** 

If we want to run multiple instances of the `data-manager-application` e.g. one for user tests and one for development we need to be able to set the jobrunnr port via [environment variables](https://www.jobrunr.io/en/documentation/configuration/spring/). 
Otherwise both instances will try to host jobrunr on the same time leading to an exception. 