### PR TITLE
Keep experimental variable fact-sheet size consistent within experimental-variables collection

### DIFF
--- a/vaadinfrontend/frontend/themes/datamanager/components/card.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/card.css
@@ -184,8 +184,6 @@
 .experimental-variables-fact-sheet {
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  flex-shrink: 1;
   flex-basis: 20%;
   font-size: var(--lumo-font-size-s);
   border: 1px solid lightgray;


### PR DESCRIPTION
**What was changed**
Remove flex-grow and flex-shrink properties to keep experiment-variable fact-sheet size consistent:

**before**
![Bildschirmfoto 2023-07-04 um 18 50 21](https://github.com/qbicsoftware/data-manager-app/assets/29627977/0808ac64-e9b2-4174-8d3b-3833688a19af)

**after**
![Bildschirmfoto 2023-07-04 um 18 49 49](https://github.com/qbicsoftware/data-manager-app/assets/29627977/d696ced2-1c9f-4b89-9a0f-0c998c98185e)
