### PR TITLE
Reference unique sample id in openBIS

### DIFF
--- a/database-connector/src/main/java/life/qbic/projectmanagement/persistence/repository/OpenbisConnector.java
+++ b/database-connector/src/main/java/life/qbic/projectmanagement/persistence/repository/OpenbisConnector.java
@@ -207,8 +207,8 @@ public class OpenbisConnector implements ExperimentalDesignVocabularyRepository,
         sampleCreation.setSpaceId(new SpacePermId(DEFAULT_SPACE_CODE));
         Map<String, String> props = new HashMap<>();
 
-        props.put("Q_SECONDARY_NAME", sample.biologicalReplicateId().toString());
-        props.put("Q_EXTERNALDB_ID", sample.label());
+        props.put("Q_SECONDARY_NAME", sample.label());
+        props.put("Q_EXTERNALDB_ID", sample.sampleId().value());
         String analyteValue = sample.sampleOrigin().getAnalyte().value();
         String openBisSampleType = retrieveOpenBisAnalyteCode(analyteValue).or(
                 () -> analyteMapper.translateSampleTypeString(analyteValue))


### PR DESCRIPTION
The openBIS sample entry will now contain the sample entity unique ID as reference to the data manager.

Moreover, as secondary name the sample label will now be used instead of the biological replicate id.