### PR TITLE
Project creation dialog shows descriptions for each layout and adheres to sizing scheme for our dialogs

### DIFF
--- a/user-interface/frontend/themes/datamanager/components/dialog.css
+++ b/user-interface/frontend/themes/datamanager/components/dialog.css
@@ -269,12 +269,13 @@ vaadin-dialog-overlay::part(title) {
   width: 100%;
   /*Necessary so the dividers span the whole dialog*/
   padding: 0;
-
 }
 
 .project-creation-dialog::part(overlay) {
   width: 100%;
   height: 100%;
+  max-width: 66%;
+  max-height: 100%
 }
 
 .project-creation-dialog::part(footer) {
@@ -302,17 +303,17 @@ vaadin-dialog-overlay::part(title) {
   padding: 1rem 4rem 3rem 4rem
 }
 
-.project-creation-dialog .collaborators-layout .contact-field .input-fields {
+.project-creation-dialog .collaborators-layout {
   gap: var(--lumo-space-m);
   display: inline-flex;
 }
 
 .project-creation-dialog .collaborators-layout .contact-field .name-field {
-  min-width: 45vw;
+  width: 100%;
 }
 
 .project-creation-dialog .collaborators-layout .contact-field .email-field {
-  min-width: 45vw;
+  width: 100%;
 }
 
 .project-creation-dialog .experiment-information-layout{

--- a/user-interface/frontend/themes/datamanager/components/div.css
+++ b/user-interface/frontend/themes/datamanager/components/div.css
@@ -133,21 +133,19 @@
 }
 
 .stepper {
-  /*Ensure that the stepper has enough space on smaller screens*/
-  min-height: 4rem;
   margin-top: 0.5rem;
   display: inline-flex;
-  margin-left: 4rem;
-  margin-right: 4rem;
+  /*Employ same padding as defined for dialog layout*/
+  padding-inline: 4rem;
 }
 
 
 .stepper .step {
-  gap: var(--lumo-space-s);
   display: flex;
   flex-direction: column;
-  justify-content: end;
   align-items: center;
+  white-space: nowrap;
+  gap: var(--lumo-space-s);
 }
 
 .stepper .step[selected] > vaadin-avatar {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
@@ -26,7 +26,7 @@ public class CollaboratorsLayout extends Div implements HasValidation {
   private final ContactField principalInvestigatorField = new ContactField(
       "Principal Investigator");
   private final ContactField responsiblePersonField = new ContactField(
-      "Project Responsible/Core Investigator (optional)");
+      "Project Responsible/Co-Investigator (optional)");
   private final ContactField projectManagerField = new ContactField("Project Manager");
   private final Binder<ProjectCollaborators> collaboratorsBinder = new Binder<>(
       ProjectCollaborators.class);

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
@@ -39,7 +39,8 @@ public class CollaboratorsLayout extends Div implements HasValidation {
   private void initLayout() {
     Span projectContactsTitle = new Span(TITLE);
     projectContactsTitle.addClassName("title");
-    Span projectContactsDescription = new Span("Important contact people of the project");
+    Span projectContactsDescription = new Span(
+        "Add the names and email address of the important contact people of the project.");
     add(projectContactsTitle);
     add(projectContactsDescription);
     add(principalInvestigatorField);

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ExperimentalInformationLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ExperimentalInformationLayout.java
@@ -76,7 +76,7 @@ public class ExperimentalInformationLayout extends Div implements HasValidation 
 
   private static Component description() {
     return new Span(
-        "The experiment name and sample origin information of the samples");
+        "Specify the experiment name and sample origin information of the samples.");
   }
 
   private static TextField nameField() {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/FundingInformationLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/FundingInformationLayout.java
@@ -35,7 +35,8 @@ public class FundingInformationLayout extends Div implements HasValidation {
   private void initLayout() {
     Span fundingInformationTitle = new Span(TITLE);
     fundingInformationTitle.addClassNames("title");
-    Span fundingInformationDescription = new Span("Description Text");
+    Span fundingInformationDescription = new Span(
+        "Specify the name and id of the research project grant, if present.");
     add(fundingInformationTitle, fundingInformationDescription, fundingField);
     addClassName("funding-information-layout");
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
@@ -59,7 +59,8 @@ public class ProjectDesignLayout extends Div implements HasValidation {
   private void initLayout() {
     Span projectDesignTitle = new Span(TITLE);
     projectDesignTitle.addClassName("title");
-    Span projectDesignDescription = new Span("Description text");
+    Span projectDesignDescription = new Span(
+        "Specify the name and objective of the research project. You can either select a project from the offer list or create a new one.");
     offerSearchField.setClassName("search-field");
     offerSearchField.setPlaceholder("Search for offers");
     offerSearchField.setPrefixComponent(VaadinIcon.SEARCH.create());


### PR DESCRIPTION
**What was changed**
1.) Instead of dummy description texts, the layouts now show the descriptions defined in the figma prototype
2.) The header of the person responsible was renamed
3.) CSS style changes so the dialog is sized as intended 

**Prototype**
The figma prototype can be found [here](https://www.figma.com/file/mYcW5viu5GpPZ852VHYBrV/Start-Page?type=design&node-id=4788-99390&mode=dev)