### PR TITLE
Removes former reference to the database connector

### DIFF
--- a/project-management/pom.xml
+++ b/project-management/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>project-management</artifactId>
-  <name>projectmanagement-domain</name>
+  <name>project-management-domain</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>

--- a/user-interface/pom.xml
+++ b/user-interface/pom.xml
@@ -220,12 +220,6 @@
     </dependency>
     <dependency>
       <groupId>life.qbic</groupId>
-      <artifactId>database-connector</artifactId>
-      <version>0.28.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>life.qbic</groupId>
       <artifactId>domain-concept</artifactId>
       <version>0.28.2</version>
       <scope>compile</scope>


### PR DESCRIPTION
Fix the following exception:

Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'simpleOfferSearchService' for bean class [life.qbic.finance.persistence.SimpleOfferSearchService] conflicts with existing, non-compatible bean definition of same name and class [life.qbic.controlling.infrastructure.SimpleOfferSearchService]

