### PR TITLE
Show existing groups in add dialog

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -403,7 +403,14 @@ public class ExperimentDetailsComponent extends PageArea {
     List<VariableLevel> levels = variables.stream()
         .flatMap(variable -> variable.levels().stream())
         .toList();
-    var dialog = ExperimentalGroupsDialog.empty(levels);
+    var groups = experimentInformationService.getExperimentalGroups(experimentId)
+        .stream().map(this::toContent).toList();
+    ExperimentalGroupsDialog dialog;
+    if(groups.isEmpty()) {
+      dialog = ExperimentalGroupsDialog.empty(levels);
+    } else {
+      dialog = ExperimentalGroupsDialog.nonEditable(levels, groups);
+    }
     dialog.addCancelEventListener(cancelEvent -> cancelEvent.getSource().close());
     dialog.addConfirmEventListener(this::onExperimentalGroupAddConfirmed);
     dialog.open();
@@ -428,7 +435,7 @@ public class ExperimentDetailsComponent extends PageArea {
         .flatMap(variable -> variable.levels().stream()).toList();
     var groups = experimentInformationService.getExperimentalGroups(experimentId)
         .stream().map(this::toContent).toList();
-    var dialog = ExperimentalGroupsDialog.prefilled(levels, groups);
+    var dialog = ExperimentalGroupsDialog.editable(levels, groups);
     dialog.addCancelEventListener(cancelEvent -> cancelEvent.getSource().close());
     dialog.addConfirmEventListener(this::onExperimentalGroupEditConfirmed);
     dialog.open();

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentalGroupInput.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentalGroupInput.java
@@ -59,7 +59,7 @@ public class ExperimentalGroupInput extends CustomField<ExperimentalGroupBean> {
    *
    * @param availableLevels Collection of {@link VariableLevel} defined for an {@link Experiment}
    */
-  public ExperimentalGroupInput(Collection<VariableLevel> availableLevels) {
+  public ExperimentalGroupInput(Collection<VariableLevel> availableLevels, boolean allowDeletion) {
     addClassName("experimental-group-entry");
     removeEventListeners = new ArrayList<>();
 
@@ -69,7 +69,10 @@ public class ExperimentalGroupInput extends CustomField<ExperimentalGroupBean> {
     var deleteIcon = new Icon(VaadinIcon.CLOSE_SMALL);
     deleteIcon.addClickListener(
         event -> fireRemoveEvent(new RemoveEvent(this, event.isFromClient())));
-    add(variableLevelSelect, replicateCountField, deleteIcon);
+    add(variableLevelSelect, replicateCountField);
+    if(allowDeletion) {
+      add(deleteIcon);
+    }
     setLevels(availableLevels);
     addValidationForVariableCount();
     variableLevelSelect.addValueChangeListener(

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
@@ -58,6 +58,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
       var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels);
       groupEntry.setCondition(group.variableLevels());
       groupEntry.setReplicateCount(group.size());
+      groupEntry.setEnabled(editMode);
       groupEntry.addRemoveEventListener(
           listener -> experimentalGroupsCollection.remove(groupEntry));
       return groupEntry;
@@ -75,14 +76,29 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   /**
-   * Creates an ExperimentalGroupsDialog prefilled with the experimental groups provided.
+   * Creates an ExperimentalGroupsDialog prefilled with the experimental groups provided. These
+   * groups can be edited.
    * @param experimentalVariables the variable levels to choose from
    * @param experimentalGroupContents the experimental groups prefilled into the input fields
    * @return a prefilled ExperimentalGroupDialog
    */
-  public static ExperimentalGroupsDialog prefilled(Collection<VariableLevel> experimentalVariables,
+  public static ExperimentalGroupsDialog editable(Collection<VariableLevel> experimentalVariables,
       Collection<ExperimentalGroupContent> experimentalGroupContents) {
     return new ExperimentalGroupsDialog(experimentalVariables, experimentalGroupContents, true);
+  }
+
+  /**
+   * Creates an ExperimentalGroupsDialog prefilled with the experimental groups provided. Existing
+   * groups can't be edited, but new groups added. Existing groups are therefore greyed out in the UI.
+   * @param experimentalVariables the variable levels to choose from
+   * @param experimentalGroupContents the experimental groups prefilled into the input fields
+   * @return a prefilled ExperimentalGroupDialog
+   */
+  public static ExperimentalGroupsDialog nonEditable(Collection<VariableLevel> experimentalVariables,
+      Collection<ExperimentalGroupContent> experimentalGroupContents) {
+    ExperimentalGroupsDialog dialog = new ExperimentalGroupsDialog(experimentalVariables, experimentalGroupContents, false);
+    dialog.addNewGroupEntry();
+    return dialog;
   }
 
   private static ExperimentalGroupContent convert(ExperimentalGroupInput experimentalGroupInput) {
@@ -158,15 +174,16 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   /**
-   * Provides the current experimental groups defined by the user.
-   *
+   * Provides experimental groups defined by the user. Only group information in enabled components
+   * is returned, as the list of existing groups cannot be changed in "add group" mode.
    * @return a collection of {@link ExperimentalGroupContent}, describing the group size (biological
    * replicates) and the variable level combination.
    * @since 1.0.0
    */
   public Collection<ExperimentalGroupContent> experimentalGroups() {
     return this.experimentalGroupsCollection.getChildren()
-        .filter(component -> component.getClass().equals(ExperimentalGroupInput.class))
+        .filter(component -> component.getClass().equals(ExperimentalGroupInput.class)
+            && ((ExperimentalGroupInput) component).isEnabled())
         .map(experimentalGroupEntry -> convert((ExperimentalGroupInput) experimentalGroupEntry))
         .toList();
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
@@ -56,7 +56,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   private void addEntries(Collection<VariableLevel> experimentalVariableLevels,
       Collection<ExperimentalGroupContent> experimentalGroupContents) {
     experimentalGroupContents.stream().map(group -> {
-      var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels);
+      var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels, editMode);
       groupEntry.setCondition(group.variableLevels());
       groupEntry.setReplicateCount(group.size());
       groupEntry.setEnabled(editMode);
@@ -155,7 +155,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
   }
 
   private void addNewGroupEntry() {
-    var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels);
+    var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels, true);
     experimentalGroupsCollection.add(groupEntry);
     groupEntry.addRemoveEventListener(event -> removeExperimentalGroupEntry(event.getSource()));
   }
@@ -168,7 +168,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
 
   private void refreshGroupEntries() {
     if (experimentalGroupsCollection.getChildren().toList().isEmpty()) {
-      var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels);
+      var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels, true);
       experimentalGroupsCollection.add(groupEntry);
       groupEntry.addRemoveEventListener(event -> removeExperimentalGroupEntry(event.getSource()));
     }


### PR DESCRIPTION
* Introduces the possibility to create an ExperimentalGroupsDialog with existing groups that cannot be edited
* This makes it easier for users to add unique experimental groups (not accidentally adding the same again)
* For the Add Groups use case, only new groups are returned
* For the Edit Groups use case, everything is returned as before, as all parts of the dialog are in "enabled" mode