### PR TITLE
Remove navigation bar from project information page

### DIFF
--- a/vaadinfrontend/frontend/themes/datamanager/components/main.css
+++ b/vaadinfrontend/frontend/themes/datamanager/components/main.css
@@ -1,6 +1,6 @@
 .main {
   display: grid;
-  gap: 1px 1px;
+  gap: 1rem 1px;
 }
 
 .main.experiment {
@@ -22,9 +22,7 @@
 
 .main.project {
   grid-template-columns: minmax(min-content, 80%) minmax(min-content, 20%);
-  grid-template-rows: minmax(130px, auto) 1fr;
   grid-template-areas:
-    "navbar support"
     "content support";
   height: 100%;
 }
@@ -70,7 +68,6 @@
   .main.project {
     grid-template-columns: minmax(1200px, 1fr);
     grid-template-areas:
-        "navbar"
     "content"
     "support";
     grid-auto-rows: auto;

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectInformationMain.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectInformationMain.java
@@ -43,7 +43,6 @@ public class ProjectInformationMain extends MainComponent implements BeforeEnter
   @Serial
   private static final long serialVersionUID = 5797835576569148873L;
   private static final Logger log = logger(ProjectInformationMain.class);
-  private final ProjectNavigationBarComponent projectNavigationBarComponent;
   private final ProjectContentComponent projectContentComponent;
   private final ProjectSupportComponent projectSupportComponent;
   private final UserPermissions userPermissions;
@@ -51,30 +50,26 @@ public class ProjectInformationMain extends MainComponent implements BeforeEnter
   private Context context;
 
   public ProjectInformationMain(
-      @Autowired ProjectNavigationBarComponent projectNavigationBarComponent,
       @Autowired ProjectContentComponent projectContentComponent,
       @Autowired ProjectSupportComponent projectSupportComponent,
       @Autowired UserPermissions userPermissions) {
     super(projectContentComponent, projectSupportComponent);
     requireNonNull(userPermissions, "userPermissions must not be null");
-    requireNonNull(projectNavigationBarComponent);
     requireNonNull(projectContentComponent);
     requireNonNull(projectSupportComponent);
-    this.projectNavigationBarComponent = projectNavigationBarComponent;
     this.projectContentComponent = projectContentComponent;
     this.projectSupportComponent = projectSupportComponent;
     this.userPermissions = userPermissions;
     layoutComponent();
     log.debug(String.format(
-        "New instance for project Information Page (#%s) created with Project Navigation Bar Component (#%s) and Project Content Component (#%s) and Project Support Component (#%s)",
-        System.identityHashCode(this), System.identityHashCode(projectNavigationBarComponent),
+        "New instance for project Information Page (#%s) created with Project Content Component (#%s) and Project Support Component (#%s)",
+        System.identityHashCode(this),
         System.identityHashCode(projectContentComponent),
         System.identityHashCode(projectSupportComponent)));
   }
 
   private void layoutComponent() {
     addClassName("project");
-    addComponentAsFirst(projectNavigationBarComponent);
   }
 
   /**
@@ -102,7 +97,6 @@ public class ProjectInformationMain extends MainComponent implements BeforeEnter
 
   private void setContext(Context context) {
     projectContentComponent.setContext(context);
-    projectNavigationBarComponent.projectId(context.projectId().orElseThrow());
     projectSupportComponent.projectId(context.projectId().orElseThrow());
   }
 


### PR DESCRIPTION
Since we are going to introduce a different navigation scheme soon, the navbar is obsolete in the project information page, since the progress is only relevant on experiment level.