### PR TITLE
Reset dialog upon batch registration

### DIFF
--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleDetailsComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleDetailsComponent.java
@@ -252,7 +252,7 @@ public class SampleDetailsComponent extends PageArea implements Serializable {
         registerBatchAndSamples(batchRegistrationSource.batchRegistrationContent(),
             batchRegistrationSource.sampleRegistrationContent()).onValue(batchId -> {
           fireBatchCreatedEvent(batchRegistrationEvent);
-          batchRegistrationDialog.close();
+          batchRegistrationDialog.resetAndClose();
           displayRegistrationSuccess();
         });
       });

--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/BatchRegistrationDialog.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/BatchRegistrationDialog.java
@@ -96,6 +96,10 @@ public class BatchRegistrationDialog extends Dialog {
     batchInformationLayout.experimentSelect.setValue(experiment);
   }
 
+  public void resetAndClose() {
+    registerBatchDialogHandler.resetAndClose();
+  }
+
   private class RegisterBatchDialogHandler implements Serializable {
 
     @Serial


### PR DESCRIPTION
**What was changed** 
Hotfix to ensure dialog is reset properly after samples have been registered correctly 