### PR TITLE
Reset appdrawer content correctly to avoid node tree exception

### DIFF
--- a/vaadinfrontend/src/main/java/life/qbic/datamanager/views/navigation/ProjectSideNavigationComponent.java
+++ b/vaadinfrontend/src/main/java/life/qbic/datamanager/views/navigation/ProjectSideNavigationComponent.java
@@ -58,7 +58,7 @@ public class ProjectSideNavigationComponent extends Div implements
   public static final String PROJECT_ID_ROUTE_PARAMETER = "projectId";
   public static final String EXPERIMENT_ID_ROUTE_PARAMETER = "experimentId";
   private static final Logger log = getLogger(ProjectSideNavigationComponent.class);
-  private static final Div content = new Div();
+  private static Div content = new Div();
   private final transient ProjectInformationService projectInformationService;
   private final transient ExperimentInformationService experimentInformationService;
   private Context context = new Context();
@@ -71,8 +71,8 @@ public class ProjectSideNavigationComponent extends Div implements
     addClassName("project-navigation-drawer");
     this.projectInformationService = projectInformationService;
     this.experimentInformationService = experimentInformationService;
+    resetContent();
     content.addClassName("content");
-    add(content);
     log.debug(
         "New instance for ProjectSideNavigationComponent {} was created",
         System.identityHashCode(this));
@@ -95,8 +95,14 @@ public class ProjectSideNavigationComponent extends Div implements
         ProjectSideNavigationComponent::addProjectNavigationListener);
   }
 
-  private static void resetContent() {
-    content.removeAll();
+  private void resetContent() {
+    //Since content is static vaadin complains if one moves it from one state tree to another
+    if (getChildren().toList().contains(content)) {
+      this.remove(content);
+    }
+    content = new Div();
+    content.addClassName("content");
+    add(content);
   }
 
   private Project loadProject(ProjectId id) {


### PR DESCRIPTION
**What was changed**
Since the content div is static, it's not possible to add it to different state trees. Trying to do so leads to a Statetree exception. 
<img width="680" alt="Bildschirmfoto 2023-10-17 um 11 12 14" src="https://github.com/qbicsoftware/data-manager-app/assets/29627977/6ad5a356-7206-4658-a32b-d08201ddb0f7">

Therefore we need to make sure the content div is reset completely and not added multiple times to the parent container 

**How to reproduce** 
1.) Login to the application and select a project so the drawer is initialized
2.) Copy the URL into a different tab and load the page 
3.) Observe state tree exception since the application tries to add a static content div to multiple instances 