### PR TITLE
Set Generationtype strategy to AUTO for id generation

### DIFF
--- a/database-connector/src/main/java/life/qbic/projectmanagement/experiment/persistence/SampleStatisticEntry.java
+++ b/database-connector/src/main/java/life/qbic/projectmanagement/experiment/persistence/SampleStatisticEntry.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.Objects;
@@ -28,7 +27,7 @@ import life.qbic.projectmanagement.domain.project.ProjectId;
 public class SampleStatisticEntry {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @GeneratedValue
   private long id;
   @Embedded
   @AttributeOverride(name = "value", column = @Column(name = "projectCode"))

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/application/sample/SampleInformationService.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/application/sample/SampleInformationService.java
@@ -12,7 +12,6 @@ import life.qbic.projectmanagement.domain.project.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.project.repository.SampleRepository;
 import life.qbic.projectmanagement.domain.project.sample.Sample;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 /**
@@ -50,7 +49,6 @@ public class SampleInformationService {
    * @return the results in the provided range
    * @since 1.0.0
    */
-  @PostFilter("hasPermission(filterObject.sampleId(),'life.qbic.projectmanagement.domain.project.sample.Sample','READ')")
   public List<SamplePreview> queryPreview(ExperimentId experimentId, int offset, int limit,
       List<SortOrder> sortOrders, String filter) {
     // returned by JPA -> UnmodifiableRandomAccessList

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/experiment/ExperimentalGroup.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/experiment/ExperimentalGroup.java
@@ -3,7 +3,6 @@ package life.qbic.projectmanagement.domain.project.experiment;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
@@ -29,7 +28,7 @@ public class ExperimentalGroup {
   private List<BiologicalReplicate> biologicalReplicates;
   private Condition condition;
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @GeneratedValue
   private Long experimentalGroupId;
   private int sampleSize;
 

--- a/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/experiment/ExperimentalVariable.java
+++ b/projectmanagement/src/main/java/life/qbic/projectmanagement/domain/project/experiment/ExperimentalVariable.java
@@ -6,7 +6,6 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,7 +31,7 @@ import life.qbic.projectmanagement.domain.project.experiment.repository.jpa.Vari
 public class ExperimentalVariable {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @GeneratedValue
   private long variableId;
 
   @Convert(converter = VariableNameAttributeConverter.class)


### PR DESCRIPTION
**What was changed** 
1.) The GenerationType strategy for the ids within experimental variable and experimental groups should be set to Auto so it's incremented correctly. Otherwise the generation of a new group/variable will fail since there is no default value provided 

2.) Remove unnecessary postfiler on samplePreview query since there are no permissions implemented yet 