### PR TITLE
Fix propagation of sample edits

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
@@ -10,6 +10,7 @@ import jakarta.annotation.security.PermitAll;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -253,8 +254,12 @@ public class SampleContentComponent extends Div {
         editBatchEvent.batchPreview().batchId()).stream().toList();
     var experimentalGroups = experimentInformationService.experimentalGroupsFor(
         context.experimentId().orElseThrow());
-    List<SampleBatchInformationSpreadsheet.SampleInfo> sampleInfos = samples.stream()
-        .map(sample -> convertSampleToSampleInfo(sample, experimentalGroups)).toList();
+
+    // need to create mutable list to order samples
+    List<SampleBatchInformationSpreadsheet.SampleInfo> sampleInfos = new ArrayList<>(samples.stream()
+        .map(sample -> convertSampleToSampleInfo(sample, experimentalGroups)).toList());
+    sampleInfos.sort(Comparator.comparing(o -> o.getSampleCode().code()));
+
     EditBatchDialog editBatchDialog = new EditBatchDialog(experiment.getName(),
         experiment.getSpecies().stream().toList(), experiment.getSpecimens().stream().toList(),
         experiment.getAnalytes().stream().toList(), experiment.getExperimentalGroups(),

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/EditBatchDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/EditBatchDialog.java
@@ -10,9 +10,6 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import life.qbic.datamanager.views.general.DialogWindow;
@@ -48,12 +45,7 @@ public class EditBatchDialog extends DialogWindow {
 
     this.batchId = batchId;
 
-    // sort by sample code
-    List<SampleInfo> mutableSampleList = new ArrayList<>(existingSamples.stream().toList());
-
-    Collections.sort(mutableSampleList, Comparator.comparing(o -> o.getSampleCode().code()));
-
-    this.existingSamples = mutableSampleList;
+    this.existingSamples = existingSamples.stream().map(SampleInfo::copy).toList();
 
     spreadsheet = new SampleBatchInformationSpreadsheet(experimentalGroups, species, specimen,
         analytes, true);
@@ -120,7 +112,8 @@ public class EditBatchDialog extends DialogWindow {
         });
 
     spreadsheet.resetRows();
-    for (SampleInfo existingSample : this.existingSamples) {
+    // don't use field, but parameter in order to compare edits later
+    for (SampleInfo existingSample : existingSamples) {
       spreadsheet.addRow(existingSample);
     }
   }


### PR DESCRIPTION
Samples are now sorted outside of the Edit Batch dialog, fixing a problem where metadata changes were not detected any more.