### PR TITLE
User can see the button in the spreadsheet layout independent of number of rows

### DIFF
--- a/vaadinfrontend/frontend/themes/datamanager/components/dialog.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/dialog.css
@@ -27,8 +27,14 @@ vaadin-dialog-overlay::part(title) {
   height: 100%
 }
 
+.batch-registration-dialog vaadin-tabsheet {
+  height: 100%;
+  width: 100%;
+}
+
 .batch-registration-dialog::part(overlay) {
   min-width: 66vw;
+  height: 100%;
 }
 
 .batch-registration-dialog .stepper vaadin-tabs {
@@ -54,7 +60,6 @@ vaadin-dialog-overlay::part(title) {
 
 .batch-registration-dialog .batch-content .data-type-information {
   display: flex;
-  height: inherit;
   flex-direction: column;
 }
 
@@ -86,10 +91,14 @@ vaadin-dialog-overlay::part(title) {
   gap: var(--lumo-space-s);
 }
 
-.batch-registration-dialog .sample-spreadsheet {
-  /*Todo Find solution on how to let spreadsheet set its size*/
+.batch-registration-dialog .sample-spreadsheet-container {
   width: 100%;
-  height: 60vh;
+  height: 100%;
+}
+
+.batch-registration-dialog .sample-spreadsheet {
+  width: 100%;
+  height: 100%;
 }
 
 .create-project-dialog .content {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleRegistrationSpreadsheet.java
@@ -622,34 +622,20 @@ public class SampleRegistrationSpreadsheet extends Spreadsheet implements Serial
     return biologicalReplicateId;
   }
 
-  public void prefillConditionsAndReplicates(boolean isPrefilled) {
+  public void prefillConditionsAndReplicates() {
     int conditionColIndex = header.indexOf(SamplesheetHeaderName.CONDITION);
     int replicateColIndex = header.indexOf(SamplesheetHeaderName.BIOLOGICAL_REPLICATE_ID);
     int rowIndex = 0;
     Set<String> conditions = conditionsToReplicates.keySet();
-    for(String condition : conditions) {
+    for (String condition : conditions) {
       List<String> sortedLabels = conditionsToReplicates.get(condition).stream()
           .sorted(new LexicographicLabelComparator()).map(BiologicalReplicate::label).toList();
       for (String label : sortedLabels) {
         rowIndex++;
         Cell replicateCell = this.getCell(rowIndex, replicateColIndex);
         Cell conditionCell = this.getCell(rowIndex, conditionColIndex);
-        if (isPrefilled) {
-          //prefill cells
-          replicateCell.setCellValue(label);
-          conditionCell.setCellValue(condition);
-        } else {
-          //remove prefilled info, except if there is only one condition or replicate
-          String neutralValue = "";
-          if (conditions.size() == 1) {
-            neutralValue = condition;
-          }
-          conditionCell.setCellValue(neutralValue);
-          if (sortedLabels.size() == 1) {
-            neutralValue = label;
-          }
-          replicateCell.setCellValue(neutralValue);
-        }
+        replicateCell.setCellValue(label);
+        conditionCell.setCellValue(condition);
       }
     }
   }

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
@@ -111,10 +111,20 @@ class SampleSpreadsheetLayout extends Div {
     sampleRegistrationSpreadsheet.addSheetToSpreadsheet(metaDataType);
   }
 
-  public void resetLayout() {
-    sampleRegistrationSpreadsheet.getCellSelectionManager().clear();
+  public void reset() {
     sampleInformationLayoutHandler.reset();
-    experiment = null;
+  }
+
+  public void resetBatchInformation() {
+    sampleInformationLayoutHandler.resetBatchInformation();
+  }
+
+  public void resetExperimentInformation() {
+    sampleInformationLayoutHandler.resetExperimentInformation();
+  }
+
+  public void resetSpreadSheet() {
+    sampleInformationLayoutHandler.resetSpreadSheet();
   }
 
   public void reloadSpreadsheet() {
@@ -143,8 +153,8 @@ class SampleSpreadsheetLayout extends Div {
     return experiment;
   }
 
-  public void prefillConditionsAndReplicates(boolean isPrefilled) {
-    sampleRegistrationSpreadsheet.prefillConditionsAndReplicates(isPrefilled);
+  public void prefillConditionsAndReplicates() {
+    sampleRegistrationSpreadsheet.prefillConditionsAndReplicates();
   }
 
   private class SampleInformationLayoutHandler implements Serializable {
@@ -153,28 +163,31 @@ class SampleSpreadsheetLayout extends Div {
     private static final long serialVersionUID = 2837608401189525502L;
 
     private void reset() {
-      resetChildValues();
-    }
-
-    private void resetChildValues() {
-      resetInstructions();
+      resetBatchInformation();
+      resetExperimentInformation();
       resetSpreadSheet();
-      hideErrorInstructions();
     }
 
-    private void resetInstructions() {
+    private void resetBatchInformation() {
       batchName.setText("");
+    }
+
+    private void resetExperimentInformation() {
+      experiment = null;
       experimentName.setText("");
+      resetErrorInstructions();
     }
 
     private void resetSpreadSheet() {
       sampleRegistrationSpreadsheet.reset();
+      sampleRegistrationSpreadsheet.getCellSelectionManager().clear();
+
     }
 
     private boolean isInputValid() {
       Result<Void, InvalidSpreadsheetInput> content = sampleRegistrationSpreadsheet.areInputsValid();
       if (content.isValue()) {
-        hideErrorInstructions();
+        resetErrorInstructions();
       }
       return content.onError(error -> displayErrorInstructions(error.getInvalidationReason()))
           .isValue();
@@ -188,7 +201,7 @@ class SampleSpreadsheetLayout extends Div {
       errorInstructionSpan.add(errorSpan);
     }
 
-    private void hideErrorInstructions() {
+    private void resetErrorInstructions() {
       errorInstructionSpan.removeAll();
     }
 

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleSpreadsheetLayout.java
@@ -55,7 +55,7 @@ class SampleSpreadsheetLayout extends Div {
   private void initContent() {
     initHeaderAndInstruction();
     Div sampleSpreadSheetContainer = new Div();
-    sampleSpreadSheetContainer.addClassName("sample-spreadsheet");
+    sampleSpreadSheetContainer.addClassName("sample-spreadsheet-container");
     sampleSpreadSheetContainer.add(sampleRegistrationSpreadsheet);
     add(sampleSpreadSheetContainer);
     styleSampleRegistrationSpreadSheet();


### PR DESCRIPTION
**What was changed**
This PR achieves two things:

1.) Adapt styling so the dialog buttons are always visible in the spreadsheetlayout 

2.) Ensure the spreadsheet is prefilled correctly(or not prefilled) and streamline reload logic in spreadsheetlayout

**How to Test**

1.) Select "My new Experiment" in "SampleRegistrationSheeTtester" project on smaller screen size on qpylon and locally and try to see if the buttons are shown. 

2.) Select "Experiment 0" in "SampleRegistrationSheeTtester" project and observe "orphaned" entries in replicate column of the spreadsheet even if prefill was not selected: 
![Bildschirmfoto 2023-08-30 um 15 11 01](https://github.com/qbicsoftware/data-manager-app/assets/29627977/5c8616b3-a125-44ab-a9be-9a39a2a5eb04)
