### PR TITLE
add optional sample property 'organism id'

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/batch/SampleUpdateRequest.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/batch/SampleUpdateRequest.java
@@ -19,6 +19,7 @@ public record SampleUpdateRequest(SampleId sampleId, SampleInformation sampleInf
    * Sample update request.
    * <p>
    * @param sampleLabel          a human-readable semantic descriptor of the sample
+   * @param organismId           optional identifier of the sample's source patient or organism
    * @param analysisMethod       analysis method to be performed
    * @param biologicalReplicate  the biological replicate the sample has been taken from
    * @param experimentalGroup    the experimental group the sample is part of
@@ -27,7 +28,8 @@ public record SampleUpdateRequest(SampleId sampleId, SampleInformation sampleInf
    * @param analyte              the analyte the sample belongs to
    * @param comment              comment relating to the sample
    */
-  public record SampleInformation(String sampleLabel, AnalysisMethod analysisMethod,
+  public record SampleInformation(String sampleLabel, String organismId,
+                                  AnalysisMethod analysisMethod,
                                   BiologicalReplicate biologicalReplicate,
                                   ExperimentalGroup experimentalGroup, OntologyClassDTO species,
                                   OntologyClassDTO specimen, OntologyClassDTO analyte,

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/sample/SamplePreview.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/sample/SamplePreview.java
@@ -45,6 +45,9 @@ public class SamplePreview {
   private String bioReplicateLabel;
   @Column(name = "label")
   private String sampleLabel;
+
+  @Column(name = "organism_id")
+  private String organismId;
   private String comment;
   @Column(name = "analysis_method")
   private String analysisMethod;
@@ -63,8 +66,8 @@ public class SamplePreview {
   }
 
   private SamplePreview(ExperimentId experimentId, SampleId sampleId, String sampleCode,
-      String batchLabel, String bioReplicateLabel,
-      String sampleLabel, ExperimentalGroup experimentalGroup, OntologyClassDTO species,
+      String batchLabel, String bioReplicateLabel, String sampleLabel, String organismId,
+      ExperimentalGroup experimentalGroup, OntologyClassDTO species,
       OntologyClassDTO specimen, OntologyClassDTO analyte, String analysisMethod, String comment) {
     Objects.requireNonNull(experimentId);
     Objects.requireNonNull(sampleId);
@@ -90,6 +93,7 @@ public class SamplePreview {
     this.analysisMethod = analysisMethod;
     // optional columns
     this.comment = comment;
+    this.organismId = organismId;
   }
 
   /**
@@ -103,6 +107,7 @@ public class SamplePreview {
    * @param bioReplicateLabel the label of the {@link BiologicalReplicate} for the {@link Sample}
    *                          associated with this preview
    * @param sampleLabel       the label of the {@link Sample} associated with this preview
+   * @param organismId        optional identifier of the patient or organism a {@link Sample} was taken of
    * @param experimentalGroup the {@link ExperimentalGroup} for the {@link Sample} associated with
    *                          this preview
    * @param species           the {@link OntologyClassDTO} for the species of this {@link Sample}
@@ -118,10 +123,12 @@ public class SamplePreview {
   public static SamplePreview create(ExperimentId experimentId, SampleId sampleId,
       String sampleCode,
       String batchLabel, String bioReplicateLabel,
-      String sampleLabel, ExperimentalGroup experimentalGroup, OntologyClassDTO species,
-      OntologyClassDTO specimen, OntologyClassDTO analyte, String analysisMethod, String comment) {
+      String sampleLabel, String organismId, ExperimentalGroup experimentalGroup,
+      OntologyClassDTO species, OntologyClassDTO specimen, OntologyClassDTO analyte,
+      String analysisMethod, String comment) {
     return new SamplePreview(experimentId, sampleId, sampleCode, batchLabel, bioReplicateLabel,
-        sampleLabel, experimentalGroup, species, specimen, analyte, analysisMethod, comment);
+        sampleLabel, organismId, experimentalGroup, species, specimen, analyte, analysisMethod,
+        comment);
   }
 
   public ExperimentId experimentId() {
@@ -168,6 +175,8 @@ public class SamplePreview {
     return comment;
   }
 
+  public String organismId() { return organismId; }
+
   public ExperimentalGroup experimentalGroup() {
     return experimentalGroup;
   }
@@ -185,7 +194,7 @@ public class SamplePreview {
         sampleCode, that.sampleCode) && Objects.equals(sampleId, that.sampleId)
         && Objects.equals(batchLabel, that.batchLabel) && Objects.equals(
         bioReplicateLabel, that.bioReplicateLabel) && Objects.equals(sampleLabel,
-        that.sampleLabel)
+        that.sampleLabel) && Objects.equals(organismId, that.organismId)
         && Objects.equals(species, that.species) && Objects.equals(specimen,
         that.specimen) && Objects.equals(analyte, that.analyte) && Objects.equals(
         experimentalGroup, that.experimentalGroup) && Objects.equals(analysisMethod,
@@ -195,7 +204,7 @@ public class SamplePreview {
   @Override
   public int hashCode() {
     return Objects.hash(experimentId, sampleCode, sampleId, batchLabel, bioReplicateLabel,
-        sampleLabel,
+        sampleLabel, organismId,
         species, specimen, analyte, experimentalGroup, analysisMethod, comment);
   }
 
@@ -208,6 +217,7 @@ public class SamplePreview {
         ", batchLabel='" + batchLabel + '\'' +
         ", sampleSource='" + bioReplicateLabel + '\'' +
         ", sampleLabel='" + sampleLabel + '\'' +
+        ", organismId='" + organismId + '\'' +
         ", species='" + species + '\'' +
         ", specimen='" + specimen + '\'' +
         ", analyte='" + analyte + '\'' +

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/Sample.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/Sample.java
@@ -42,6 +42,8 @@ public class Sample {
   @AttributeOverride(name = "uuid", column = @Column(name = "sample_id"))
   private SampleId id;
   private String label;
+  @Column(name = "organism_id")
+  private String organismId;
   private String comment;
 
   @Column(name = "analysis_method")
@@ -54,13 +56,14 @@ public class Sample {
   @Embedded
   private SampleOrigin sampleOrigin;
 
-  private Sample(SampleId id, SampleCode sampleCode, BatchId assignedBatch, String label,
-      ExperimentId experimentId, Long experimentalGroupId, SampleOrigin sampleOrigin,
+  private Sample(SampleId id, SampleCode sampleCode, BatchId assignedBatch, String label, String
+      organismId, ExperimentId experimentId, Long experimentalGroupId, SampleOrigin sampleOrigin,
       BiologicalReplicateId replicateReference, AnalysisMethod analysisMethod, String comment
   ) {
     this.id = id;
     this.sampleCode = Objects.requireNonNull(sampleCode);
     this.label = label;
+    this.organismId = organismId;
     this.experimentId = experimentId;
     this.experimentalGroupId = experimentalGroupId;
     this.sampleOrigin = sampleOrigin;
@@ -87,8 +90,8 @@ public class Sample {
     SampleId sampleId = SampleId.create();
     return new Sample(sampleId, sampleCode,
         sampleRegistrationRequest.assignedBatch(),
-        sampleRegistrationRequest.label(), sampleRegistrationRequest.experimentId(),
-        sampleRegistrationRequest.experimentalGroupId(),
+        sampleRegistrationRequest.label(), sampleRegistrationRequest.organismId(),
+        sampleRegistrationRequest.experimentId(), sampleRegistrationRequest.experimentalGroupId(),
         sampleRegistrationRequest.sampleOrigin(), sampleRegistrationRequest.replicateReference(),
         sampleRegistrationRequest.analysisMethod(), sampleRegistrationRequest.comment());
   }
@@ -105,13 +108,10 @@ public class Sample {
     return this.sampleCode;
   }
 
-  public SampleOrigin sampleOrigin() {
-    return this.sampleOrigin;
-  }
+  public SampleOrigin sampleOrigin() { return this.sampleOrigin; }
 
-  public String label() {
-    return this.label;
-  }
+  public String label() { return this.label; }
+  public String organismId() { return this.organismId; }
 
   public Optional<String> comment() {
     return Optional.ofNullable(comment);
@@ -145,6 +145,8 @@ public class Sample {
   public void setLabel(String label) {
     this.label = label;
   }
+
+  public void setOrganismId(String organismId) { this.organismId = organismId; }
 
   public void setComment(String comment) {
     this.comment = comment;

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/SampleRegistrationRequest.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/SampleRegistrationRequest.java
@@ -10,6 +10,7 @@ import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
  * Serves as a parameter object for sample creation.
  *
  * @param label               a human-readable semantic descriptor of the sample
+ * @param organismId          optional identifier of the patient or organism a sample was taken of
  * @param assignedBatch       the assigned batch
  * @param experimentId        the experiment reference
  * @param experimentalGroupId the experimental group id the sample is part of
@@ -17,19 +18,20 @@ import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
  * @param sampleOrigin        information about the sample origin.
  * @param analysisMethod      analysis method to be performed
  * @param comment             comment relating to the sample
+ *
  * @since 1.0.0
  */
-public record SampleRegistrationRequest(String label, BatchId assignedBatch,
+public record SampleRegistrationRequest(String label, String organismId, BatchId assignedBatch,
                                         ExperimentId experimentId, Long experimentalGroupId,
                                         BiologicalReplicateId replicateReference,
                                         SampleOrigin sampleOrigin, AnalysisMethod analysisMethod,
                                         String comment) {
 
-  public SampleRegistrationRequest(String label, BatchId assignedBatch, ExperimentId experimentId,
-      Long experimentalGroupId, BiologicalReplicateId replicateReference,
-      SampleOrigin sampleOrigin, AnalysisMethod analysisMethod,
-      String comment) {
+  public SampleRegistrationRequest(String label, String organismId, BatchId assignedBatch,
+      ExperimentId experimentId, Long experimentalGroupId, BiologicalReplicateId replicateReference,
+      SampleOrigin sampleOrigin, AnalysisMethod analysisMethod, String comment) {
     this.label = Objects.requireNonNull(label);
+    this.organismId = organismId;
     this.assignedBatch = Objects.requireNonNull(assignedBatch);
     this.experimentId = Objects.requireNonNull(experimentId);
     this.experimentalGroupId = Objects.requireNonNull(experimentalGroupId);
@@ -39,6 +41,5 @@ public record SampleRegistrationRequest(String label, BatchId assignedBatch,
     this.comment = comment;
 
   }
-
 
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/service/SampleDomainService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/service/SampleDomainService.java
@@ -65,6 +65,7 @@ public class SampleDomainService {
                     sampleUpdateRequest -> sampleUpdateRequest.sampleId().equals(sample.sampleId()))
                 .findFirst().orElseThrow();
             sample.setLabel(sampleInfo.sampleInformation().sampleLabel());
+            sample.setOrganismId(sampleInfo.sampleInformation().organismId());
             sample.setAnalysisMethod(sampleInfo.sampleInformation().analysisMethod());
             sample.setSampleOrigin(SampleOrigin.create(sampleInfo.sampleInformation().species(),
                 sampleInfo.sampleInformation().specimen(),

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/SampleRegistrationServiceSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/SampleRegistrationServiceSpec.groovy
@@ -43,7 +43,7 @@ class SampleRegistrationServiceSpec extends Specification {
     def "Invalid SampleRegistrationRequests returns a Result containing a SAMPLE_REGISTRATION_FAILED response code"() {
         given:
         SampleOrigin sampleOrigin = SampleOrigin.create(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO())
-        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("my_label", BatchId.create(), ExperimentId.create(), 5, BiologicalReplicateId.create(), sampleOrigin, AnalysisMethod.ATAC_SEQ, "no comment")
+        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("my_label", "my patient", BatchId.create(), ExperimentId.create(), 5, BiologicalReplicateId.create(), sampleOrigin, AnalysisMethod.ATAC_SEQ, "no comment")
         SampleCode sampleCode = SampleCode.create("QABCDE")
         sampleCodeService.generateFor(projectId) >> Result.fromValue(sampleCode)
         Map<SampleCode, SampleRegistrationRequest> sampleCodesToRegistrationRequests = new HashMap<>()
@@ -64,7 +64,7 @@ class SampleRegistrationServiceSpec extends Specification {
     def "Valid SampleRegistrationRequests returns a Result with the list of registered Samples"() {
         given:
         SampleOrigin sampleOrigin = SampleOrigin.create(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO())
-        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("my_label", BatchId.create(), ExperimentId.create(), 4, BiologicalReplicateId.create(), sampleOrigin, AnalysisMethod.ATAC_SEQ, "a comment")
+        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("my_label","my patient", BatchId.create(), ExperimentId.create(), 4, BiologicalReplicateId.create(), sampleOrigin, AnalysisMethod.ATAC_SEQ, "a comment")
         SampleCode sampleCode = SampleCode.create("QABCDE")
         Sample sample = Sample.create(sampleCode, sampleRegistrationRequest)
         sampleCodeService.generateFor(projectId) >> Result.fromValue(sampleCode)
@@ -87,7 +87,7 @@ class SampleRegistrationServiceSpec extends Specification {
     def "If project cannot be found, valid SampleRegistrationRequests returns a Result containing a SAMPLE_REGISTRATION_FAILED response code"() {
         given:
         SampleOrigin sampleOrigin = SampleOrigin.create(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO())
-        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("my_label", BatchId.create(), ExperimentId.create(), 4, BiologicalReplicateId.create(), sampleOrigin, AnalysisMethod.ATAC_SEQ, "a comment")
+        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("my_label","my patient", BatchId.create(), ExperimentId.create(), 4, BiologicalReplicateId.create(), sampleOrigin, AnalysisMethod.ATAC_SEQ, "a comment")
         SampleCode sampleCode = SampleCode.create("QABCDE")
         Sample sample = Sample.create(sampleCode, sampleRegistrationRequest)
         sampleCodeService.generateFor(projectId) >> Result.fromValue(sampleCode)

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/domain/service/SampleDomainServiceSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/domain/service/SampleDomainServiceSpec.groovy
@@ -28,11 +28,11 @@ class SampleDomainServiceSpec extends Specification {
 
     def "When a sample has been successfully registered, a sample registered event is dispatched"() {
         given:
-        Sample testSample = Sample.create(SampleCode.create("test"), new SampleRegistrationRequest("test sample", BatchId.create(), ExperimentId.create(), 1L, BiologicalReplicateId.create(), new SampleOrigin(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO()), AnalysisMethod.WES, ""))
+        Sample testSample = Sample.create(SampleCode.create("test"), new SampleRegistrationRequest("test sample", "patient 1", BatchId.create(), ExperimentId.create(), 1L, BiologicalReplicateId.create(), new SampleOrigin(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO()), AnalysisMethod.WES, ""))
         Contact who = new Contact()
         Project project = Project.create(new ProjectIntent(new ProjectTitle("a title"), new ProjectObjective("an objective")), new ProjectCode("QABCD"), who, who, who)
         Map<SampleCode, SampleRegistrationRequest> sampleCodesToRegistrationRequests = new HashMap<>()
-        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("test sample", BatchId.create(), ExperimentId.create(), 1L, BiologicalReplicateId.create(), new SampleOrigin(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO()), AnalysisMethod.WES, "")
+        SampleRegistrationRequest sampleRegistrationRequest = new SampleRegistrationRequest("test sample", "patient 1", BatchId.create(), ExperimentId.create(), 1L, BiologicalReplicateId.create(), new SampleOrigin(new OntologyClassDTO(), new OntologyClassDTO(), new OntologyClassDTO()), AnalysisMethod.WES, "")
         sampleCodesToRegistrationRequests.put(SampleCode.create("test"), sampleRegistrationRequest)
 
         and:

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleContentComponent.java
@@ -199,7 +199,7 @@ public class SampleContentComponent extends Div {
     List<SampleRegistrationRequest> sampleRegistrationRequests;
     sampleRegistrationRequests = sampleInfos.stream()
         .map(sample -> new SampleRegistrationRequest(
-            sample.getSampleLabel(),
+            sample.getSampleLabel(), sample.getOrganismId(),
             batchId,
             context.experimentId().orElseThrow(),
             sample.getExperimentalGroup().id(),
@@ -214,10 +214,10 @@ public class SampleContentComponent extends Div {
   private SampleUpdateRequest generateSampleUpdateRequestFromSampleInfo(
       SampleInfo sampleInfo) {
     return new SampleUpdateRequest(sampleInfo.getSampleId(), new SampleInformation(
-        sampleInfo.getSampleLabel(), sampleInfo.getAnalysisToBePerformed(),
-        sampleInfo.getBiologicalReplicate(), sampleInfo.getExperimentalGroup(),
-        sampleInfo.getSpecies(), sampleInfo.getSpecimen(), sampleInfo.getAnalyte(),
-        sampleInfo.getCustomerComment()));
+        sampleInfo.getSampleLabel(), sampleInfo.getOrganismId(),
+        sampleInfo.getAnalysisToBePerformed(), sampleInfo.getBiologicalReplicate(),
+        sampleInfo.getExperimentalGroup(), sampleInfo.getSpecies(), sampleInfo.getSpecimen(),
+        sampleInfo.getAnalyte(), sampleInfo.getCustomerComment()));
   }
 
   private void displayUpdateSuccess() {
@@ -289,7 +289,7 @@ public class SampleContentComponent extends Div {
                 .equals(sample.biologicalReplicateId())).findFirst().orElseThrow();
     return SampleBatchInformationSpreadsheet.SampleInfo.create(sample.sampleId(),
         sample.sampleCode(), sample.analysisMethod(),
-        sample.label(),
+        sample.label(), sample.organismId(),
         biologicalReplicate, experimentalGroup, sample.sampleOrigin()
             .getSpecies(), sample.sampleOrigin().getSpecimen(), sample.sampleOrigin().getAnalyte(),
         sample.comment().orElse(""));

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/SampleDetailsComponent.java
@@ -287,6 +287,8 @@ public class SampleDetailsComponent extends PageArea implements Serializable {
         .setTooltipGenerator(SamplePreview::sampleCode);
     sampleGrid.addColumn(SamplePreview::sampleLabel).setHeader("Sample Label")
         .setSortProperty("sampleLabel").setTooltipGenerator(SamplePreview::sampleLabel);
+    sampleGrid.addColumn(SamplePreview::organismId).setHeader("Organism ID")
+        .setSortProperty("organismId").setTooltipGenerator(SamplePreview::organismId);
     sampleGrid.addColumn(SamplePreview::batchLabel).setHeader("Batch")
         .setSortProperty("batchLabel").setTooltipGenerator(SamplePreview::batchLabel);
     sampleGrid.addColumn(SamplePreview::replicateLabel).setHeader("Biological Replicate")

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleBatchInformationSpreadsheet.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/SampleBatchInformationSpreadsheet.java
@@ -66,6 +66,9 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
         .requireDistinctValues()
         .setRequired();
 
+    addColumn("Organism ID", SampleInfo::getOrganismId,
+        SampleInfo::setOrganismId);
+
     addColumn("Condition", SampleInfo::getExperimentalGroup,
         experimentalGroup -> formatConditionString(experimentalGroup.condition()),
         (sampleInfo, conditionString) -> updateSampleInfoWithMatchingExperimentalGroup(
@@ -129,6 +132,7 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
     private SampleCode sampleCode;
     private AnalysisMethod analysisToBePerformed;
     private String sampleLabel;
+    private String organismId;
     private BiologicalReplicate biologicalReplicate;
     private ExperimentalGroup experimentalGroup;
     private OntologyClassDTO species;
@@ -139,14 +143,15 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
     public static SampleInfo create(
         AnalysisMethod analysisMethod,
         String sampleLabel,
+        String organismId,
         BiologicalReplicate biologicalReplicate,
         ExperimentalGroup experimentalGroup,
         OntologyClassDTO species,
         OntologyClassDTO specimen,
         OntologyClassDTO analyte,
         String customerComment) {
-      return create(null, null, analysisMethod, sampleLabel, biologicalReplicate, experimentalGroup,
-          species, specimen, analyte, customerComment);
+      return create(null, null, analysisMethod, sampleLabel, organismId,
+          biologicalReplicate, experimentalGroup, species, specimen, analyte, customerComment);
     }
 
     public static SampleInfo create(
@@ -154,6 +159,7 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
         SampleCode sampleCode,
         AnalysisMethod analysisMethod,
         String sampleLabel,
+        String organismId,
         BiologicalReplicate biologicalReplicate,
         ExperimentalGroup experimentalGroup,
         OntologyClassDTO species,
@@ -165,6 +171,7 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
       sampleInfo.setSampleCode(sampleCode);
       sampleInfo.setAnalysisToBePerformed(analysisMethod);
       sampleInfo.setSampleLabel(sampleLabel);
+      sampleInfo.setOrganismId(organismId);
       sampleInfo.setExperimentalGroup(experimentalGroup);
       sampleInfo.setBiologicalReplicate(biologicalReplicate);
       sampleInfo.setSpecies(species);
@@ -204,6 +211,10 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
 
     public void setSampleLabel(String sampleLabel) {
       this.sampleLabel = sampleLabel;
+    }
+    public String getOrganismId() { return organismId; }
+    public void setOrganismId(String organismId) {
+      this.organismId = organismId;
     }
 
     public OntologyClassDTO getSpecies() {
@@ -262,6 +273,7 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
           "]")
           .add("analysisToBePerformed=" + analysisToBePerformed)
           .add("sampleLabel='" + sampleLabel + "'")
+          .add("organismId='" + organismId + "'")
           .add("biologicalReplicate=" + biologicalReplicate)
           .add("experimentalGroup=" + experimentalGroup)
           .add("species=" + species)
@@ -281,6 +293,7 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
       sampleInfo.sampleCode = original.sampleCode;
       sampleInfo.sampleId = original.sampleId;
       sampleInfo.sampleLabel = original.sampleLabel;
+      sampleInfo.organismId = original.organismId;
       sampleInfo.species = original.species;
       sampleInfo.specimen = original.specimen;
       return sampleInfo;
@@ -309,6 +322,9 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
       if (!Objects.equals(sampleLabel, that.sampleLabel)) {
         return false;
       }
+      if (!Objects.equals(organismId, that.organismId)) {
+        return false;
+      }
       if (!Objects.equals(biologicalReplicate, that.biologicalReplicate)) {
         return false;
       }
@@ -333,6 +349,7 @@ public class SampleBatchInformationSpreadsheet extends Spreadsheet<SampleInfo> {
       result = 31 * result + (sampleCode != null ? sampleCode.hashCode() : 0);
       result = 31 * result + (analysisToBePerformed != null ? analysisToBePerformed.hashCode() : 0);
       result = 31 * result + (sampleLabel != null ? sampleLabel.hashCode() : 0);
+      result = 31 * result + (organismId != null ? organismId.hashCode() : 0);
       result = 31 * result + (biologicalReplicate != null ? biologicalReplicate.hashCode() : 0);
       result = 31 * result + (experimentalGroup != null ? experimentalGroup.hashCode() : 0);
       result = 31 * result + (species != null ? species.hashCode() : 0);


### PR DESCRIPTION
Adds the property 'Organism Id' to Sample objects, Sample creation and Sample editing.

This optional property allows to discriminate between samples that are from the same patient or model organism and samples that are from different individuals.

Since the property is optional, these changes are backwards compatible and older batches/samples can still be displayed/edited. However, the following column has to be added to the **sample** table:

`organism_id varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL`