### PR TITLE
Project overview grid fills the height of the project overview page

### DIFF
--- a/vaadinfrontend/frontend/themes/datamanager/components/project-collection.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/project-collection.css
@@ -1,11 +1,22 @@
 .project-collection {
-  display: grid;
+  display: flex;
   gap: 1rem;
+  height: 100%;
+  flex-flow: column;
 }
-
 
 .project-collection .controls {
   display: flex;
   align-content: space-between;
   gap: 1rem;
+}
+
+.project-collection .projects-grid {
+  height: 100%;
+  width: 100%;
+}
+
+.project-collection .projects-grid-section {
+  height: 100%;
+  width: 100%;
 }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/overview/components/ProjectCollectionComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/overview/components/ProjectCollectionComponent.java
@@ -140,6 +140,7 @@ public class ProjectCollectionComponent extends PageArea {
             projectPreview -> asClientLocalDateTime(projectPreview.lastModified()),
             "yyyy-MM-dd HH:mm:ss")).setKey("lastModified").setHeader("lastModified").setSortable(true)
         .setSortProperty("lastModified");
+    projectGrid.addClassName("projects-grid");
   }
 
   private void layoutTitleSection() {
@@ -152,7 +153,7 @@ public class ProjectCollectionComponent extends PageArea {
   }
 
   private void layoutGridSection() {
-    gridSection.addClassName("projects-grid");
+    gridSection.addClassName("projects-grid-section");
   }
 
   private void fireCreateClickedEvent() {


### PR DESCRIPTION
**What was changed**
Ensure that the project-overview grid does not take the default vaadin height of 400px but 100% of the possible height within the project page 

