### PR TITLE
Small UI and usability changes for ontology term selection

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermJpaRepository.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermJpaRepository.java
@@ -1,5 +1,6 @@
 package life.qbic.projectmanagement.infrastructure.ontology;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import life.qbic.projectmanagement.application.OntologyClassEntity;
@@ -58,15 +59,9 @@ public class OntologyTermJpaRepository implements OntologyTermLookup {
       }
       return order;
     }).toList();
-    // provide a short list of initial values when no search string was provided
-    if(searchString.isBlank()) {
-      return ontologyTermRepository.findByLabelNotNullAndOntologyIn(ontologies,
-          new OffsetBasedRequest(offset, limit, Sort.by(orders))).getContent();
-    }
-    // if the search string is shorter than 2, normal matching is faster
-    if(searchString.length()==1) {
-      return ontologyTermRepository.findByLabelStartingWithIgnoreCaseAndOntologyIn(searchString, ontologies,
-          new OffsetBasedRequest(offset, limit, Sort.by(orders))).getContent();
+    searchString = searchString.trim();
+    if(searchString.length() < 2) {
+      return new ArrayList<>();
     }
     // otherwise create a more complex search term for fulltext search
     String searchTerm = buildSearchTerm(searchString);

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/OntologyTermInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/OntologyTermInformationService.java
@@ -44,8 +44,8 @@ public class OntologyTermInformationService {
   public List<OntologyClassEntity> queryOntologyTerm(String termFilter, List<String> ontologies,
       int offset, int limit, List<SortOrder> sortOrders) {
     // returned by JPA -> UnmodifiableRandomAccessList
-    List<OntologyClassEntity> termList = ontologyTermLookup.query(termFilter, ontologies, offset, limit,
-        sortOrders);
+    List<OntologyClassEntity> termList = ontologyTermLookup.query(termFilter, ontologies, offset,
+        50, sortOrders);
     // the list must be modifiable for spring security to filter it
     return new ArrayList<>(termList);
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
@@ -1,0 +1,42 @@
+package life.qbic.datamanager.views.projects.project.experiments.experiment;
+
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.data.provider.SortDirection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import life.qbic.projectmanagement.application.OntologyClassEntity;
+import life.qbic.projectmanagement.application.OntologyTermInformationService;
+import life.qbic.projectmanagement.application.SortOrder;
+import life.qbic.projectmanagement.domain.model.Ontology;
+
+/**
+ *
+ */
+public class OntologyFilterConnector {
+
+  private final OntologyTermInformationService ontologyTermInformationService;
+
+  public OntologyFilterConnector(OntologyTermInformationService ontologyTermInformationService) {
+    this.ontologyTermInformationService = ontologyTermInformationService;
+  }
+
+
+  public <T> void initComboBoxWithOntologyDatasource(
+      MultiSelectComboBox<T> box, List<Ontology> ontologies,
+      Function<OntologyClassEntity, T> ontologyMapping) {
+
+    box.setRequired(true);
+    box.setHelperText("Please provide at least two letters to search for entries.");
+
+    box.setItemsWithFilterConverter(
+        query -> ontologyTermInformationService.queryOntologyTerm(query.getFilter().orElse(""),
+            ontologies.stream().map(Ontology::getAbbreviation).toList(),
+            query.getOffset(),
+            query.getLimit(), query.getSortOrders().stream().map(
+                    it -> new SortOrder(it.getSorted(), it.getDirection().equals(SortDirection.DESCENDING)))
+                .collect(Collectors.toList())).stream().map(ontologyMapping),
+        entity -> entity
+    );
+  }
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
@@ -11,7 +11,8 @@ import life.qbic.projectmanagement.application.SortOrder;
 import life.qbic.projectmanagement.domain.model.Ontology;
 
 /**
- *
+ * Connects the OntologyTermInformationService to a Combobox of variable type, setting up a user-
+ * provided filter converter between OntologyClassEntity and the Combobox type
  */
 public class OntologyFilterConnector {
 
@@ -22,6 +23,14 @@ public class OntologyFilterConnector {
   }
 
 
+  /**
+   *
+   * @param box             The ComboBox that will allow selection of database terms
+   * @param ontologies      A list of Ontologies whose terms should be shown in the ComboBox
+   * @param ontologyMapping A mapping between OntologyClassEntity and the type T of the ComboBox
+   *                        (for example String)
+   * @param <T>             The Type of the ComboBox, for example String
+   */
   public <T> void initComboBoxWithOntologyDatasource(
       MultiSelectComboBox<T> box, List<Ontology> ontologies,
       Function<OntologyClassEntity, T> ontologyMapping) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/create/ExperimentAddDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/create/ExperimentAddDialog.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
-import com.vaadin.flow.data.provider.SortDirection;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -18,13 +17,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import life.qbic.datamanager.views.events.UserCancelEvent;
 import life.qbic.datamanager.views.general.DialogWindow;
-import life.qbic.projectmanagement.application.OntologyClassEntity;
+import life.qbic.datamanager.views.projects.project.experiments.experiment.OntologyFilterConnector;
 import life.qbic.projectmanagement.application.OntologyTermInformationService;
-import life.qbic.projectmanagement.application.SortOrder;
 import life.qbic.projectmanagement.domain.model.Ontology;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.Analyte;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.Species;
@@ -46,13 +42,12 @@ public class ExperimentAddDialog extends DialogWindow {
 
   private static final String CHIP_BADGE = "chip-badge";
   private static final String WIDTH_INPUT = "full-width-input";
-  private final transient OntologyTermInformationService ontologyTermInformationService;
   private final Binder<ExperimentDraft> binder = new Binder<>();
+  private final OntologyFilterConnector ontologyFilterConnector;
 
   public ExperimentAddDialog(
       OntologyTermInformationService ontologyTermInformationService) {
-    this.ontologyTermInformationService = ontologyTermInformationService;
-
+    this.ontologyFilterConnector = new OntologyFilterConnector(ontologyTermInformationService);
     Span experimentHeader = new Span("Experiment");
     experimentHeader.addClassName("header");
 
@@ -66,7 +61,8 @@ public class ExperimentAddDialog extends DialogWindow {
             + "values are allowed!");
 
     MultiSelectComboBox<Species> speciesBox = new MultiSelectComboBox<>("Species");
-    initComboBoxWithDatasource(speciesBox, List.of(Ontology.NCBI_TAXONOMY),
+    speciesBox.addClassNames(CHIP_BADGE, WIDTH_INPUT);
+    ontologyFilterConnector.initComboBoxWithOntologyDatasource(speciesBox, List.of(Ontology.NCBI_TAXONOMY),
         term -> new Species(term.getLabel()));
     speciesBox.setItemLabelGenerator(Species::label);
     binder.forField(speciesBox)
@@ -75,7 +71,8 @@ public class ExperimentAddDialog extends DialogWindow {
             ExperimentDraft::setSpecies);
 
     MultiSelectComboBox<Specimen> specimenBox = new MultiSelectComboBox<>("Specimen");
-        initComboBoxWithDatasource(specimenBox, Arrays.asList(Ontology.PLANT_ONTOLOGY, Ontology.BRENDA_TISSUE_ONTOLOGY),
+    specimenBox.addClassNames(CHIP_BADGE, WIDTH_INPUT);
+    ontologyFilterConnector.initComboBoxWithOntologyDatasource(specimenBox, Arrays.asList(Ontology.PLANT_ONTOLOGY, Ontology.BRENDA_TISSUE_ONTOLOGY),
             term -> new Specimen(term.getLabel()));
     specimenBox.setItemLabelGenerator(Specimen::label);
     binder.forField(specimenBox)
@@ -84,7 +81,8 @@ public class ExperimentAddDialog extends DialogWindow {
             ExperimentDraft::setSpecimens);
 
     MultiSelectComboBox<Analyte> analyteBox = new MultiSelectComboBox<>("Analyte");
-    initComboBoxWithDatasource(analyteBox, List.of(Ontology.BIOASSAY_ONTOLOGY),
+    analyteBox.addClassNames(CHIP_BADGE, WIDTH_INPUT);
+    ontologyFilterConnector.initComboBoxWithOntologyDatasource(analyteBox, List.of(Ontology.BIOASSAY_ONTOLOGY),
         term -> new Analyte(term.getLabel()));
     analyteBox.setItemLabelGenerator(Analyte::label);
     binder.forField(analyteBox)
@@ -107,23 +105,6 @@ public class ExperimentAddDialog extends DialogWindow {
     setConfirmButtonLabel("Add");
     setCancelButtonLabel("Cancel");
     add(createExperimentContent);
-  }
-
-  private <T> void initComboBoxWithDatasource(MultiSelectComboBox<T> box, List<Ontology> ontologies,
-      Function<OntologyClassEntity, T> ontologyMapping) {
-
-    box.setRequired(true);
-    box.addClassNames(CHIP_BADGE, WIDTH_INPUT);
-
-    box.setItemsWithFilterConverter(
-        query -> ontologyTermInformationService.queryOntologyTerm(query.getFilter().orElse(""),
-            ontologies.stream().map(Ontology::getAbbreviation).toList(),
-            query.getOffset(),
-            query.getLimit(), query.getSortOrders().stream().map(
-                    it -> new SortOrder(it.getSorted(), it.getDirection().equals(SortDirection.DESCENDING)))
-                .collect(Collectors.toList())).stream().map(ontologyMapping),
-        entity -> entity
-    );
   }
 
   @Override


### PR DESCRIPTION
* Do not show terms until user types at least two letters
* State this in helper text
* Return only 50 results per search to prevent scrolling lag