### PR TITLE
Enforce full width of tag-collection within experimental group card

### DIFF
--- a/vaadinfrontend/frontend/themes/datamanager/components/card.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/card.css
@@ -85,12 +85,6 @@
   max-width: 300px;
 }
 
-.experiment-group .content {
-  display: inline-flex;
-  flex-wrap: wrap;
-
-}
-
 .experimental-group-card-collection {
   display: flex;
   align-content: space-evenly;
@@ -98,19 +92,11 @@
   gap: 1rem;
 }
 
-.experimental-group div {
-  margin-bottom: 1em;
-}
-
-.experimental-group .tag-collection {
-  display: inline-flex;
-  flex-wrap: wrap;
-}
-
 .experimental-group .header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  margin-bottom: var(--lumo-space-m);
 }
 
 .experimental-group .title {
@@ -119,6 +105,13 @@
   font-weight: bold;
   white-space: nowrap;
   margin-bottom: 1em;
+}
+
+.experimental-group .content {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--lumo-space-m);
+  margin-bottom: var(--lumo-space-m);
 }
 
 .experimental-group vaadin-icon {

--- a/vaadinfrontend/frontend/themes/datamanager/components/tag-collection.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/tag-collection.css
@@ -2,6 +2,7 @@
   display: inline-flex;
   flex-wrap: wrap;
   gap: var(--lumo-space-xs);
+  width: 100%;
 }
 
 /* vaadin badge styling*/


### PR DESCRIPTION
**What was changed** 
Check first experimental group in Experiment0 in SampleRegistrationSheet tester project for comparison
**Before**
<img width="331" alt="Bildschirmfoto 2023-07-05 um 14 52 15" src="https://github.com/qbicsoftware/data-manager-app/assets/29627977/4f232967-2904-4dfe-8dee-dfa58dc6ad9b">
**After**
<img width="343" alt="Bildschirmfoto 2023-07-05 um 14 53 56" src="https://github.com/qbicsoftware/data-manager-app/assets/29627977/a2142234-146e-4229-91ae-24b5f6b66dca">
