### PR TITLE
User can toggle to see or hide additional properties within the samplegrid if defined for a sample

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/sample/SamplePreview.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/sample/SamplePreview.java
@@ -3,18 +3,22 @@ package life.qbic.projectmanagement.application.sample;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import life.qbic.projectmanagement.domain.model.batch.Batch;
 import life.qbic.projectmanagement.domain.model.experiment.BiologicalReplicate;
 import life.qbic.projectmanagement.domain.model.experiment.Experiment;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentalGroup;
+import life.qbic.projectmanagement.domain.model.experiment.repository.jpa.SamplePropertiesAttributeConverter;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
 import life.qbic.projectmanagement.domain.model.sample.Sample;
 import life.qbic.projectmanagement.domain.model.sample.SampleCode;
@@ -42,7 +46,6 @@ public class SamplePreview {
   private String bioReplicateLabel;
   @Column(name = "label")
   private String sampleLabel;
-
   @Column(name = "organism_id")
   private String organismId;
   private String comment;
@@ -54,6 +57,8 @@ public class SamplePreview {
   private OntologyClassDTO species;
   private OntologyClassDTO specimen;
   private OntologyClassDTO analyte;
+  @Convert(converter = SamplePropertiesAttributeConverter.class)
+  private HashMap<String, String> properties;
 
   protected SamplePreview() {
     //needed by JPA
@@ -177,6 +182,17 @@ public class SamplePreview {
     return experimentalGroup;
   }
 
+  public HashMap<String, String> sampleProperties() {
+    return properties;
+  }
+
+  public void addSampleProperties(Map<String, String> sampleProperties) {
+    if (sampleProperties.isEmpty()) {
+      return;
+    }
+    this.properties.putAll(sampleProperties);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -194,14 +210,15 @@ public class SamplePreview {
         && Objects.equals(species, that.species) && Objects.equals(specimen,
         that.specimen) && Objects.equals(analyte, that.analyte) && Objects.equals(
         experimentalGroup, that.experimentalGroup) && Objects.equals(analysisMethod,
-        that.analysisMethod) && Objects.equals(comment, that.comment);
+        that.analysisMethod) && Objects.equals(comment, that.comment) && Objects.equals(properties,
+        that.properties);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(experimentId, sampleCode, sampleId, batchLabel, bioReplicateLabel,
         sampleLabel, organismId,
-        species, specimen, analyte, experimentalGroup, analysisMethod, comment);
+        species, specimen, analyte, experimentalGroup, analysisMethod, comment, properties);
   }
 
   @Override
@@ -220,6 +237,7 @@ public class SamplePreview {
         ", analysisMethod='" + analysisMethod + '\'' +
         ", comment='" + comment + '\'' +
         ", conditions=" + experimentalGroup +
+        ", properties=" + properties +
         '}';
   }
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/repository/jpa/SamplePropertiesAttributeConverter.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/repository/jpa/SamplePropertiesAttributeConverter.java
@@ -1,0 +1,36 @@
+package life.qbic.projectmanagement.domain.model.experiment.repository.jpa;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.HashMap;
+
+@Converter()
+public class SamplePropertiesAttributeConverter implements AttributeConverter<HashMap<String, String>,
+    String> {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(HashMap<String, String> attribute) {
+    try {
+      return objectMapper.writeValueAsString(attribute);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public HashMap<String, String> convertToEntityAttribute(String dbData) {
+    try {
+      if (dbData == null) {
+        return new HashMap<>();
+      } else {
+        return objectMapper.readValue(dbData, HashMap.class);
+      }
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/user-interface/frontend/themes/datamanager/components/page-area.css
+++ b/user-interface/frontend/themes/datamanager/components/page-area.css
@@ -1,9 +1,4 @@
 /* All custom css for components which extend the page-area component go in here! */
-.page {
-  height: 100%;
-  width: 100%;
-}
-
 .page-area {
   background-color: var(--lumo-base-color);
   padding: var(--lumo-space-m);
@@ -184,6 +179,22 @@
   flex-direction: column;
   margin-bottom: var(--lumo-space-m);
   height: 100%;
+}
+
+.sample-details-component .sample-grid .sample-property-layout {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  row-gap: var(--lumo-space-s);
+  column-gap: var(--lumo-space-m);
+  flex-wrap: wrap;
+}
+
+.sample-details-component .sample-grid .sample-property-layout .sample-property {
+  height: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .sample-details-component .sample-tab-content {


### PR DESCRIPTION
**What was changed** 

1.) Introduce column within sample table which contains the properties as a JSON 
2.) Convert Json to Hashmap in our application via dedicated converter
3.) Show sample properties for samples within the itemdetails of a sample if the user clicks on the toggle button.
4.) Toggle button only appears if additional properties have been defined

**How to test**
1.) Go to SampleDetailsComponent within an experiment with a sample for which properties are defined. E.g. Project QOPBS
2.) Press the toggle button in the properties column (only present if a sample has properties defined)
3.) Observe dummy data