### PR TITLE
display more info about ontology terms for experiments

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/vocabulary/OntologyClassDTO.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/vocabulary/OntologyClassDTO.java
@@ -30,6 +30,16 @@ public class OntologyClassDTO {
   public OntologyClassDTO() {
   }
 
+  /**
+   *
+   * @param ontology        - the abbreviation of the ontology a class/term belongs to
+   * @param ontologyVersion - the version of the ontology
+   * @param ontologyIri     - the iri of this ontology (e.g. link to the owl)
+   * @param label           - a humanly readable label for the term
+   * @param name            - the identifier unique for this ontology and term (e.g. NCBITaxon_9606)
+   * @param description     - an optional description of the term
+   * @param classIri        - the iri where this specific class is found/described
+   */
   public OntologyClassDTO(String ontology, String ontologyVersion, String ontologyIri,
       String label, String name, String description, String classIri) {
     this.ontology = ontology;

--- a/user-interface/frontend/themes/datamanager/components/div.css
+++ b/user-interface/frontend/themes/datamanager/components/div.css
@@ -37,6 +37,15 @@
   align-items: baseline;
 }
 
+.ontology-component {
+  display: flex;
+}
+
+.ontology-component .subtitle {
+  font-size: var(--lumo-font-size-s);
+  color: var(--lumo-secondary-text-color);
+}
+
 .card-deck {
   display: flex;
   align-content: space-evenly;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
@@ -1,0 +1,31 @@
+package life.qbic.datamanager.views.general;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import life.qbic.projectmanagement.domain.model.Ontology;
+import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
+
+@Tag(Tag.DIV)
+public class OntologyComponent extends Component implements HasComponents {
+  public OntologyComponent(OntologyClassDTO contentDTO) {
+    String ontologyName = Ontology.findOntologyByAbbreviation(contentDTO.getOntology()).getName();
+    styleLayout(contentDTO.getLabel(), contentDTO.getName(), ontologyName);
+  }
+
+  private void styleLayout(String label, String id, String ontology) {
+    addClassName("ontology-component");
+
+    var upperDiv = new Div();
+    upperDiv.add(new Span(label+ " ("+id+")"));
+    var lowerDiv = new Div();
+    Span subtitle = new Span(ontology);
+    subtitle.addClassNames("subtitle");
+    lowerDiv.add(subtitle);
+    upperDiv.add(lowerDiv);
+
+    add(upperDiv);
+  }
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
@@ -16,6 +16,7 @@ public class OntologyComponent extends Component implements HasComponents {
     addClassName("ontology-component");
 
     var upperDiv = new Div();
+    // creates a line with label and ontology name (id), e.g. "Homo sapiens (NCBITaxon_9606)"
     upperDiv.add(new Span(contentDTO.getLabel()) + " (" + contentDTO.getName() + ")");
     var lowerDiv = new Div();
     Span subtitle = new Span(ontologyName);

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
@@ -12,16 +12,13 @@ import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyCl
 public class OntologyComponent extends Component implements HasComponents {
   public OntologyComponent(OntologyClassDTO contentDTO) {
     String ontologyName = Ontology.findOntologyByAbbreviation(contentDTO.getOntology()).getName();
-    styleLayout(contentDTO.getLabel(), contentDTO.getName(), ontologyName);
-  }
 
-  private void styleLayout(String label, String id, String ontology) {
     addClassName("ontology-component");
 
     var upperDiv = new Div();
-    upperDiv.add(new Span(label+ " ("+id+")"));
+    upperDiv.add(new Span(contentDTO.getLabel()) + " (" + contentDTO.getName() + ")");
     var lowerDiv = new Div();
-    Span subtitle = new Span(ontology);
+    Span subtitle = new Span(ontologyName);
     subtitle.addClassNames("subtitle");
     lowerDiv.add(subtitle);
     upperDiv.add(lowerDiv);

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -365,6 +365,7 @@ public class ExperimentDetailsComponent extends PageArea {
     for(OntologyClassDTO ontologyClass : ontologyClasses) {
       Span termSpan = new Span(ontologyClass.getLabel());
       String ontologyName = Ontology.findOntologyByAbbreviation(ontologyClass.getOntology()).getName();
+      // creates a line with label and ontology name (id), e.g. "Homo sapiens (NCBITaxon_9606)"
       termSpan.setTitle(ontologyClass.getName()+ "("+ontologyName+")");
       list.add(termSpan);
     }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -53,6 +53,7 @@ import life.qbic.projectmanagement.application.ExperimentInformationService;
 import life.qbic.projectmanagement.application.ExperimentInformationService.ExperimentalGroupDTO;
 import life.qbic.projectmanagement.application.OntologyTermInformationService;
 import life.qbic.projectmanagement.application.sample.SampleInformationService;
+import life.qbic.projectmanagement.domain.model.Ontology;
 import life.qbic.projectmanagement.domain.model.experiment.Experiment;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentalDesign;
@@ -60,6 +61,7 @@ import life.qbic.projectmanagement.domain.model.experiment.ExperimentalDesign.Ad
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentalGroup;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentalVariable;
 import life.qbic.projectmanagement.domain.model.experiment.VariableLevel;
+import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -349,7 +351,7 @@ public class ExperimentDetailsComponent extends PageArea {
     content.add(sampleSourceComponent);
   }
 
-  private Span createSampleSourceList(String title, Icon icon, List<String> tags) {
+  private Span createSampleSourceList(String title, Icon icon, List<OntologyClassDTO> ontologyClasses) {
     Span iconAndList = new Span();
     iconAndList.addClassName("icon-with-list");
     iconAndList.add(icon);
@@ -360,19 +362,21 @@ public class ExperimentDetailsComponent extends PageArea {
     listTitle.addClassName("title");
     list.add(listTitle);
     list.addClassName("taglist");
-    tags.forEach(name -> list.add(new Span(name)));
+    for(OntologyClassDTO ontologyClass : ontologyClasses) {
+      Span termSpan = new Span(ontologyClass.getLabel());
+      String ontologyName = Ontology.findOntologyByAbbreviation(ontologyClass.getOntology()).getName();
+      termSpan.setTitle(ontologyClass.getName()+ "("+ontologyName+")");
+      list.add(termSpan);
+    }
     iconAndList.add(list);
     return iconAndList;
   }
 
   private void loadSampleSources(Experiment experiment) {
     sampleSourceComponent.removeAll();
-    List<String> speciesTags = new ArrayList<>();
-    List<String> specimenTags = new ArrayList<>();
-    List<String> analyteTags = new ArrayList<>();
-    experiment.getSpecies().forEach(species -> speciesTags.add(species.getLabel()));
-    experiment.getSpecimens().forEach(specimen -> specimenTags.add(specimen.getLabel()));
-    experiment.getAnalytes().forEach(analyte -> analyteTags.add(analyte.getLabel()));
+    List<OntologyClassDTO> speciesTags = new ArrayList<>(experiment.getSpecies());
+    List<OntologyClassDTO> specimenTags = new ArrayList<>(experiment.getSpecimens());
+    List<OntologyClassDTO> analyteTags = new ArrayList<>(experiment.getAnalytes());
 
     sampleSourceComponent.add(
         createSampleSourceList("Species", VaadinIcon.BUG.create(), speciesTags));

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
@@ -45,10 +45,10 @@ public class OntologyFilterConnector {
                 .collect(Collectors.toList())).stream().map(entity -> OntologyClassDTO.from(entity)),
         entity -> entity
     );
-    box.setRenderer(createRenderer());
+    box.setRenderer(ontologyComponentRenderer());
   }
 
-  private Renderer<OntologyClassDTO> createRenderer() {
+  private Renderer<OntologyClassDTO> ontologyComponentRenderer() {
       return new ComponentRenderer<OntologyComponent, OntologyClassDTO>(ontologyClassDTO ->
         new OntologyComponent(ontologyClassDTO) );
     }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/OntologyFilterConnector.java
@@ -2,12 +2,15 @@ package life.qbic.datamanager.views.projects.project.experiments.experiment;
 
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import java.util.List;
 import java.util.stream.Collectors;
+import life.qbic.datamanager.views.general.OntologyComponent;
 import life.qbic.projectmanagement.application.OntologyTermInformationService;
 import life.qbic.projectmanagement.application.SortOrder;
 import life.qbic.projectmanagement.domain.model.Ontology;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
+import com.vaadin.flow.data.renderer.Renderer;
 
 /**
  * Connects the OntologyTermInformationService to a Combobox of variable type, setting up a user-
@@ -42,5 +45,12 @@ public class OntologyFilterConnector {
                 .collect(Collectors.toList())).stream().map(entity -> OntologyClassDTO.from(entity)),
         entity -> entity
     );
+    box.setRenderer(createRenderer());
   }
+
+  private Renderer<OntologyClassDTO> createRenderer() {
+      return new ComponentRenderer<OntologyComponent, OntologyClassDTO>(ontologyClassDTO ->
+        new OntologyComponent(ontologyClassDTO) );
+    }
+
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/Tag.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/Tag.java
@@ -8,4 +8,9 @@ public class Tag extends Span {
     super(text);
     addClassName("tag");
   }
+
+  public Tag(String text, String toolTip) {
+    this(text);
+    setTitle(toolTip);
+  }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectDetailsComponent.java
@@ -175,6 +175,10 @@ public class ProjectDetailsComponent extends PageArea {
     return noPersonAssignedSpan;
   }
 
+  /**
+   * Creates tags for a list of ontology terms. Each tag display the term label and contains a tooltip
+   * which is built from ontology term name (e.g. NCBITaxon_9606) and the ontology it is taken from
+   */
   private static List<Tag> createTagsFrom(Stream<OntologyClassDTO> entries) {
     return entries.distinct().map(entry -> new Tag(entry.getLabel(),
         entry.getName()+"("+ Ontology.findOntologyByAbbreviation(entry.getOntology()).getName()+")"))

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectDetailsComponent.java
@@ -101,13 +101,13 @@ public class ProjectDetailsComponent extends PageArea {
     var specimen = new Div();
     specimen.addClassName(TAG_COLLECTION_CSS_CLASS);
     createTagsFrom(experiments.stream().flatMap(experiment -> experiment.getSpecimens().stream()))
-        .forEach(species::add);
+        .forEach(specimen::add);
     entries.add(new Entry("Specimen", "Tissue, cells or other matrix extracted from the "
         + "species", specimen));
     var analyte = new Div();
     analyte.addClassName(TAG_COLLECTION_CSS_CLASS);
     createTagsFrom(experiments.stream().flatMap(experiment -> experiment.getAnalytes().stream()))
-        .forEach(species::add);
+        .forEach(analyte::add);
     entries.add(new Entry("Analyte", "", analyte));
     return entries;
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/info/ProjectDetailsComponent.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import life.qbic.application.commons.ApplicationException;
 import life.qbic.datamanager.views.Context;
 import life.qbic.datamanager.views.general.PageArea;
@@ -21,11 +22,9 @@ import life.qbic.datamanager.views.projects.project.experiments.experiment.Tag;
 import life.qbic.datamanager.views.projects.project.info.InformationComponent.Entry;
 import life.qbic.projectmanagement.application.ExperimentInformationService;
 import life.qbic.projectmanagement.application.ProjectInformationService;
+import life.qbic.projectmanagement.domain.model.Ontology;
 import life.qbic.projectmanagement.domain.model.experiment.Experiment;
-import life.qbic.projectmanagement.domain.model.experiment.vocabulary.Analyte;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
-import life.qbic.projectmanagement.domain.model.experiment.vocabulary.Species;
-import life.qbic.projectmanagement.domain.model.experiment.vocabulary.Specimen;
 import life.qbic.projectmanagement.domain.model.project.Contact;
 import life.qbic.projectmanagement.domain.model.project.Funding;
 import life.qbic.projectmanagement.domain.model.project.Project;
@@ -96,16 +95,19 @@ public class ProjectDetailsComponent extends PageArea {
 
     var species = new Div();
     species.addClassName(TAG_COLLECTION_CSS_CLASS);
-    speciesTags(experiments).forEach(species::add);
+    createTagsFrom(experiments.stream().flatMap(experiment -> experiment.getSpecies().stream()))
+        .forEach(species::add);
     entries.add(new Entry("Species", "", species));
     var specimen = new Div();
     specimen.addClassName(TAG_COLLECTION_CSS_CLASS);
-    specimenTags(experiments).forEach(specimen::add);
+    createTagsFrom(experiments.stream().flatMap(experiment -> experiment.getSpecimens().stream()))
+        .forEach(species::add);
     entries.add(new Entry("Specimen", "Tissue, cells or other matrix extracted from the "
         + "species", specimen));
     var analyte = new Div();
     analyte.addClassName(TAG_COLLECTION_CSS_CLASS);
-    analyteTags(experiments).forEach(analyte::add);
+    createTagsFrom(experiments.stream().flatMap(experiment -> experiment.getAnalytes().stream()))
+        .forEach(species::add);
     entries.add(new Entry("Analyte", "", analyte));
     return entries;
   }
@@ -173,33 +175,9 @@ public class ProjectDetailsComponent extends PageArea {
     return noPersonAssignedSpan;
   }
 
-  private static List<Tag> speciesTags(List<Experiment> experiments) {
-    return experiments.stream()
-        .flatMap(experiment -> experiment.getSpecies().stream())
-        .map(OntologyClassDTO::getLabel)
-        .distinct()
-        .sorted()
-        .map(Tag::new)
-        .toList();
-  }
-
-  private static List<Tag> specimenTags(List<Experiment> experiments) {
-    return experiments.stream()
-        .flatMap(experiment -> experiment.getSpecimens().stream())
-        .map(OntologyClassDTO::getLabel)
-        .distinct()
-        .sorted()
-        .map(Tag::new)
-        .toList();
-  }
-
-  private static List<Tag> analyteTags(List<Experiment> experiments) {
-    return experiments.stream()
-        .flatMap(experiment -> experiment.getAnalytes().stream())
-        .map(OntologyClassDTO::getLabel)
-        .distinct()
-        .sorted()
-        .map(Tag::new)
+  private static List<Tag> createTagsFrom(Stream<OntologyClassDTO> entries) {
+    return entries.distinct().map(entry -> new Tag(entry.getLabel(),
+        entry.getName()+"("+ Ontology.findOntologyByAbbreviation(entry.getOntology()).getName()+")"))
         .toList();
   }
 


### PR DESCRIPTION
* renders OntologyComponent in dropdown menus using ontologies - this displays the name of the source ontology and the "name" (unique ID of the term)
* the same information is added as a tooltip for tags and spans used in experiment and project overview components