### PR TITLE
Batch registration is enqueued propely with jobrunnr

### DIFF
--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/SampleRegisteredPolicy.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/SampleRegisteredPolicy.java
@@ -22,7 +22,7 @@ public class SampleRegisteredPolicy {
   /**
    * Creates an instance of a {@link SampleRegisteredPolicy} object.
    * <p>
-   * All directives will be created an subscribed upon instantiation.
+   * All directives will be created and subscribed upon instantiation.
    *
    * @param addSampleToBatch directive to update the affected sample
    *                         {@link life.qbic.projectmanagement.domain.project.sample.Batch}

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/AddSampleToBatch.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/AddSampleToBatch.java
@@ -44,7 +44,7 @@ public class AddSampleToBatch implements DomainEventSubscriber<SampleRegistered>
     jobScheduler.enqueue(() -> addSampleToBatch(event.registeredSample(), event.assignedBatch()));
   }
 
-  @Job(name = "Add Sample To Batch Job", retries = 2)
+  @Job(name = "Add_Sample_To_Batch")
   public void addSampleToBatch(SampleId sample, BatchId batch) throws RuntimeException {
     batchRegistrationService.addSampleToBatch(sample, batch).onError(responseCode -> {
       throw new RuntimeException(

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/CreateNewSampleStatisticsEntry.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/policy/directive/CreateNewSampleStatisticsEntry.java
@@ -12,6 +12,7 @@ import life.qbic.projectmanagement.domain.project.Project;
 import life.qbic.projectmanagement.domain.project.ProjectId;
 import life.qbic.projectmanagement.domain.project.event.ProjectRegisteredEvent;
 import life.qbic.projectmanagement.domain.project.repository.ProjectRepository;
+import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.scheduling.JobScheduler;
 import org.springframework.stereotype.Component;
 
@@ -50,6 +51,7 @@ public class CreateNewSampleStatisticsEntry implements
     jobScheduler.enqueue(() -> createSampleStatisticsEntry(event.createdProject()));
   }
 
+  @Job(name = "Create_Sample_Statistics_Entry")
   public void createSampleStatisticsEntry(String projectId) throws RuntimeException {
     var id = ProjectId.parse(projectId);
     if (sampleStatisticsEntryMissing(id)) {

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/sample/SampleRegistrationService.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/sample/SampleRegistrationService.java
@@ -50,7 +50,7 @@ public class SampleRegistrationService {
             Collection<SampleRegistrationRequest> sampleRegistrationRequests, ProjectId projectId) {
         Objects.requireNonNull(sampleRegistrationRequests);
         Objects.requireNonNull(projectId);
-        if (sampleRegistrationRequests.size() < 1) {
+        if (sampleRegistrationRequests.isEmpty()) {
             return Result.fromError(ResponseCode.NO_SAMPLES_DEFINED);
         }
         Map<SampleCode, SampleRegistrationRequest> sampleCodesToRegistrationRequests = new HashMap<>();

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/sample/Batch.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/sample/Batch.java
@@ -1,9 +1,12 @@
 package life.qbic.projectmanagement.domain.project.sample;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -21,6 +24,7 @@ import java.util.Objects;
 public class Batch {
 
   @EmbeddedId
+  @Column(name = "id")
   private BatchId id;
 
   @Column(name = "batchLabel")
@@ -29,7 +33,8 @@ public class Batch {
   @Column(name = "isPilot")
   private boolean pilot;
 
-  @ElementCollection(targetClass = SampleId.class)
+  @ElementCollection(targetClass = SampleId.class, fetch = FetchType.EAGER)
+  @CollectionTable(name = "sample_batches_sampleid", joinColumns = @JoinColumn(name = "batch_id"))
   private List<SampleId> sampleIds;
 
   protected Batch() {

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/sample/SampleId.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/sample/SampleId.java
@@ -4,12 +4,12 @@ import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.UUID;
+import org.springframework.lang.NonNull;
 
 /**
  * Unique sample identifier. Identifies a sample unambiguously in Tuebingen's
@@ -21,6 +21,7 @@ public class SampleId implements Serializable {
     @Serial
     private static final long serialVersionUID = 1841536150220843163L;
 
+    @NonNull
     @Column(name = "sample_id")
     private final String uuid;
 

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
@@ -378,8 +378,6 @@ public class SampleRegistrationSpreadsheet extends Spreadsheet implements Serial
    * dropdown components and which should be default cells
    *
    * @param headerNames List of headerNames dependent on the selected {@link MetadataType}
-   * @return cellValueOptionsForColumnMap map grouping the selectable cell values within the cells
-   * of a column with the {@link SamplesheetHeaderName} of the colum
    */
   private void generateCellValueOptionsMap(
       List<SamplesheetHeaderName> headerNames) {
@@ -641,14 +639,16 @@ public class SampleRegistrationSpreadsheet extends Spreadsheet implements Serial
           replicateCell.setCellValue(label);
           conditionCell.setCellValue(condition);
         } else {
-          //remove prefilled info, except if there is only one condition
-          replicateCell.setCellValue("");
+          //remove prefilled info, except if there is only one condition or replicate
           String neutralValue = "";
           if (conditions.size() == 1) {
             neutralValue = condition;
           }
           conditionCell.setCellValue(neutralValue);
-          replicateCell.setCellValue("");
+          if (sortedLabels.size() == 1) {
+            neutralValue = label;
+          }
+          replicateCell.setCellValue(neutralValue);
         }
       }
     }


### PR DESCRIPTION
**What was changed**
As of now all the scheduled jobs in jobrunnr for the batch registration were not working properly. 
(Check failed jobs on your local jobrunr instance) 
This PR ensures that the sampleIds are loaded properly before the batch is registered and fixes the database schema between sampleIds and batchIds. 
Also it fixes a minor issue in the spreadsheet if only one biological replicate is in the experiment. 
Finally the jobs now have a proper naming schema to make debugging easier 
