### PR TITLE
Show number of samples, creation- and modificationdate in batchdetailscomponent

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/DeletionService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/DeletionService.java
@@ -97,19 +97,19 @@ public class DeletionService {
     deletedBatchId.onError(error -> {
       throw new ApplicationException("Could not delete batch " + batchId);
     });
-    deleteSamples(projectId, samples);
+    deleteSamples(projectId, batchId, samples);
     return deletedBatchId.getValue();
   }
 
 
   @Transactional
   public void deleteSamples(
-      ProjectId projectId, Collection<SampleId> samplesCollection) {
+      ProjectId projectId, BatchId batchId, Collection<SampleId> samplesCollection) {
     var project = projectInformationService.find(projectId);
     if (project.isEmpty()) {
       throw new IllegalArgumentException("Could not find project " + projectId);
     }
-    sampleDomainService.deleteSamples(project.get(), samplesCollection);
+    sampleDomainService.deleteSamples(project.get(), batchId, samplesCollection);
   }
 
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/batch/BatchRegistrationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/batch/BatchRegistrationService.java
@@ -98,6 +98,21 @@ public class BatchRegistrationService {
     }
   }
 
+  public Result<BatchId, ResponseCode> deleteSampleFromBatch(SampleId sampleId, BatchId batchId) {
+    var searchResult = batchRepository.find(batchId);
+    if (searchResult.isEmpty()) {
+      return Result.fromError(ResponseCode.BATCHES_COULD_NOT_BE_RETRIEVED);
+    } else {
+      Batch batch = searchResult.get();
+      batch.removeSample(sampleId);
+      var result = batchRepository.update(batch);
+      if (result.isError()) {
+        return Result.fromError(ResponseCode.BATCH_UPDATE_FAILED);
+      }
+      return Result.fromValue(batch.batchId());
+    }
+  }
+
   /**
    * Edits the information contained within a {@link Batch} and its corresponding registered
    * {@link Sample}
@@ -150,7 +165,7 @@ public class BatchRegistrationService {
       sampleRegistrationService.updateSamples(projectId, editedSamples);
     }
     if (!deletedSamples.isEmpty()) {
-      deletionService.deleteSamples(projectId, deletedSamples);
+      deletionService.deleteSamples(projectId, batchId, deletedSamples);
     }
     return Result.fromValue(batch.batchId());
   }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/policy/SampleDeletedPolicy.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/policy/SampleDeletedPolicy.java
@@ -1,0 +1,36 @@
+package life.qbic.projectmanagement.application.policy;
+
+import life.qbic.domain.concepts.DomainEventDispatcher;
+import life.qbic.projectmanagement.application.policy.directive.DeleteSampleFromBatch;
+import life.qbic.projectmanagement.domain.model.batch.Batch;
+import life.qbic.projectmanagement.domain.model.sample.event.SampleDeleted;
+
+/**
+ * <b>Policy: Sample Deleted</b>
+ * <p>
+ * A collection of all directives that need to be executed after a sample has been deleted
+ * <p>
+ * The policy subscribes to events of type
+ * {@link SampleDeleted} and ensures the
+ * registration of all business required directives.
+ *
+ * @since 1.0.0
+ */
+public class SampleDeletedPolicy {
+
+  private final DeleteSampleFromBatch deleteSampleFromBatch;
+
+  /**
+   * Creates an instance of a {@link SampleDeletedPolicy} object.
+   * <p>
+   * All directives will be created and subscribed upon instantiation.
+   *
+   * @param deleteSampleFromBatch directive to remove the affected sample from
+   *                         {@link Batch}
+   * @since 1.0.0
+   */
+  public SampleDeletedPolicy(DeleteSampleFromBatch deleteSampleFromBatch) {
+    this.deleteSampleFromBatch = deleteSampleFromBatch;
+    DomainEventDispatcher.instance().subscribe(this.deleteSampleFromBatch);
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/DeleteSampleFromBatch.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/DeleteSampleFromBatch.java
@@ -14,7 +14,7 @@ import org.jobrunr.scheduling.JobScheduler;
 import org.springframework.stereotype.Component;
 
 /**
- * <b>Directive: Delete Sample to Batch</b>
+ * <b>Directive: Delete Sample from Batch</b>
  * <p>
  * After a sample has been deleted, we need to update the batch and remove
  * the sample reference of the deleted sample.

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/DeleteSampleFromBatch.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/DeleteSampleFromBatch.java
@@ -1,0 +1,56 @@
+package life.qbic.projectmanagement.application.policy.directive;
+
+import static life.qbic.logging.service.LoggerFactory.logger;
+
+import life.qbic.domain.concepts.DomainEvent;
+import life.qbic.domain.concepts.DomainEventSubscriber;
+import life.qbic.logging.api.Logger;
+import life.qbic.projectmanagement.application.batch.BatchRegistrationService;
+import life.qbic.projectmanagement.domain.model.batch.BatchId;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
+import life.qbic.projectmanagement.domain.model.sample.event.SampleDeleted;
+import org.jobrunr.jobs.annotations.Job;
+import org.jobrunr.scheduling.JobScheduler;
+import org.springframework.stereotype.Component;
+
+/**
+ * <b>Directive: Delete Sample to Batch</b>
+ * <p>
+ * After a sample has been deleted, we need to update the batch and remove
+ * the sample reference of the deleted sample.
+ *
+ * @since 1.0.0
+ */
+@Component
+public class DeleteSampleFromBatch implements DomainEventSubscriber<SampleDeleted> {
+
+  private static final Logger log = logger(DeleteSampleFromBatch.class);
+  private final BatchRegistrationService batchRegistrationService;
+  private final JobScheduler jobScheduler;
+
+  public DeleteSampleFromBatch(BatchRegistrationService batchRegistrationService,
+      JobScheduler jobScheduler) {
+    this.batchRegistrationService = batchRegistrationService;
+    this.jobScheduler = jobScheduler;
+  }
+
+  @Override
+  public Class<? extends DomainEvent> subscribedToEventType() {
+    return SampleDeleted.class;
+  }
+
+  @Override
+  public void handleEvent(SampleDeleted event) {
+    jobScheduler.enqueue(() -> deleteSampleFromBatch(event.deletedSample(), event.assignedBatch()));
+  }
+
+  @Job(name = "Delete_Sample_From_Batch")
+  public void deleteSampleFromBatch(SampleId sample, BatchId batch) throws RuntimeException {
+    batchRegistrationService.deleteSampleFromBatch(sample, batch).onError(responseCode -> {
+      throw new RuntimeException(
+          String.format("Deletion of sample %s from batch %s failed, response code was %s ", sample,
+              batch,
+              responseCode));
+    });
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/batch/Batch.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/batch/Batch.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +35,12 @@ public class Batch {
   @Column(name = "isPilot")
   private boolean pilot;
 
+  @Column(name = "lastModified")
+  private Instant lastModified;
+
+  @Column(name = "createdOn")
+  private Instant createdOn;
+
   @ElementCollection(targetClass = SampleId.class, fetch = FetchType.EAGER)
   @CollectionTable(name = "sample_batches_sampleid", joinColumns = @JoinColumn(name = "batch_id"))
   private List<SampleId> sampleIds;
@@ -47,6 +54,8 @@ public class Batch {
     this.label = Objects.requireNonNull(label);
     this.sampleIds = Objects.requireNonNull(sampleIds.stream().toList());
     this.pilot = isPilot;
+    this.lastModified = Instant.now();
+    this.createdOn = Instant.now();
   }
 
   /**
@@ -78,17 +87,22 @@ public class Batch {
 
   public void addSample(SampleId sampleId) {
     this.sampleIds.add(sampleId);
+    this.lastModified = Instant.now();
   }
 
   public void removeSample(SampleId sampleToRemove) {
     this.sampleIds.remove(sampleToRemove);
+    this.lastModified = Instant.now();
   }
 
   public void setLabel(String label) {
     this.label = label;
+    this.lastModified = Instant.now();
   }
+
   public void setPilot(boolean pilot) {
     this.pilot = pilot;
+    this.lastModified = Instant.now();
   }
 
 
@@ -103,6 +117,19 @@ public class Batch {
   public boolean isPilot() {
     return pilot;
   }
+
+  public Instant lastModified() {
+    return lastModified;
+  }
+
+  public Instant createdOn() {
+    return createdOn;
+  }
+
+  public List<SampleId> samples() {
+    return sampleIds;
+  }
+
 
   @Override
   public boolean equals(Object o) {
@@ -119,5 +146,17 @@ public class Batch {
   @Override
   public int hashCode() {
     return Objects.hash(id);
+  }
+
+  @Override
+  public String toString() {
+    return "Batch{" +
+        "id=" + id +
+        ", label='" + label + '\'' +
+        ", pilot=" + pilot +
+        ", lastModified=" + lastModified +
+        ", createdOn=" + createdOn +
+        ", sampleIds=" + sampleIds +
+        '}';
   }
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/event/SampleDeleted.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/event/SampleDeleted.java
@@ -1,0 +1,62 @@
+package life.qbic.projectmanagement.domain.model.sample.event;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serial;
+import java.time.Instant;
+import java.util.Objects;
+import life.qbic.domain.concepts.DomainEvent;
+import life.qbic.projectmanagement.domain.model.batch.BatchId;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
+
+/**
+ * <b>Sample Deleted - Domain Event</b>
+ * <p>
+ * A registered sample has been deleted
+ *
+ * @since 1.0.0
+ */
+public class SampleDeleted extends DomainEvent {
+
+  @Serial
+  private static final long serialVersionUID = 8134640209226646506L;
+  private final Instant occurredOn;
+  @JsonProperty("batchId")
+  private final BatchId assignedBatch;
+  @JsonProperty("sampleId")
+  private final SampleId deletedSample;
+
+  private SampleDeleted(Instant occurredOn, BatchId assignedBatch, SampleId deletedSample) {
+    this.occurredOn = Objects.requireNonNull(occurredOn);
+    this.assignedBatch = Objects.requireNonNull(assignedBatch);
+    this.deletedSample = Objects.requireNonNull(deletedSample);
+  }
+
+  /**
+   * Creates a new {@link SampleDeleted} object instance.
+   *
+   * @param assignedBatch    the batch reference the sample will be deleted from
+   * @param deletedSample the sample reference of the to be deleted sample
+   * @return a new instance of this domain event
+   * @since 1.0.0
+   */
+  public static SampleDeleted create(BatchId assignedBatch, SampleId deletedSample) {
+    return new SampleDeleted(Instant.now(), assignedBatch, deletedSample);
+  }
+
+  @JsonGetter("occurredOn")
+  @Override
+  public Instant occurredOn() {
+    return this.occurredOn;
+  }
+
+  @JsonGetter("assignedBatch")
+  public BatchId assignedBatch() {
+    return this.assignedBatch;
+  }
+
+  @JsonGetter("deletedSample")
+  public SampleId deletedSample() {
+    return this.deletedSample;
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/service/SampleDomainService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/service/SampleDomainService.java
@@ -8,12 +8,14 @@ import java.util.Objects;
 import life.qbic.application.commons.Result;
 import life.qbic.domain.concepts.DomainEventDispatcher;
 import life.qbic.projectmanagement.application.batch.SampleUpdateRequest;
+import life.qbic.projectmanagement.domain.model.batch.BatchId;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.sample.Sample;
 import life.qbic.projectmanagement.domain.model.sample.SampleCode;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
 import life.qbic.projectmanagement.domain.model.sample.SampleOrigin;
 import life.qbic.projectmanagement.domain.model.sample.SampleRegistrationRequest;
+import life.qbic.projectmanagement.domain.model.sample.event.SampleDeleted;
 import life.qbic.projectmanagement.domain.model.sample.event.SampleRegistered;
 import life.qbic.projectmanagement.domain.repository.SampleRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,10 +79,16 @@ public class SampleDomainService {
         sampleRepository.updateAll(project, samplesToUpdate);
     }
 
-    public void deleteSamples(Project project,
+    public void deleteSamples(Project project, BatchId batchId,
         Collection<SampleId> samples) {
         Objects.requireNonNull(samples);
         sampleRepository.deleteAll(project, samples);
+        samples.forEach(sampleId -> dispatchSuccessfulSampleDeletion(sampleId, batchId));
+    }
+
+    private void dispatchSuccessfulSampleDeletion(SampleId sampleId, BatchId batchId) {
+        SampleDeleted sampleDeleted = SampleDeleted.create(batchId, sampleId);
+        DomainEventDispatcher.instance().dispatch(sampleDeleted);
     }
 
     private void dispatchSuccessfulSampleRegistration(Sample sample) {

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/policy/SampleDeletedPolicySpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/policy/SampleDeletedPolicySpec.groovy
@@ -1,0 +1,39 @@
+package life.qbic.projectmanagement.application.policy
+
+import life.qbic.domain.concepts.DomainEventDispatcher
+import life.qbic.projectmanagement.application.policy.directive.DeleteSampleFromBatch
+import life.qbic.projectmanagement.domain.model.batch.BatchId
+import life.qbic.projectmanagement.domain.model.sample.SampleId
+import life.qbic.projectmanagement.domain.model.sample.event.SampleDeleted
+import spock.lang.Specification
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+
+class SampleDeletedPolicySpec extends Specification {
+
+    def "Given a sample deletion event, the directive to remove the sample from a batch is executed"() {
+        given:
+        SampleDeleted sampleDeleted = SampleDeleted.create(BatchId.create(), SampleId.create())
+
+        and:
+        DeleteSampleFromBatch deleteSampleFromBatch = Mock(DeleteSampleFromBatch.class)
+        deleteSampleFromBatch.subscribedToEventType() >> SampleDeleted.class
+
+        and:
+        SampleDeletedPolicy sampleDeletedPolicy = new SampleDeletedPolicy(deleteSampleFromBatch)
+
+        when:
+        DomainEventDispatcher.instance().dispatch(sampleDeleted)
+
+        then:
+        1 * deleteSampleFromBatch.handleEvent(sampleDeleted)
+    }
+
+
+}

--- a/user-interface/frontend/themes/datamanager/components/div.css
+++ b/user-interface/frontend/themes/datamanager/components/div.css
@@ -26,9 +26,9 @@
 }
 
 .batch-details-component .editor-buttons {
-  display: flex;
+  display: inline-flex;
   gap: var(--lumo-space-s);
-  justify-content: end;
+  justify-content: start;
 }
 
 .batch-details-component .title-and-controls {

--- a/user-interface/src/main/java/life/qbic/datamanager/AppConfig.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/AppConfig.java
@@ -36,9 +36,11 @@ import life.qbic.projectmanagement.application.communication.broadcasting.Messag
 import life.qbic.projectmanagement.application.policy.BatchRegisteredPolicy;
 import life.qbic.projectmanagement.application.policy.ProjectAccessGrantedPolicy;
 import life.qbic.projectmanagement.application.policy.ProjectRegisteredPolicy;
+import life.qbic.projectmanagement.application.policy.SampleDeletedPolicy;
 import life.qbic.projectmanagement.application.policy.SampleRegisteredPolicy;
 import life.qbic.projectmanagement.application.policy.directive.AddSampleToBatch;
 import life.qbic.projectmanagement.application.policy.directive.CreateNewSampleStatisticsEntry;
+import life.qbic.projectmanagement.application.policy.directive.DeleteSampleFromBatch;
 import life.qbic.projectmanagement.application.policy.directive.InformUserAboutGrantedAccess;
 import life.qbic.projectmanagement.application.policy.directive.InformUsersAboutBatchRegistration;
 import life.qbic.projectmanagement.application.policy.integration.UserActivated;
@@ -195,6 +197,13 @@ public class AppConfig {
       BatchRegistrationService batchRegistrationService, JobScheduler jobScheduler) {
     var addSampleToBatch = new AddSampleToBatch(batchRegistrationService, jobScheduler);
     return new SampleRegisteredPolicy(addSampleToBatch);
+  }
+
+  @Bean
+  public SampleDeletedPolicy sampleDeletedPolicy(BatchRegistrationService batchRegistrationService,
+      JobScheduler jobScheduler) {
+    var deleteSampleFromBatch = new DeleteSampleFromBatch(batchRegistrationService, jobScheduler);
+    return new SampleDeletedPolicy(deleteSampleFromBatch);
   }
 
   @Bean

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/BatchDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/BatchDetailsComponent.java
@@ -3,6 +3,7 @@ package life.qbic.datamanager.views.projects.project.samples;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.html.Div;
@@ -143,6 +144,9 @@ public class BatchDetailsComponent extends Div implements Serializable {
     Button viewButton = new Button(viewIcon);
     Button editButton = new Button(editIcon);
     Button deleteButton = new Button(deleteIcon);
+    viewButton.addThemeVariants(ButtonVariant.LUMO_ICON, ButtonVariant.LUMO_TERTIARY_INLINE);
+    editButton.addThemeVariants(ButtonVariant.LUMO_ICON, ButtonVariant.LUMO_TERTIARY_INLINE);
+    deleteButton.addThemeVariants(ButtonVariant.LUMO_ICON, ButtonVariant.LUMO_TERTIARY_INLINE);
     viewButton.addClickListener(e -> fireEvent(new ViewBatchEvent(this, batchPreview,
         e.isFromClient())));
     deleteButton.addClickListener(e -> fireEvent(new DeleteBatchEvent(this, batchPreview.batchId(),

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
@@ -40,7 +40,6 @@ import life.qbic.projectmanagement.domain.model.batch.Batch;
 import life.qbic.projectmanagement.domain.model.batch.BatchId;
 import life.qbic.projectmanagement.domain.model.experiment.BiologicalReplicate;
 import life.qbic.projectmanagement.domain.model.experiment.Experiment;
-import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentalGroup;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
@@ -74,7 +73,7 @@ public class SampleContentComponent extends Div {
   private final transient SampleInformationService sampleInformationService;
   private final transient DeletionService deletionService;
   private final transient SampleDetailsComponent sampleDetailsComponent;
-  private final BatchDetailsComponent batchDetailsComponent;
+  private final transient BatchDetailsComponent batchDetailsComponent;
 
   public SampleContentComponent(@Autowired ProjectInformationService projectInformationService,
       @Autowired ExperimentInformationService experimentInformationService,
@@ -119,9 +118,7 @@ public class SampleContentComponent extends Div {
   public void setContext(Context context) {
     this.context = context;
     ProjectId projectId = context.projectId().orElseThrow();
-    ExperimentId experimentId = context.experimentId().orElseThrow();
-    batchDetailsComponent.setExperiment(
-        experimentInformationService.find(experimentId).orElseThrow());
+    batchDetailsComponent.setContext(context);
     projectInformationService.find(projectId)
         .ifPresentOrElse(
             project -> {
@@ -169,7 +166,6 @@ public class SampleContentComponent extends Div {
   private void reload() {
     setContext(context);
   }
-
 
   private void registerBatch(ConfirmEvent confirmEvent) {
     String batchLabel = confirmEvent.getData().batchName();

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleDetailsComponent.java
@@ -66,8 +66,8 @@ public class SampleDetailsComponent extends PageArea implements Serializable {
   private final Disclaimer noGroupsDefinedDisclaimer;
   private final Disclaimer noSamplesRegisteredDisclaimer;
   private final Grid<SamplePreview> sampleGrid;
-  private final ExperimentInformationService experimentInformationService;
-  private final SampleInformationService sampleInformationService;
+  private final transient ExperimentInformationService experimentInformationService;
+  private final transient SampleInformationService sampleInformationService;
 
   public SampleDetailsComponent(@Autowired SampleInformationService sampleInformationService,
       @Autowired ExperimentInformationService experimentInformationService) {
@@ -193,10 +193,8 @@ public class SampleDetailsComponent extends PageArea implements Serializable {
     if (context.projectId().isEmpty()) {
       throw new ApplicationException("no project id in context " + context);
     }
-
     this.context = context;
-    ExperimentId experimentId = context.experimentId()
-        .orElseThrow(() -> new ApplicationException("no experiment id in context " + context));
+    ExperimentId experimentId = context.experimentId().get();
     setExperiment(experimentInformationService.find(experimentId).orElseThrow());
   }
 


### PR DESCRIPTION
**What was changed** 
This PR introduces the logic to show and adjust the number of samples, the modification date and creation date for a batch in the batchgrid. 

**Technical Issues**
1.) To show the correct number of samples after a batch editing has taken place, a seperate "SampleDeletion" domain event has to be published and consumed as a job by jobrunr correctly.
This works locally, however if the job event is taken by qpylon then the job can't be run since the necessary methods are only implemented in this branch

2.) Because of the "lag" introduced through the job consumption via jobrunr during sample deletion or creation, the sample number is only adjusted if the page is reloaded after the job has run in jobrunr successfully. 