### PR TITLE
Inform User that row deletion is not possible if only one row remains in the spreadsheet. 

### DIFF
--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
@@ -220,6 +220,10 @@ public class SampleRegistrationSpreadsheet extends Spreadsheet implements Serial
    */
   public void deleteRow(int index) {
     //delete row
+    if (getRows() == 1) {
+      // only one row remaining -> the header row
+      return;
+    }
     deleteRows(index, index);
     //move other rows up
     if (index + 1 < getRows()) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
@@ -219,10 +219,6 @@ public class SampleRegistrationSpreadsheet extends Spreadsheet implements Serial
    * @param index 0-based row index of the row to remove
    */
   public void deleteRow(int index) {
-    if (getRows() == 1) {
-      // only one row remaining -> the header row
-      return;
-    }
     //delete row
     deleteRows(index, index);
     //move other rows up

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
@@ -60,7 +60,7 @@ class SampleSpreadsheetLayout extends Div {
     add(sampleSpreadSheetContainer);
     styleSampleRegistrationSpreadSheet();
     initButtonLayout();
-    initNotifications();
+    addComponentAsFirst(lastRowDeletionNotification);
   }
 
   private void initHeaderAndInstruction() {
@@ -96,10 +96,6 @@ class SampleSpreadsheetLayout extends Div {
     sampleInformationButtons.add(backButton, addRowButton, deleteRowButton, cancelButton,
         registerButton);
     add(sampleInformationButtons);
-  }
-
-  private void initNotifications() {
-    addComponentAsFirst(lastRowDeletionNotification);
   }
 
   private boolean isLastRow() {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
@@ -44,7 +44,7 @@ class SampleSpreadsheetLayout extends Div {
   //The spreadsheet breaks if the Notification is generated via an ApplicationException
   private final StyledNotification lastRowDeletionNotification = new StyledNotification(
       new ErrorMessage("Can't delete last row",
-          "At least One row has to remain in the spreadsheet"));
+          "At least one row has to remain in the spreadsheet"));
 
   SampleSpreadsheetLayout() {
     initContent();

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
@@ -11,6 +11,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import life.qbic.application.commons.Result;
+import life.qbic.datamanager.views.notifications.ErrorMessage;
+import life.qbic.datamanager.views.notifications.StyledNotification;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.SampleRegistrationSpreadsheet.InvalidSpreadsheetInput;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.SampleRegistrationSpreadsheet.NGSRowDTO;
 import life.qbic.projectmanagement.domain.project.experiment.Experiment;
@@ -39,6 +41,11 @@ class SampleSpreadsheetLayout extends Div {
   private final SampleInformationLayoutHandler sampleInformationLayoutHandler;
   private ExperimentId experiment;
 
+  //The spreadsheet breaks if the Notification is generated via an ApplicationException
+  private final StyledNotification lastRowDeletionNotification = new StyledNotification(
+      new ErrorMessage("Can't delete last row",
+          "At least One row has to remain in the spreadsheet"));
+
   SampleSpreadsheetLayout() {
     initContent();
     this.addClassName("batch-content");
@@ -53,6 +60,7 @@ class SampleSpreadsheetLayout extends Div {
     add(sampleSpreadSheetContainer);
     styleSampleRegistrationSpreadSheet();
     initButtonLayout();
+    initNotifications();
   }
 
   private void initHeaderAndInstruction() {
@@ -76,12 +84,26 @@ class SampleSpreadsheetLayout extends Div {
     addRowButton.addClickListener(
         (ComponentEventListener<ClickEvent<Button>>) buttonClickEvent -> sampleRegistrationSpreadsheet.addRow());
     deleteRowButton.addClickListener(
-        event -> sampleRegistrationSpreadsheet.deleteRow(
-            sampleRegistrationSpreadsheet.getRows() - 1));
+        event -> {
+          if (!isLastRow()) {
+            sampleRegistrationSpreadsheet.deleteRow(
+                sampleRegistrationSpreadsheet.getRows() - 1);
+          } else {
+            lastRowDeletionNotification.open();
+          }
+        });
     registerButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
     sampleInformationButtons.add(backButton, addRowButton, deleteRowButton, cancelButton,
         registerButton);
     add(sampleInformationButtons);
+  }
+
+  private void initNotifications() {
+    addComponentAsFirst(lastRowDeletionNotification);
+  }
+
+  private boolean isLastRow() {
+    return sampleRegistrationSpreadsheet.getRows() <= 2;
   }
 
   private void styleSampleRegistrationSpreadSheet() {


### PR DESCRIPTION
**What was changed**
The user is now unable to delete the final row(outside of the columnheaders) and is informed via a notification that this is not possible. 

**Technical Note**
I wanted to propagate the notification via an applicationexception within the layout, however this leads to the spreadsheet component breaking entirely, which is why a dedicated notification was necessary. 