### PR TITLE
Remove primary style of add button in experimentlistcomponent

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/ExperimentListComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/ExperimentListComponent.java
@@ -129,7 +129,6 @@ public class ExperimentListComponent extends PageArea {
     Div controls = new Div();
     controls.addClassName("controls");
     Button addButton = new Button("Add");
-    addButton.addClassName("primary");
     addButton.addClickListener(
         event -> fireEvent(new AddExperimentClickEvent(this, event.isFromClient())));
     controls.add(addButton);


### PR DESCRIPTION
**What was changed**
The add experiment button now fits the color scheme defined in the [prototype](https://www.figma.com/file/mYcW5viu5GpPZ852VHYBrV/Start-Page?type=design&node-id=4276-88806&mode=dev)