### PR TITLE
Address indexing error within acl deletion when user is removed from a project

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/authorization/acl/ProjectAccessServiceImpl.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/authorization/acl/ProjectAccessServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.security.acls.model.NotFoundException;
 import org.springframework.security.acls.model.Permission;
 import org.springframework.security.acls.model.Sid;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -142,7 +141,7 @@ public class ProjectAccessServiceImpl implements ProjectAccessService {
   private void deleteAces(MutableAcl mutableAcl,
       Predicate<AccessControlEntry> accessControlEntryPredicate) {
     List<AccessControlEntry> aclEntries = mutableAcl.getEntries();
-    for (int i = 0; i < aclEntries.size(); i++) {
+    for (int i = aclEntries.size() - 1; i >= 0; i--) {
       if (accessControlEntryPredicate.test(aclEntries.get(i))) {
         mutableAcl.deleteAce(i);
       }


### PR DESCRIPTION
**What was changed** 
Revoking access to a project is done via deleting the acl entries within a mutable acl object. However the current implementation leads to an indexing issue since we're deleting entries from a list that is not in sync with the copied aclEntries list. This can be avoided by starting the deletion and iteration from the highest number in the list.