### PR TITLE
Redesign experiment summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ error-screenshots/
 /frontend/generated/vaadin-featureflags.ts
 /vaadinfrontend/vite.config.ts
 /vaadinfrontend/src/main/dev-bundle/
+
+# Empty file that is created when changing css?
+/vaadinfrontend/frontend/themes/datamanager/theme-editor.css

--- a/vaadinfrontend/frontend/themes/datamanager/components/page-area.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/page-area.css
@@ -70,7 +70,7 @@
   font-size: small;
 }
 
-.page-area.experiment-details-component .sample-source-display .icon-with-list .vaadin-icon {
+.page-area.experiment-details-component .sample-source-display .icon-with-list vaadin-icon {
   color: var(--lumo-primary-color);
   margin-right: 1em;
   margin-top: 0.5em;

--- a/vaadinfrontend/frontend/themes/datamanager/components/page-area.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/page-area.css
@@ -49,6 +49,32 @@
   flex-direction: column;
 }
 
+.page-area.experiment-details-component .sample-source-display {
+  flex-direction: row;
+  display: flex;
+}
+
+.page-area.experiment-details-component .sample-source-display .icon-with-list {
+  flex-direction: row;
+  flex-grow: 0.2;
+  display: flex;
+}
+
+.page-area.experiment-details-component .sample-source-display .icon-with-list .taglist {
+  flex-direction: column;
+  display: flex;
+}
+
+.page-area.experiment-details-component .sample-source-display .icon-with-list .taglist .title {
+  font-size: small;
+}
+
+.page-area.experiment-details-component .sample-source-display .icon-with-list .vaadin-icon {
+  color: var(--lumo-primary-color);
+  margin-right: 1em;
+  margin-top: 0.5em;
+}
+
 .page-area.experiment-details-component .header {
   display: flex;
   justify-content: space-between;

--- a/vaadinfrontend/frontend/themes/datamanager/components/page-area.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/page-area.css
@@ -63,6 +63,7 @@
 .page-area.experiment-details-component .sample-source-display .icon-with-list .taglist {
   flex-direction: column;
   display: flex;
+  line-height: 1.3em;
 }
 
 .page-area.experiment-details-component .sample-source-display .icon-with-list .taglist .title {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -366,7 +366,6 @@ public class ExperimentDetailsComponent extends PageArea {
     Span iconAndList = new Span();
     iconAndList.addClassName("icon-with-list");
     iconAndList.add(icon);
-    icon.addClassName("vaadin-icon");
 
     Div list = new Div();
     Span listTitle = new Span();

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -9,6 +9,8 @@ import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -79,6 +81,8 @@ public class ExperimentDetailsComponent extends PageArea {
   private final Span title = new Span();
   private final Span buttonBar = new Span();
   private final Div tagCollection = new Div();
+
+  private final Span sampleSourceComponent = new Span();
   private final TabSheet experimentSheet = new TabSheet();
   private final ExperimentalVariablesComponent experimentalVariablesComponent = ExperimentalVariablesComponent.create(
       new ArrayList<>());
@@ -155,6 +159,7 @@ public class ExperimentDetailsComponent extends PageArea {
     title.addClassName("title");
     addTagCollectionToContent();
     addExperimentNotesComponent();
+    addSampleSourceInformationComponent();
     layoutTabSheet();
   }
 
@@ -351,6 +356,46 @@ public class ExperimentDetailsComponent extends PageArea {
     content.add(experimentNotes);
   }
 
+  private void addSampleSourceInformationComponent() {
+    sampleSourceComponent.addClassName("sample-source-display");
+
+    content.add(sampleSourceComponent);
+  }
+
+  private Span createSampleSourceList(String title, Icon icon, List<String> tags) {
+    Span iconAndList = new Span();
+    iconAndList.addClassName("icon-with-list");
+    iconAndList.add(icon);
+    icon.addClassName("vaadin-icon");
+
+    Div list = new Div();
+    Span listTitle = new Span();
+    listTitle.setText(title);
+    listTitle.addClassName("title");
+    list.add(listTitle);
+    list.addClassName("taglist");
+    tags.forEach(name -> list.add(new Span(name)));
+    iconAndList.add(list);
+    return iconAndList;
+  }
+
+  private void loadSampleSources(Experiment experiment) {
+    sampleSourceComponent.removeAll();
+    List<String> speciesTags = new ArrayList<>();
+    List<String> specimenTags = new ArrayList<>();
+    List<String> analyteTags = new ArrayList<>();
+    experiment.getSpecies().forEach(species -> speciesTags.add(species.value()));
+    experiment.getSpecimens().forEach(specimen -> specimenTags.add(specimen.value()));
+    experiment.getAnalytes().forEach(analyte -> analyteTags.add(analyte.value()));
+
+    sampleSourceComponent.add(
+        createSampleSourceList("Species", VaadinIcon.BUG.create(), speciesTags));
+    sampleSourceComponent.add(
+        createSampleSourceList("Specimen", VaadinIcon.DROP.create(), specimenTags));
+    sampleSourceComponent.add(
+        createSampleSourceList("Analytes", VaadinIcon.CLUSTER.create(), analyteTags));
+  }
+
   private void layoutTabSheet() {
     experimentSheet.add("Experimental Variables", experimentalVariables);
     experimentalVariables.addClassName(Display.FLEX);
@@ -464,7 +509,6 @@ public class ExperimentDetailsComponent extends PageArea {
     notification.open();
   }
 
-
   private void reloadExperimentalGroups() {
     loadExperimentalGroups();
     if (hasExperimentalGroups()) {
@@ -489,8 +533,6 @@ public class ExperimentDetailsComponent extends PageArea {
     this.experimentalGroupCount = experimentalGroupsCards.size();
   }
 
-
-
   private void addExperimentalVariables(
       List<ExperimentalVariableContent> experimentalVariableContents) {
     experimentalVariableContents.forEach(
@@ -512,6 +554,7 @@ public class ExperimentDetailsComponent extends PageArea {
   private void loadExperimentInformation(Experiment experiment) {
     title.setText(experiment.getName());
     loadTagInformation(experiment);
+    loadSampleSources(experiment);
     loadExperimentalVariables(experiment);
     loadExperimentalGroups();
     if (experiment.variables().isEmpty()) {
@@ -527,11 +570,8 @@ public class ExperimentDetailsComponent extends PageArea {
 
   private void loadTagInformation(Experiment experiment) {
     tagCollection.removeAll();
-    List<String> tags = new ArrayList<>();
-    experiment.getSpecies().forEach(species -> tags.add(species.value()));
-    experiment.getSpecimens().forEach(specimen -> tags.add(specimen.value()));
-    experiment.getAnalytes().forEach(analyte -> tags.add(analyte.value()));
-    tags.stream().map(Tag::new).forEach(tagCollection::add);
+
+    tagCollection.add(new Tag("Space for tags"));
   }
 
   private void loadExperimentalVariables(Experiment experiment) {
@@ -547,7 +587,6 @@ public class ExperimentDetailsComponent extends PageArea {
   private void onNoVariablesDefined() {
     experimentalGroups.removeAll();
     experimentalGroups.add(noExperimentalVariablesDefined);
-
   }
 
   private void onNoGroupsDefined() {


### PR DESCRIPTION
* removes species, specimen, analyte tags from the top of the experiment page
* adds default tag as an example, until notes are correctly implemented
* implements new display of species, specimen and analytes below the tags
<img width="950" alt="image" src="https://github.com/qbicsoftware/data-manager-app/assets/10232219/a73bcae9-200a-4f5a-b13c-532ddf0d2edc">
