### PR TITLE
Fix spreadsheet breaking on deletion request

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/QbicSampleDataRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/QbicSampleDataRepo.java
@@ -37,4 +37,5 @@ public interface QbicSampleDataRepo {
 
   void updateAll(Collection<Sample> samples);
 
+  boolean canDeleteSample(ProjectCode projectCode, SampleCode sampleCode);
 }

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/SampleRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/SampleRepositoryImpl.java
@@ -98,6 +98,12 @@ public class SampleRepositoryImpl implements SampleRepository {
   }
 
   @Override
+  public boolean isSampleRemovable(Project project, SampleId sampleId) {
+    SampleCode sampleCode = qbicSampleRepository.findById(sampleId).get().sampleCode();
+    return sampleDataRepo.canDeleteSample(project.getProjectCode(), sampleCode);
+  }
+
+  @Override
   public Result<Collection<Sample>, SampleInformationService.ResponseCode> findSamplesByExperimentId(
       ExperimentId experimentId) {
     Objects.requireNonNull(experimentId);
@@ -131,5 +137,6 @@ public class SampleRepositoryImpl implements SampleRepository {
   public List<Sample> findSamplesBySampleId(List<SampleId> sampleId) {
     return qbicSampleRepository.findAllById(sampleId);
   }
+
 
 }

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
@@ -272,6 +272,23 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
     sampleCodesToDelete.forEach(code -> deleteOpenbisSample(DEFAULT_SPACE_CODE, code));
   }
 
+  @Override
+  public boolean canDeleteSample(ProjectCode projectCode, SampleCode codeToDelete) {
+    ExperimentFetchOptions fetchOptions = new ExperimentFetchOptions();
+    fetchOptions.withSamplesUsing(fetchSamplesCompletely());
+    for (Experiment experiment : searchExperimentsByProjectCode(projectCode.value(), fetchOptions)) {
+      for (Sample sample : experiment.getSamples()) {
+        String sampleCode = sample.getCode();
+        if (codeToDelete.code().equals(sampleCode)) {
+          if (isSampleWithData(List.of(sample))) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
   /**
    * Recursive method checking child samples for datasets
    */

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/DeletionService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/DeletionService.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static life.qbic.logging.service.LoggerFactory.logger;
 
 import java.util.Collection;
-import java.util.Optional;
 import life.qbic.application.commons.ApplicationException;
 import life.qbic.application.commons.Result;
 import life.qbic.logging.api.Logger;
@@ -113,11 +112,17 @@ public class DeletionService {
     sampleDomainService.deleteSamples(project.get(), samplesCollection);
   }
 
+  /**
+   * Confirms that a sample can be removed. Might indicate that sample removal is not possible due
+   * to the following reasons:
+   * <ul>
+   *   <li> data is connected to the sample
+   *
+   * @param sampleId
+   * @param projectId
+   * @return
+   */
   public boolean isSampleRemovable(SampleId sampleId, ProjectId projectId) {
-    // "sample" without Id only exists in table, not the database, it can be removed
-    if(sampleId==null) {
-      return true;
-    }
     var project = projectInformationService.find(projectId);
     if (project.isEmpty()) {
       throw new IllegalArgumentException("Could not find project " + projectId);

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/DeletionService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/DeletionService.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static life.qbic.logging.service.LoggerFactory.logger;
 
 import java.util.Collection;
+import java.util.Optional;
 import life.qbic.application.commons.ApplicationException;
 import life.qbic.application.commons.Result;
 import life.qbic.logging.api.Logger;
@@ -110,6 +111,18 @@ public class DeletionService {
       throw new IllegalArgumentException("Could not find project " + projectId);
     }
     sampleDomainService.deleteSamples(project.get(), samplesCollection);
+  }
+
+  public boolean isSampleRemovable(SampleId sampleId, ProjectId projectId) {
+    // "sample" without Id only exists in table, not the database, it can be removed
+    if(sampleId==null) {
+      return true;
+    }
+    var project = projectInformationService.find(projectId);
+    if (project.isEmpty()) {
+      throw new IllegalArgumentException("Could not find project " + projectId);
+    }
+    return sampleDomainService.isSampleRemovable(project.get(), sampleId);
   }
 
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/repository/SampleRepository.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/repository/SampleRepository.java
@@ -39,4 +39,6 @@ public interface SampleRepository {
   void updateAll(Project project, Collection<Sample> updatedSamples);
 
   List<Sample> findSamplesBySampleId(List<SampleId> sampleId);
+
+  boolean isSampleRemovable(Project project, SampleId sampleId);
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/service/SampleDomainService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/service/SampleDomainService.java
@@ -88,6 +88,10 @@ public class SampleDomainService {
         DomainEventDispatcher.instance().dispatch(sampleRegistered);
     }
 
+    public boolean isSampleRemovable(Project project, SampleId sampleId) {
+        return sampleRepository.isSampleRemovable(project, sampleId);
+    }
+
     /**
      * Response error codes for the sample registration
      *

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import life.qbic.application.commons.ApplicationException;
@@ -205,10 +204,18 @@ public class Spreadsheet<T> extends Component implements HasComponents,
    */
   public List<T> getData() {
     return rows.stream()
-        .filter(row -> row instanceof DataRow)
-        .map(row -> (DataRow) row)
+        .filter(DataRow.class::isInstance)
+        .map(DataRow.class::cast)
         .map(DataRow::data)
         .toList();
+  }
+
+  /**
+   * @param data the data to search for
+   * @return the data row index of the given data; -1 if not found
+   */
+  public int getDataRowIndex(T data) {
+    return getData().indexOf(data);
   }
 
   /**
@@ -493,7 +500,6 @@ public class Spreadsheet<T> extends Component implements HasComponents,
    */
   private void deleteRow(int index) {
     int lastRowIndex = rowCount() - 1;
-    int nextRowIndex = index + 1;
     if (index > lastRowIndex) {
       throw new IllegalArgumentException(
           "There is no row at index " + index + ". There are only rows with index up to "
@@ -689,7 +695,7 @@ public class Spreadsheet<T> extends Component implements HasComponents,
         .mapToObj(rowIndex -> getCell(rowIndex, columnIndex))
         .filter(Optional::isPresent).map(Optional::get)
         .map(this::getCellValue)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   private ValidationResult validateCell(Cell cell) {
@@ -746,7 +752,6 @@ public class Spreadsheet<T> extends Component implements HasComponents,
       markCellAsValid(cell);
     } else {
       markCellAsInvalid(cell);
-      setErrorMessage(validationResult.errorMessage());
     }
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
@@ -220,8 +220,8 @@ public class Spreadsheet<T> extends Component implements HasComponents,
   public T getLastRowData() {
     int lastRowIndex = rowCount() - 1;
     Row lastRow = getRow(lastRowIndex);
-    if(lastRow instanceof DataRow) {
-      return ((DataRow) lastRow).data;
+    if(lastRow instanceof DataRow dataRow) {
+      return dataRow.data;
     }
     return null;//other possibilities?
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/spreadsheet/Spreadsheet.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.component.spreadsheet.SpreadsheetComponentFactory;
 import com.vaadin.flow.shared.Registration;
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -210,6 +211,22 @@ public class Spreadsheet<T> extends Component implements HasComponents,
         .map(DataRow::data)
         .toList();
   }
+
+
+  /**
+   * Get the data in the last row of the spreadsheet
+   * @return the underlying data of the last row
+   */
+  public T getLastRowData() {
+    int lastRowIndex = rowCount() - 1;
+    Row lastRow = getRow(lastRowIndex);
+    if(lastRow instanceof DataRow) {
+      return ((DataRow) lastRow).data;
+    }
+    return null;//other possibilities?
+  }
+
+
 
   /**
    *
@@ -729,6 +746,13 @@ public class Spreadsheet<T> extends Component implements HasComponents,
       return; // does not apply to column headers
     }
     cell.setCellStyle(invalidCellStyle);
+  }
+
+  public void markLastRowInvalid() {
+    int lastRowIndex = rowCount() - 1;
+    Cell sampleCodeCell = getCell(lastRowIndex, 1).get();
+    markCellAsInvalid(sampleCodeCell);
+    refreshCells(Arrays.asList(sampleCodeCell));
   }
 
   private void markCellAsValid(Cell cell) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
@@ -26,7 +26,7 @@ import life.qbic.datamanager.views.projects.project.samples.BatchDetailsComponen
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.BatchRegistrationDialog;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.BatchRegistrationDialog.ConfirmEvent;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.EditBatchDialog;
-import life.qbic.datamanager.views.projects.project.samples.registration.batch.EditBatchDialog.RemoveRowEvent;
+import life.qbic.datamanager.views.projects.project.samples.registration.batch.EditBatchDialog.RemoveLastRowClickedEvent;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.SampleBatchInformationSpreadsheet;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.SampleBatchInformationSpreadsheet.SampleInfo;
 import life.qbic.projectmanagement.application.DeletionService;
@@ -310,13 +310,17 @@ public class SampleContentComponent extends Div {
     });
   }
 
-  private void removeRowFromBatch(EditBatchDialog.RemoveRowEvent removeRowEvent) {
-    EditBatchDialog dialog = removeRowEvent.getSource();
-    if(deletionService.isSampleRemovable(removeRowEvent.getSampleInfo().getSampleId(),
-        context.projectId().orElseThrow())) {
-      dialog.removeRow();
+  private void removeRowFromBatch(RemoveLastRowClickedEvent removeRowClickedEvent) {
+    EditBatchDialog dialog = removeRowClickedEvent.getSource();
+    int dataRowIndex = removeRowClickedEvent.getDataRowIndex();
+
+    SampleId sampleId = removeRowClickedEvent.getSampleInfo().getSampleId();
+    ProjectId projectId = context.projectId().orElseThrow();
+
+    if(deletionService.isSampleRemovable(sampleId, projectId)) {
+      dialog.removeLastRow();
     } else {
-      dialog.displayRemoveRowError();
+      dialog.displayRemoveRowError(dataRowIndex);
     }
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
@@ -25,6 +25,7 @@ import life.qbic.datamanager.views.projects.project.samples.BatchDetailsComponen
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.BatchRegistrationDialog;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.BatchRegistrationDialog.ConfirmEvent;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.EditBatchDialog;
+import life.qbic.datamanager.views.projects.project.samples.registration.batch.EditBatchDialog.RemoveRowEvent;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.SampleBatchInformationSpreadsheet;
 import life.qbic.datamanager.views.projects.project.samples.registration.batch.SampleBatchInformationSpreadsheet.SampleInfo;
 import life.qbic.projectmanagement.application.DeletionService;
@@ -262,6 +263,7 @@ public class SampleContentComponent extends Div {
             .batchId(), editBatchEvent.batchPreview().batchLabel(), sampleInfos);
     editBatchDialog.addCancelListener(cancelEvent -> cancelEvent.getSource().close());
     editBatchDialog.addConfirmListener(this::editBatch);
+    editBatchDialog.addRemoveRowListener(this::removeRowFromBatch);
     editBatchDialog.open();
   }
 
@@ -301,6 +303,16 @@ public class SampleContentComponent extends Div {
       confirmEvent.getSource().close();
       throw new ApplicationException("error code: " + error);
     });
+  }
+
+  private void removeRowFromBatch(EditBatchDialog.RemoveRowEvent removeRowEvent) {
+    EditBatchDialog dialog = removeRowEvent.getSource();
+    if(deletionService.isSampleRemovable(removeRowEvent.getSampleInfo().getSampleId(),
+        context.projectId().orElseThrow())) {
+      dialog.removeRow();
+    } else {
+      dialog.displayRemoveRowError();
+    }
   }
 
   private void deleteBatch(DeleteBatchEvent deleteBatchEvent) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/EditBatchDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/EditBatchDialog.java
@@ -144,7 +144,22 @@ public class EditBatchDialog extends DialogWindow {
   }
 
   private void onRemoveLastRowClicked(ClickEvent<Button> clickEvent) {
+    SampleInfo sampleInfo = spreadsheet.getLastRowData();
+    fireEvent(new RemoveRowEvent(this, clickEvent.isFromClient(),
+        sampleInfo));
+  }
+
+  /**
+   * Removes the last row. Any checks for validity of the operation should be performed before using
+   * the related event
+   */
+  public void removeRow() {
     spreadsheet.removeLastRow();
+  }
+
+  public void displayRemoveRowError() {
+    spreadsheet.setErrorMessage("Sample can not be removed because data is attached.");
+    spreadsheet.markLastRowInvalid();
   }
 
   private void onAddRowClicked(ClickEvent<Button> clickEvent) {
@@ -215,6 +230,33 @@ public class EditBatchDialog extends DialogWindow {
    */
   public void addConfirmListener(ComponentEventListener<ConfirmEvent> listener) {
     addListener(ConfirmEvent.class, listener);
+  }
+
+  public void addRemoveRowListener(ComponentEventListener<RemoveRowEvent> listener) {
+    addListener(RemoveRowEvent.class, listener);
+  }
+
+  public static class RemoveRowEvent extends ComponentEvent<EditBatchDialog> {
+
+    private final SampleInfo sampleInfo;
+    /**
+     * Creates a new event using the given source and indicator whether the event originated from
+     * the client side or the server side. Is used to remove the last sample row, but only if that
+     * is allowed (e.g. no datasets attached).
+     *
+     * @param source     the source component
+     * @param fromClient <code>true</code> if the event originated from the client
+     *                   side, <code>false</code> otherwise
+     * @param sampleInfo SampleInfo corresponding to the row to be removed
+     */
+    public RemoveRowEvent(EditBatchDialog source, boolean fromClient, SampleInfo sampleInfo) {
+      super(source, fromClient);
+      this.sampleInfo = sampleInfo;
+    }
+
+    public SampleInfo getSampleInfo() {
+      return sampleInfo;
+    }
   }
 
   public static class CancelEvent extends ComponentEvent<EditBatchDialog> {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleBatchInformationSpreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleBatchInformationSpreadsheet.java
@@ -22,6 +22,7 @@ import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyCl
 import life.qbic.projectmanagement.domain.model.sample.AnalysisMethod;
 import life.qbic.projectmanagement.domain.model.sample.SampleCode;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
+import org.apache.poi.ss.usermodel.Cell;
 
 /**
  * A spreadsheet used for sample batch information
@@ -108,6 +109,14 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
 
     for (int i = 0; i < INITIAL_ROW_COUNT; i++) {
       addEmptyRow();
+    }
+  }
+
+  public void markCellInColumnInvalid(String colName, int dataRowIndex) {
+    Optional<Cell> cell = super.getCellByColNameAndRowIndex(colName, dataRowIndex);
+    if(cell.isPresent()) {
+      super.markCellAsInvalid(cell.get());
+      super.refreshCells(Arrays.asList(cell.get()));
     }
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleBatchInformationSpreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleBatchInformationSpreadsheet.java
@@ -22,7 +22,6 @@ import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyCl
 import life.qbic.projectmanagement.domain.model.sample.AnalysisMethod;
 import life.qbic.projectmanagement.domain.model.sample.SampleCode;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
-import org.apache.poi.ss.usermodel.Cell;
 
 /**
  * A spreadsheet used for sample batch information
@@ -112,13 +111,6 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
     }
   }
 
-  public void markCellInColumnInvalid(String colName, int dataRowIndex) {
-    Optional<Cell> cell = super.getCellByColNameAndRowIndex(colName, dataRowIndex);
-    if(cell.isPresent()) {
-      super.markCellAsInvalid(cell.get());
-      super.refreshCells(Arrays.asList(cell.get()));
-    }
-  }
 
   /**
    * adds an empty row to the spreadsheet


### PR DESCRIPTION
Pressing the **remove row** button in the **edit batch** dialog to remove samples now sends an event that checks if samples can be removed (or if data is attached).
If users are not allowed to remove that sample, the spreadsheet is used to inform the user about this, similar to other validation errors.
This fixes the issue that a notification popup would break the spreadsheet UI.
Removing samples outside of the spreadsheet context (deleting the whole batch) will still show the respective notification.