### PR TITLE
Highlight and provide Linkage to Onthology Class Iri

### DIFF
--- a/user-interface/frontend/themes/datamanager/components/div.css
+++ b/user-interface/frontend/themes/datamanager/components/div.css
@@ -1,12 +1,3 @@
-.ontology-component {
-  display: flex;
-}
-
-.ontology-component .subtitle {
-  font-size: var(--lumo-font-size-s);
-  color: var(--lumo-secondary-text-color);
-}
-
 .card-deck {
   display: flex;
   align-content: space-evenly;
@@ -53,6 +44,12 @@
 .experiment-navigation-component .experiment-navigation-tabs .arrow-tab {
   align-items: end;
   color: var(--lumo-contrast-60pct);
+}
+
+.ontology-component {
+  display: flex;
+  flex-direction: column;
+  gap: var(--lumo-space-s);
 }
 
 .project-creation-stepper-arrow {

--- a/user-interface/frontend/themes/datamanager/components/page-area.css
+++ b/user-interface/frontend/themes/datamanager/components/page-area.css
@@ -52,29 +52,38 @@
 .experiment-details-component .sample-source-display {
   flex-direction: row;
   display: flex;
+  justify-content: space-between;
 }
 
-.experiment-details-component .sample-source-display .icon-with-list {
-  flex-direction: row;
-  flex-grow: 0.2;
-  display: flex;
-}
-
-.experiment-details-component .sample-source-display .icon-with-list .taglist {
+.experiment-details-component .sample-source-display .sample-source {
   flex-direction: column;
   display: flex;
-  line-height: 1.3em;
+  row-gap: var(--lumo-space-m);
 }
 
-.experiment-details-component .sample-source-display .icon-with-list .taglist .title {
-  font-size: small;
+.experiment-details-component .sample-source-display .sample-source .header {
+  display: inline-flex;
+  justify-content: start;
+  align-items: start;
+  column-gap: var(--lumo-space-m);
+  font-size: var(--lumo-font-size-m);
 }
 
-.experiment-details-component .sample-source-display .icon-with-list vaadin-icon {
-  color: var(--lumo-primary-color);
-  margin-right: 1em;
-  margin-top: 0.5em;
+.experiment-details-component .sample-source-display .sample-source .ontologies {
+  display: flex;
+  row-gap: var(--lumo-space-s);
+  align-items: center;
+  width: 100%;
+  flex-direction: column;
 }
+
+.experiment-details-component .sample-source-display .sample-source .ontologies .ontology {
+  display: inline-flex;
+  gap: var(--lumo-space-s);
+  align-items: center;
+  width: 100%;
+}
+
 
 .experiment-details-component .header {
   display: flex;

--- a/user-interface/frontend/themes/datamanager/components/page-area.css
+++ b/user-interface/frontend/themes/datamanager/components/page-area.css
@@ -67,6 +67,7 @@
   align-items: start;
   column-gap: var(--lumo-space-m);
   font-size: var(--lumo-font-size-m);
+  font-weight: 500;
 }
 
 .experiment-details-component .sample-source-display .sample-source .ontologies {

--- a/user-interface/frontend/themes/datamanager/components/span.css
+++ b/user-interface/frontend/themes/datamanager/components/span.css
@@ -25,6 +25,7 @@
   font-size: var(--lumo-font-size-s);
   line-height: 1;
   text-decoration-line: underline;
+  width: min-content;
 }
 
 span.bold {

--- a/user-interface/frontend/themes/datamanager/components/span.css
+++ b/user-interface/frontend/themes/datamanager/components/span.css
@@ -9,6 +9,24 @@
   padding: var(--lumo-space-xs);
 }
 
+.error-text {
+  color: var(--lumo-error-text-color);
+}
+
+/* ontology-link styling */
+.ontology-link {
+  display: inline-flex;
+  box-sizing: border-box;
+  padding: 0.4em calc(0.5em + var(--lumo-border-radius-s) / 4);
+  color: var(--lumo-primary-text-color);
+  background-color: var(--lumo-primary-color-10pct);
+  border-radius: var(--lumo-border-radius-s);
+  font-family: var(--lumo-font-family);
+  font-size: var(--lumo-font-size-s);
+  line-height: 1;
+  text-decoration-line: underline;
+}
+
 span.bold {
   font-weight: bold;
 }
@@ -20,8 +38,11 @@ span.title {
   margin-bottom: 0.5rem;
 }
 
-.error-text {
-  color: var(--lumo-error-text-color);
+.spreadsheet-list-item {
+  display: inline-flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
 }
 
 /* vaadin badge styling*/
@@ -53,11 +74,4 @@ span.title {
 .tag.contrast {
   color: var(--lumo-contrast-80pct);
   background-color: var(--lumo-contrast-5pct);
-}
-
-.spreadsheet-list-item {
-  display: inline-flex;
-  width: 100%;
-  justify-content: space-between;
-  align-items: center;
 }

--- a/user-interface/frontend/themes/datamanager/components/vaadin-custom.css
+++ b/user-interface/frontend/themes/datamanager/components/vaadin-custom.css
@@ -31,6 +31,11 @@ vaadin-multi-select-combo-box.chip-badge vaadin-multi-select-combo-box-chip {
   font-size: var(--lumo-font-size-s);
 }
 
+/* The checkmark has to be in the beginning line of an item if the item spans multiple lines */
+vaadin-multi-select-combo-box-item {
+  align-items: start;
+}
+
 /*Style overflow chip color within multi-select combobox as badges" */
 vaadin-multi-select-combo-box.chip-badge vaadin-multi-select-combo-box-chip[slot="overflow"]::before, vaadin-multi-select-combo-box-chip[slot="overflow"]::after {
   border-color: var(--lumo-primary-color-10pct);

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
@@ -3,8 +3,6 @@ package life.qbic.datamanager.views.general;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.html.Anchor;
-import com.vaadin.flow.component.html.AnchorTarget;
 import com.vaadin.flow.component.html.Span;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
 
@@ -13,12 +11,11 @@ public class OntologyComponent extends Component implements HasComponents {
   public OntologyComponent(OntologyClassDTO contentDTO) {
     Span ontologyLabel = new Span(contentDTO.getLabel());
     ontologyLabel.addClassName("bold");
-    String ontologyLinkName = contentDTO.getName().replace("_", ":");
-    Anchor ontologyLink = new Anchor(contentDTO.getClassIri(), ontologyLinkName);
+    String ontologyNameContent = contentDTO.getName().replace("_", ":");
+    Span ontologyName = new Span(ontologyNameContent);
     /*Clicking the Link should open the origin page in a new tab*/
-    ontologyLink.setTarget(AnchorTarget.BLANK);
-    ontologyLink.addClassName("ontology-link");
+    ontologyName.addClassName("ontology-name");
     addClassName("ontology-component");
-    add(ontologyLabel, ontologyLink);
+    add(ontologyLabel, ontologyName);
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
@@ -11,6 +11,7 @@ public class OntologyComponent extends Component implements HasComponents {
   public OntologyComponent(OntologyClassDTO contentDTO) {
     Span ontologyLabel = new Span(contentDTO.getLabel());
     ontologyLabel.addClassName("bold");
+    /* Ontology terms are delimited by a column, the underscore is only used in the web environment*/
     String ontologyNameContent = contentDTO.getName().replace("_", ":");
     Span ontologyName = new Span(ontologyNameContent);
     /*Clicking the Link should open the origin page in a new tab*/

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/OntologyComponent.java
@@ -3,28 +3,22 @@ package life.qbic.datamanager.views.general;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.AnchorTarget;
 import com.vaadin.flow.component.html.Span;
-import life.qbic.projectmanagement.domain.model.Ontology;
 import life.qbic.projectmanagement.domain.model.experiment.vocabulary.OntologyClassDTO;
 
 @Tag(Tag.DIV)
 public class OntologyComponent extends Component implements HasComponents {
   public OntologyComponent(OntologyClassDTO contentDTO) {
-    String ontologyName = Ontology.findOntologyByAbbreviation(contentDTO.getOntologyAbbreviation())
-        .getName();
-
+    Span ontologyLabel = new Span(contentDTO.getLabel());
+    ontologyLabel.addClassName("bold");
+    String ontologyLinkName = contentDTO.getName().replace("_", ":");
+    Anchor ontologyLink = new Anchor(contentDTO.getClassIri(), ontologyLinkName);
+    /*Clicking the Link should open the origin page in a new tab*/
+    ontologyLink.setTarget(AnchorTarget.BLANK);
+    ontologyLink.addClassName("ontology-link");
     addClassName("ontology-component");
-
-    var upperDiv = new Div();
-    // creates a line with label and ontology name (id), e.g. "Homo sapiens (NCBITaxon_9606)"
-    upperDiv.add(new Span(contentDTO.getLabel() + " (" + contentDTO.getName() + ")"));
-    var lowerDiv = new Div();
-    Span subtitle = new Span(ontologyName);
-    subtitle.addClassNames("subtitle");
-    lowerDiv.add(subtitle);
-    upperDiv.add(lowerDiv);
-
-    add(upperDiv);
+    add(ontologyLabel, ontologyLink);
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -355,9 +355,12 @@ public class ExperimentDetailsComponent extends PageArea {
     return new ComponentRenderer<>(ontologyClassDTO -> {
       Span ontology = new Span();
       Span ontologyLabel = new Span(ontologyClassDTO.getLabel());
-      Span ontologyName = new Span(ontologyClassDTO.getName());
-      ontologyName.addClassName("tag");
-      Anchor ontologyClassIri = new Anchor(ontologyClassDTO.getClassIri(), ontologyName);
+      /*Ontology terms are delimited by a column, the underscore is only used in the web environment*/
+      String ontologyLinkName = ontologyClassDTO.getName().replace("_", ":");
+      Span ontologyLink = new Span(ontologyLinkName);
+      ontologyLink.addClassName("ontology-link");
+      Anchor ontologyClassIri = new Anchor(ontologyClassDTO.getClassIri(), ontologyLink);
+      ontologyClassIri.setTarget("_blank");
       ontology.add(ontologyLabel, ontologyClassIri);
       ontology.addClassName("ontology");
       return ontology;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.AnchorTarget;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
@@ -360,7 +361,7 @@ public class ExperimentDetailsComponent extends PageArea {
       Span ontologyLink = new Span(ontologyLinkName);
       ontologyLink.addClassName("ontology-link");
       Anchor ontologyClassIri = new Anchor(ontologyClassDTO.getClassIri(), ontologyLink);
-      ontologyClassIri.setTarget("_blank");
+      ontologyClassIri.setTarget(AnchorTarget.BLANK);
       ontology.add(ontologyLabel, ontologyClassIri);
       ontology.addClassName("ontology");
       return ontology;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -85,7 +85,6 @@ public class ExperimentDetailsComponent extends PageArea {
   private final Div header = new Div();
   private final Span title = new Span();
   private final Span buttonBar = new Span();
-  private final Div tagCollection = new Div();
   private final Span sampleSourceComponent = new Span();
   private final TabSheet experimentSheet = new TabSheet();
   private final Div experimentalGroups = new Div();
@@ -167,8 +166,6 @@ public class ExperimentDetailsComponent extends PageArea {
     initButtonBar();
     header.add(title, buttonBar);
     title.addClassName("title");
-    addTagCollectionToContent();
-    addExperimentNotesComponent();
     addSampleSourceInformationComponent();
     layoutTabSheet();
   }
@@ -331,18 +328,6 @@ public class ExperimentDetailsComponent extends PageArea {
     existingGroupsPreventVariableEdit.addRejectListener(
         rejectEvent -> rejectEvent.getSource().close());
     existingGroupsPreventVariableEdit.open();
-  }
-
-  private void addTagCollectionToContent() {
-    tagCollection.addClassName("tag-collection");
-    content.add(tagCollection);
-  }
-
-  private void addExperimentNotesComponent() {
-    Span emptyNotes = new Span("Click to add Notes");
-    ToggleDisplayEditComponent<Span, TextField, String> experimentNotes = new ToggleDisplayEditComponent<>(
-        Span::new, new TextField(), emptyNotes);
-    content.add(experimentNotes);
   }
 
   private void addSampleSourceInformationComponent() {
@@ -551,11 +536,6 @@ public class ExperimentDetailsComponent extends PageArea {
     } else {
       onGroupsDefined();
     }
-  }
-
-  private void loadTagInformation() {
-    tagCollection.removeAll();
-    tagCollection.add(new Tag("Space for tags"));
   }
 
   private void loadExperimentalVariables(Experiment experiment) {


### PR DESCRIPTION
**What was changed**
1.) Render Species, Specimen and Analyte List in ExperimentDetailsComponent according to [prototype](https://www.figma.com/file/mYcW5viu5GpPZ852VHYBrV/Start-Page?type=design&node-id=6300-15816&mode=dev) with linkage to ClassIri of the selected onthology

A) Before:
![Bildschirmfoto 2024-02-01 um 14 25 54](https://github.com/qbicsoftware/data-manager-app/assets/29627977/6be11e73-5037-4cfc-a71d-c111b9343244)

B) New Design:
![Bildschirmfoto 2024-02-01 um 14 25 57](https://github.com/qbicsoftware/data-manager-app/assets/29627977/ea363cee-eef8-4eba-b293-24e3465340ae)

2.) Render Items within Multiselectcombobox according to [protoype](https://www.figma.com/file/mYcW5viu5GpPZ852VHYBrV/Start-Page?type=design&node-id=4788-99390&mode=dev) with correct formatting and layout:

A) Before:
![Bildschirmfoto 2024-02-01 um 14 26 20](https://github.com/qbicsoftware/data-manager-app/assets/29627977/18fb69cc-27c8-470f-a861-19aa668aed07)

B) New Design:
![Bildschirmfoto 2024-02-01 um 14 26 11](https://github.com/qbicsoftware/data-manager-app/assets/29627977/e9204f8e-8288-4037-b131-379e45a94c19)

3.) Sort the css classes within the touched files alphabetically

4.) Remove the unused components within the ExperimentDetailsComponent (Note taking Textfield and "Space for Tags" Span)
