### PR TITLE
Remove cell comments and always close dialogue to address remaining spreadsheet issues

### DIFF
--- a/application-commons/src/main/java/life/qbic/application/commons/Result.java
+++ b/application-commons/src/main/java/life/qbic/application/commons/Result.java
@@ -266,6 +266,15 @@ public abstract class Result<V, E> {
   public abstract V valueOrElseThrow(Supplier<? extends RuntimeException> supplier);
 
   /**
+   * Returns the value if the result is a value; throws the exception returned by the
+   * exceptionMapper function otherwise.
+   *
+   * @param exceptionMapper the function that maps the error to the exception to be thrown
+   * @return the stored value
+   */
+  public abstract V valueOrElseThrow(Function<E, ? extends RuntimeException> exceptionMapper);
+
+  /**
    * Returns the error or throws a {@link InvalidResultAccessException} if no error is present
    *
    * @return the error
@@ -279,10 +288,6 @@ public abstract class Result<V, E> {
 
     private Value(V value) {
       this.value = value;
-    }
-
-    private V get() {
-      return value;
     }
 
     @Override
@@ -370,6 +375,11 @@ public abstract class Result<V, E> {
     }
 
     @Override
+    public V valueOrElseThrow(Function<E, ? extends RuntimeException> exceptionMapper) {
+      return value;
+    }
+
+    @Override
     public E getError() {
       throw new InvalidResultAccessException("No error present.");
     }
@@ -400,10 +410,6 @@ public abstract class Result<V, E> {
 
     private Error(E error) {
       this.error = error;
-    }
-
-    private E get() {
-      return error;
     }
 
     @Override
@@ -490,6 +496,11 @@ public abstract class Result<V, E> {
     @Override
     public V valueOrElseThrow(Supplier<? extends RuntimeException> supplier) {
       throw supplier.get();
+    }
+
+    @Override
+    public V valueOrElseThrow(Function<E, ? extends RuntimeException> exceptionMapper) {
+      throw exceptionMapper.apply(error);
     }
 
     @Override

--- a/application-commons/src/test/groovy/life/qbic/application/commons/ErrorSpec.groovy
+++ b/application-commons/src/test/groovy/life/qbic/application/commons/ErrorSpec.groovy
@@ -80,7 +80,7 @@ class ErrorSpec extends Specification {
         when:
         var result = errorObject.map(function)
         then:
-        result.get() == errorObject.get()
+        result.value == errorObject.value
     }
 
     def "transform error returns an either with transformed error"() {
@@ -89,7 +89,7 @@ class ErrorSpec extends Specification {
         when:
         var result = errorObject.mapError(function)
         then:
-        result.get() == function.apply(errorObject.get())
+        result.getError() == function.apply(errorObject.getError())
     }
 
     def "either containing a value is equal to another either containing the value"() {
@@ -115,7 +115,7 @@ class ErrorSpec extends Specification {
         var result = errorObject.flatMap(mapper)
 
         then:
-        result.get() == errorObject.get()
+        result.getError() == errorObject.getError()
     }
 
     def "bind error returns an either with the mapped error"() {
@@ -124,7 +124,7 @@ class ErrorSpec extends Specification {
         when:
         var result = errorObject.flatMapError(mapper)
         then:
-        result == mapper.apply(errorObject.get())
+        result == mapper.apply(errorObject.getError())
     }
 
     def "fold returns the mapped error"() {
@@ -142,7 +142,7 @@ class ErrorSpec extends Specification {
         var result = errorObject.recover(function)
         then:
         result.isValue()
-        result.get() == function.apply(errorObject.get())
+        result.valueOrElseThrow(() -> new RuntimeException("Test")) == function.apply(errorObject.getError())
     }
 
     def "getValue throws an exception"() {
@@ -170,10 +170,5 @@ class ErrorSpec extends Specification {
         then:
         def e = thrown(RuntimeException)
         e == expectedException
-    }
-
-    def "getError returns the error"() {
-        expect:
-        errorObject.get() == errorObject.getError()
     }
 }

--- a/application-commons/src/test/groovy/life/qbic/application/commons/ValueSpec.groovy
+++ b/application-commons/src/test/groovy/life/qbic/application/commons/ValueSpec.groovy
@@ -83,7 +83,7 @@ class ValueSpec extends Specification {
         when:
         var result = valueObject.map(function)
         then:
-        result.get() == function.apply(valueObject.get())
+        result.valueOrElseThrow(() -> new RuntimeException("Test")) == function.apply(valueObject.valueOrElseThrow(() -> new RuntimeException("Test")))
     }
 
     def "transform error returns an either with unchanged error"() {
@@ -92,7 +92,8 @@ class ValueSpec extends Specification {
         when:
         var result = valueObject.mapError(function)
         then:
-        result.get() == valueObject.get()
+        result.valueOrElseThrow(() -> new RuntimeException("Test")) == valueObject.valueOrElseThrow(() -> new RuntimeException("Test"))
+
     }
 
     def "either containing a value is equal to another either containing the value"() {
@@ -117,7 +118,7 @@ class ValueSpec extends Specification {
         when:
         var result = valueObject.flatMap(mapper)
         then:
-        result == mapper.apply(valueObject.get())
+        result == mapper.apply(valueObject.valueOrElseThrow(() -> new RuntimeException("Test")))
     }
 
     def "bind error returns an either with unchanged error"() {
@@ -127,7 +128,7 @@ class ValueSpec extends Specification {
         var result = valueObject.flatMapError(mapper)
 
         then:
-        result.get() == valueObject.get()
+        result.valueOrElseThrow(() -> new RuntimeException("Test")) == valueObject.valueOrElseThrow(() -> new RuntimeException("Test"))
     }
 
     def "fold returns the mapped value"() {
@@ -145,22 +146,17 @@ class ValueSpec extends Specification {
 
     def "getValue returns the value"() {
         expect:
-        valueObject.get() == valueObject.getValue()
+        valueObject.valueOrElseThrow(() -> new RuntimeException("Test")) == valueObject.getValue()
     }
 
     def "valueOrElse returns the value"() {
         expect:
-        valueObject.get() == valueObject.valueOrElse("my other Value")
+        valueObject.valueOrElseThrow(() -> new RuntimeException("Test")) == valueObject.valueOrElse("my other Value")
     }
 
     def "valueOrElseGet returns the value"() {
         expect:
-        valueObject.get() == valueObject.valueOrElseGet(() -> "my other value")
-    }
-
-    def "valueOrElseThrow returns the value"() {
-        expect:
-        valueObject.get() == valueObject.valueOrElseThrow(() -> new RuntimeException("Oha! No value!"))
+        valueObject.valueOrElseThrow(() -> new RuntimeException("Test")) == valueObject.valueOrElseGet(() -> "my other value")
     }
 
     def "getError throws an exception"() {

--- a/user-interface/frontend/themes/datamanager/components/spreadsheet.css
+++ b/user-interface/frontend/themes/datamanager/components/spreadsheet.css
@@ -1,22 +1,3 @@
-#spreadsheet-overlays .v-spreadsheet-comment-overlay {
-  /* we need the comment to show in front of vaadin dialogs
-  the html element itself has the style of z-index of 1.
-  We need to overwrite it (!important) as direct element styles have preference over css.*/
-  z-index: 201 !important;
-}
-
-#spreadsheet-overlays .v-spreadsheet-comment-overlay {
-  border-style: solid;
-  border-color: var(--lumo-warning-color);
-  border-width: 1px;
-}
-
-#spreadsheet-overlays .v-spreadsheet-comment-overlay .popupContent {
-  font-size: 0.9em;
-  background-color: white;
-  padding: 0.2em;
-}
-
 .spreadsheet,
 .spreadsheet-container {
   width: 100%;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
@@ -32,15 +32,12 @@ import life.qbic.logging.api.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Comment;
-import org.apache.poi.ss.usermodel.CreationHelper;
-import org.apache.poi.ss.usermodel.Drawing;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.xssf.usermodel.XSSFColor;
-import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 
 /**
  * This spreadsheet component can be used to show data beans in configurable rows.
@@ -70,10 +67,6 @@ public class Spreadsheet<T> extends Component implements HasComponents,
   private final transient CellStyle rowNumberStyle;
   private final transient CellStyle columnHeaderStyle;
 
-  // apache helpers
-  private final transient CreationHelper creationHelper;
-  private final transient Drawing<?> drawingPatriarch;
-
   protected ValidationMode validationMode;
 
   //ATTENTION: we need to hard-code this. We cannot ensure that the Calibri font is installed.
@@ -83,8 +76,6 @@ public class Spreadsheet<T> extends Component implements HasComponents,
   public Spreadsheet() {
     addClassName("spreadsheet-container");
     delegateSpreadsheet.setActiveSheetProtected("");
-    creationHelper = delegateSpreadsheet.getWorkbook().getCreationHelper();
-    drawingPatriarch = delegateSpreadsheet.getActiveSheet().createDrawingPatriarch();
 
     defaultCellStyle = getDefaultCellStyle(delegateSpreadsheet.getWorkbook());
     lockedCellStyle = createLockedCellStyle(delegateSpreadsheet.getWorkbook());
@@ -673,12 +664,6 @@ public class Spreadsheet<T> extends Component implements HasComponents,
 
   }
 
-  private Comment createComment(String comment) {
-    Comment cellComment = drawingPatriarch.createCellComment(creationHelper.createClientAnchor());
-    cellComment.setString(new XSSFRichTextString(comment));
-    return cellComment;
-  }
-
   private static Color getErrorBackgroundColor() {
     float alpha = 0.1f;
     float hueAngle = 0f; // 0: red; 120: green, 240: blue
@@ -744,8 +729,6 @@ public class Spreadsheet<T> extends Component implements HasComponents,
     if (columnHeaderStyle.equals(cell.getCellStyle())) {
       return; // does not apply to column headers
     }
-    Comment cellComment = createComment(errorMessage);
-    cell.setCellComment(cellComment);
     cell.setCellStyle(invalidCellStyle);
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
@@ -747,7 +747,8 @@ public class Spreadsheet<T> extends Component implements HasComponents,
   }
 
   private boolean hasCellValidationChanged(Cell cell, ValidationResult validationResult) {
-    return !isCellValid(cell) || !validationResult.isValid();
+    return !(isCellValid(cell) && validationResult.isValid())
+        || !(isCellInvalid(cell) && validationResult.isInvalid());
   }
 
   private boolean isCellValid(Cell cell) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
@@ -31,7 +31,6 @@ import life.qbic.datamanager.views.general.spreadsheet.validation.ValidationResu
 import life.qbic.logging.api.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -722,7 +721,7 @@ public class Spreadsheet<T> extends Component implements HasComponents,
         .orElse(ValidationResult.valid());
   }
 
-  private void markCellAsInvalid(Cell cell, String errorMessage) {
+  private void markCellAsInvalid(Cell cell) {
     if (rowNumberStyle.equals(cell.getCellStyle())) {
       return; // does not apply to row numbers
     }
@@ -737,32 +736,18 @@ public class Spreadsheet<T> extends Component implements HasComponents,
       return; // only apply to invalid cells
     }
     cell.setCellStyle(defaultCellStyle);
-    cell.removeCellComment();
   }
 
   private void updateCellValidationStatus(Cell cell, ValidationResult validationResult) {
     if (validationResult.isValid()) {
       markCellAsValid(cell);
     } else {
-      markCellAsInvalid(cell, validationResult.errorMessage());
+      markCellAsInvalid(cell);
     }
   }
 
   private boolean hasCellValidationChanged(Cell cell, ValidationResult validationResult) {
-    if (isCellValid(cell) && validationResult.isValid()) {
-      return false;
-    }
-    if (isCellInvalid(cell) && validationResult.isInvalid()) {
-      Comment existingComment = cell.getCellComment();
-      assert Objects.nonNull(validationResult.errorMessage()) : "error message is never null";
-      if (Objects.isNull(existingComment)) {
-        // error message is never null
-        return true;
-      }
-      return !validationResult.errorMessage()
-          .equals(existingComment.getString().getString());
-    }
-    return true;
+    return !isCellValid(cell) || !validationResult.isValid();
   }
 
   private boolean isCellValid(Cell cell) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
@@ -180,9 +180,9 @@ public class SampleContentComponent extends Div {
             context.projectId().orElseThrow())
         .onError(responseCode -> displayRegistrationFailure())
         .onValue(ignored -> fireEvent(new BatchRegisteredEvent(this, false)))
-        .onValue(ignored -> confirmEvent.getSource().close())
         .onValue(batchId -> displayRegistrationSuccess())
         .onValue(ignored -> reload());
+    confirmEvent.getSource().close();
   }
 
   private List<SampleRegistrationRequest> generateSampleRequestsFromSampleInfo(BatchId batchId,
@@ -292,9 +292,9 @@ public class SampleContentComponent extends Div {
     var result = batchRegistrationService.editBatch(confirmEvent.getData().batchId(),
         confirmEvent.getData().batchName(), isPilot, createdSamples, editedSamples,
         deletedSamples, context.projectId().orElseThrow());
-    result.onValue(ignored -> confirmEvent.getSource().close());
     result.onValue(batchId -> displayUpdateSuccess());
     result.onValue(ignored -> reload());
+    confirmEvent.getSource().close();
   }
 
   private void deleteBatch(DeleteBatchEvent deleteBatchEvent) {


### PR DESCRIPTION
**What was changed**
**1.) Drag and drop within the cells of a spreadsheet is stuck when a comment is shown**
Seems to be related to the drawingpatriarch used in the vaadin spreadsheet. For now drag and drop is only possible if no cell comment pops up during drag and drop operations. Since this behaviour is finicky we remove the comments for now. 

**2.) The Spreadsheet rendering collapses if a notification is shown or closed**
Rendering the notification popup or closure leads to the breakage of the spreadsheet which would necessitate a complete refresh of all cells within the spreadsheet. Since this is not feasible for all possible notifications, the easier solution for now is to just close the dialog and show the notification afterwards. 

**ToDo**
Since the spreadsheet is a "gift" that keeps on giving, I'd recommend we get in contact with vaadin support and discuss our implementation with their suggested one and try to iron out why it's so finicky and hard to manage. 

### Possible Topics could include:

**Difference Apache POI and Vaadin Spreadsheet:** 

1.) ErrorBox and Promptboxes are not working 
2.) Rendering of column and cell width within Spreadsheet is not adapting to outer container except if forced manually. 
3.) Apache POI Data validation does not work at all
4.) Notification are not shown correctly and sometimes pop up behind the dialog containing the spreadsheet 
