### PR TITLE
only load unique ontology terms

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/OntologyFilterConnector.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/OntologyFilterConnector.java
@@ -36,7 +36,7 @@ public class OntologyFilterConnector {
             query.getOffset(),
             query.getLimit(),
             sortOrders);
-    return ontologyClassEntities.stream().map(OntologyClassDTO::from);
+    return ontologyClassEntities.stream().map(OntologyClassDTO::from).distinct();
   }
 
 }


### PR DESCRIPTION
* queries to the ontology database (via filter input) now return a list of unique values, fixing an issue with the displayed components
* this is only an additional safeguard, as duplicates will be removed from the table and the scripts to fill the table adapted

See also: https://github.com/qbicsoftware/dm-onthology-terms/pull/2