### PR TITLE
align add-variable dialog with UI of add-group dialog

### DIFF
--- a/vaadinfrontend/frontend/themes/datamanager/components/dialog.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/dialog.css
@@ -246,6 +246,11 @@ Used by both project creation and experiment creation dialog, thus the unique na
   align-items: baseline;
 }
 
+.experiment-variable-dialog vaadin-icon {
+  cursor: pointer;
+  color: var(--lumo-primary-color);
+}
+
 .experiment-group-dialog vaadin-icon {
   cursor: pointer;
   color: var(--lumo-primary-color);
@@ -253,6 +258,16 @@ Used by both project creation and experiment creation dialog, thus the unique na
 
 .experiment-group-dialog .header {
   font-weight: bold;
+}
+
+.experiment-variable-dialog .add-new-group-action {
+  display: flex;
+  column-gap: 1rem;
+  color: var(--lumo-primary-color)
+}
+
+.experiment-variable-dialog .add-new-group-action span {
+  cursor: pointer;
 }
 
 .experiment-variable-dialog .content {
@@ -265,6 +280,9 @@ Used by both project creation and experiment creation dialog, thus the unique na
   column-gap: 1rem;
   color: var(--lumo-primary-color)
 }
+.experiment-group-dialog .add-new-group-action span {
+  cursor: pointer;
+}
 
 .experiment-group-dialog .content {
   display: grid;
@@ -274,11 +292,6 @@ Used by both project creation and experiment creation dialog, thus the unique na
 .experiment-group-dialog .content .group-collection {
   display: grid;
   gap: 1rem;
-}
-
-
-.experiment-group-dialog .add-new-group-action span {
-  cursor: pointer;
 }
 
 .experiment-variable-dialog .content .variables {
@@ -294,11 +307,6 @@ Used by both project creation and experiment creation dialog, thus the unique na
   display: flex;
   align-items: center;
   gap: var(--lumo-space-l);
-}
-
-.experiment-variable-dialog .content .row vaadin-icon {
-  cursor: pointer;
-  color: var(--lumo-primary-color);
 }
 
 .project-information-dialog::part(overlay) {

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
@@ -123,7 +123,6 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   private void layoutComponent() {
-    System.err.println("layout called");
     layoutHeaderAndFooter();
 
     content.addClassName("content");
@@ -151,7 +150,6 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   private void addNewGroupEntry() {
-    System.err.println("add called");
     var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels);
     experimentalGroupsCollection.add(groupEntry);
     groupEntry.addRemoveEventListener(event -> removeExperimentalGroupEntry(event.getSource()));

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
@@ -123,6 +123,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   private void layoutComponent() {
+    System.err.println("layout called");
     layoutHeaderAndFooter();
 
     content.addClassName("content");
@@ -150,6 +151,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   private void addNewGroupEntry() {
+    System.err.println("add called");
     var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels);
     experimentalGroupsCollection.add(groupEntry);
     groupEntry.addRemoveEventListener(event -> removeExperimentalGroupEntry(event.getSource()));

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalVariablesDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalVariablesDialog.java
@@ -31,6 +31,7 @@ public class ExperimentalVariablesDialog extends DialogWindow {
   private final Div dialogueContentLayout = new Div();
   private final Div experimentalVariableRowsContainerLayout = new Div();
   private final Span addExperimentalVariableLayoutRow = new Span();
+  private final Div addNewVariableContainer = new Div();
   private final MODE mode;
 
   public ExperimentalVariablesDialog() {
@@ -138,13 +139,10 @@ public class ExperimentalVariablesDialog extends DialogWindow {
   private void reset() {
     this.experimentalVariablesLayoutRows.clear();
     this.experimentalVariableRowsContainerLayout.removeAll();
-    initDefineExperimentalVariableLayout();
+    appendEmptyRowForAddMode();
   }
 
-  private void initDefineExperimentalVariableLayout() {
-    final Span experimentalDesignHeader = new Span("Define Experimental Variable");
-    experimentalDesignHeader.addClassName("header");
-    this.experimentalVariableRowsContainerLayout.add(experimentalDesignHeader);
+  private void appendEmptyRowForAddMode() {
     if (isAdding()) {
       appendEmptyRow();
     }
@@ -174,21 +172,34 @@ public class ExperimentalVariablesDialog extends DialogWindow {
     if (wasRemoved) {
       this.experimentalVariableRowsContainerLayout.remove(experimentalVariableRowLayout);
     }
+    if(experimentalVariableRowsContainerLayout.getChildren().toList().isEmpty()) {
+      appendEmptyRowForAddMode();
+    }
   }
 
   private void layoutComponent() {
-    setHeaderTitle("Experimental Design");
+    setHeaderTitle("Define Experimental Variable");
     final DialogFooter footer = getFooter();
     footer.add(this.cancelButton, this.confirmButton);
   }
 
   private void initDialogueContent() {
-    initDefineExperimentalVariableLayout();
+    appendEmptyRowForAddMode();
     initDesignVariableTemplate();
     this.dialogueContentLayout.addClassName("content");
     this.experimentalVariableRowsContainerLayout.addClassName("variables");
     this.dialogueContentLayout.add(this.experimentalVariableRowsContainerLayout);
-    this.dialogueContentLayout.add(this.addExperimentalVariableLayoutRow);
+
+    this.dialogueContentLayout.add(addNewVariableContainer);
+
+    addNewVariableContainer.addClassName("add-new-group-action");
+
+    var addNewVariableIcon = new Icon(VaadinIcon.PLUS);
+    addNewVariableIcon.addClickListener(listener -> appendEmptyRow());
+    Span addVariableHelperText = new Span("Add Experimental Variable");
+    addVariableHelperText.addClickListener(listener -> appendEmptyRow());
+    addNewVariableContainer.add(addNewVariableIcon, addVariableHelperText);
+
     add(this.dialogueContentLayout);
   }
 


### PR DESCRIPTION
* remove one of the two titles in the add variable dialog
* style adding of variables like in add-group dialog
* if the last variable row is removed in "add mode" (as opposed to edit mode), a new empty row is automatically added
* remove some unnecessary CSS