### PR TITLE
Fix sample editing and project search in openBIS

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
@@ -45,7 +45,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import life.qbic.logging.api.Logger;
 import life.qbic.openbis.openbisclient.OpenBisClient;
 import life.qbic.projectmanagement.domain.model.project.Project;
@@ -234,8 +233,14 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
     handleOperations(operation);
   }
 
+  /**
+   * Performs a list of provided update operations. Creates a mutable list beforehand, as that is
+   * necessary
+   * @param samplesToUpdate List of SampleUpdate objects containing changes to one or more samples
+   */
   private void updateOpenbisSamples(List<SampleUpdate> samplesToUpdate) {
-    IOperation operation = new UpdateSamplesOperation(samplesToUpdate);
+    List<SampleUpdate> mutableUpdates = new ArrayList<>(samplesToUpdate);
+    IOperation operation = new UpdateSamplesOperation(mutableUpdates);
     handleOperations(operation);
   }
 
@@ -344,8 +349,7 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
 
   private List<SampleUpdate> convertSamplesToSampleUpdates(
       Collection<life.qbic.projectmanagement.domain.model.sample.Sample> updatedSamples) {
-    // do not replace the collect with "toList()" - this creates an immutable list, which crashes the transaction
-    return updatedSamples.stream().map(this::createSampleUpdate).collect(Collectors.toList());
+    return updatedSamples.stream().map(this::createSampleUpdate).toList();
   }
 
   record VocabularyTerm(String code, String label, String description) {

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
@@ -344,6 +344,7 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
 
   private List<SampleUpdate> convertSamplesToSampleUpdates(
       Collection<life.qbic.projectmanagement.domain.model.sample.Sample> updatedSamples) {
+    // do not replace the collect with "toList()" - this creates an immutable list, which crashes the transaction
     return updatedSamples.stream().map(this::createSampleUpdate).collect(Collectors.toList());
   }
 

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import life.qbic.logging.api.Logger;
 import life.qbic.openbis.openbisclient.OpenBisClient;
 import life.qbic.projectmanagement.domain.model.project.Project;
@@ -314,10 +315,7 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
       Collection<life.qbic.projectmanagement.domain.model.sample.Sample> samples)
       throws SampleNotUpdatedException {
     try {
-      /*FixMe Throws org.springframework.remoting.RemoteAccessException: Could not access HTTP invoker remote service
-          and invalid stream header: 3C68746D
-      */
-      // updateOpenbisSamples(convertSamplesToSampleUpdates(samples));
+      updateOpenbisSamples(convertSamplesToSampleUpdates(samples));
     } catch (RuntimeException e) {
       throw new SampleNotUpdatedException(
           "Samples could not be updated due to " + e.getCause() + " with " + e.getMessage());
@@ -346,7 +344,7 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
 
   private List<SampleUpdate> convertSamplesToSampleUpdates(
       Collection<life.qbic.projectmanagement.domain.model.sample.Sample> updatedSamples) {
-    return updatedSamples.stream().map(this::createSampleUpdate).toList();
+    return updatedSamples.stream().map(this::createSampleUpdate).collect(Collectors.toList());
   }
 
   record VocabularyTerm(String code, String label, String description) {

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
@@ -437,7 +437,7 @@ public class OpenbisConnector implements QbicProjectDataRepo, QbicSampleDataRepo
 
   @Override
   public boolean projectExists(ProjectCode projectCode) {
-    return !searchProjectsByCode(projectCode.toString()).isEmpty();
+    return !searchProjectsByCode(projectCode.value()).isEmpty();
   }
 
   // Convenience RTE to describe connection issues

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/AnalysisMethod.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/AnalysisMethod.java
@@ -60,7 +60,7 @@ public enum AnalysisMethod {
   Proteomics related analysis methods
    */
 
-  PROTEOMICS("PROTEOMIICS", "Proteomics", ""),
+  PROTEOMICS("PROTEOMICS", "Proteomics", ""),
 
   PHOSPHO_PROTEOMICS("PHOSPHO", "Phosphoproteomics", ""),
 


### PR DESCRIPTION
* Fixes and enables sample metadata update in openBIS, which was caused by an immutable list
* Fixes project search in openBIS, which was not searching for the project code
* Fixes a typo in Analysis Type