### PR TITLE
Allow users to set themselves as collaborator(s)

### DIFF
--- a/user-interface/frontend/themes/datamanager/components/dialog.css
+++ b/user-interface/frontend/themes/datamanager/components/dialog.css
@@ -203,6 +203,7 @@ vaadin-dialog-overlay::part(title) {
 }
 
 .edit-project-dialog .contact-field .prefill-input-fields {
+  line-height: 0;
   display: flex;
   gap: 1em;
   align-items: baseline;
@@ -212,6 +213,13 @@ vaadin-dialog-overlay::part(title) {
 .contact-field .input-fields,
 .contact-field .input-fields > * {
   width: 100%;
+}
+
+.contact-field .prefill-input-fields {
+  line-height: 0;
+  display: flex;
+  gap: 1em;
+  align-items: baseline;
 }
 
 .contact-field .prefill-input-fields .contact-self-select {

--- a/user-interface/frontend/themes/datamanager/components/dialog.css
+++ b/user-interface/frontend/themes/datamanager/components/dialog.css
@@ -202,10 +202,20 @@ vaadin-dialog-overlay::part(title) {
   align-items: baseline;
 }
 
+.edit-project-dialog .contact-field .prefill-input-fields {
+  display: flex;
+  gap: 1em;
+  align-items: baseline;
+}
+
 .contact-field .contact-selection,
 .contact-field .input-fields,
 .contact-field .input-fields > * {
   width: 100%;
+}
+
+.contact-field .prefill-input-fields .contact-self-select {
+  width: 130px;
 }
 
 .edit-project-dialog .form-content .contact-field .name-field {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/contact/AutocompleteContactField.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/contact/AutocompleteContactField.java
@@ -2,6 +2,8 @@ package life.qbic.datamanager.views.general.contact;
 
 import static java.util.Objects.isNull;
 
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.customfield.CustomField;
 import com.vaadin.flow.component.html.Div;
@@ -26,10 +28,11 @@ public class AutocompleteContactField extends CustomField<Contact> implements
 
 
   private final ComboBox<Contact> contactSelection;
-
+  private final Button selfSelect;
   private final ComboBox<String> nameField;
   private final ComboBox<String> emailField;
   private final Binder<Contact> binder;
+  private Contact userAsContact;
 
   public AutocompleteContactField(String label) {
     setLabel(label);
@@ -45,6 +48,10 @@ public class AutocompleteContactField extends CustomField<Contact> implements
     contactSelection.setRenderer(new ComponentRenderer<>(AutocompleteContactField::renderContact));
     contactSelection.setItemLabelGenerator(
         contact -> "%s - %s".formatted(contact.getFullName(), contact.getEmail()));
+
+    selfSelect = new Button("Select myself");
+    selfSelect.addClassName("contact-self-select");
+    selfSelect.addClickListener(this::onSelfSelected);
 
     nameField = new ComboBox<>();
     nameField.setAllowCustomValue(true);
@@ -83,11 +90,19 @@ public class AutocompleteContactField extends CustomField<Contact> implements
         .bind(Contact::getEmail,
             Contact::setEmail);
 
+    Div preselectLayout = new Div(contactSelection, selfSelect);
+    preselectLayout.addClassName("prefill-input-fields");
+
     Div layout = new Div(nameField, emailField);
     layout.addClassName("input-fields");
-    add(contactSelection, layout);
+
+    add(preselectLayout, layout);
     setItems(new ArrayList<>());
     clear();
+  }
+
+  private void onSelfSelected(ClickEvent<Button> buttonClickEvent) {
+    setContact(userAsContact);
   }
 
   private void updateValidationProperty() {
@@ -118,6 +133,10 @@ public class AutocompleteContactField extends CustomField<Contact> implements
     setContact(valueChanged.getValue());
     // clear selection box
     valueChanged.getHasValue().clear();
+  }
+  
+  public void setLoggedInUser(Contact contact) {
+    userAsContact = contact;
   }
 
   public void setContact(Contact contact) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/contact/AutocompleteContactField.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/contact/AutocompleteContactField.java
@@ -8,6 +8,7 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.customfield.CustomField;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.validator.EmailValidator;
@@ -29,8 +30,8 @@ public class AutocompleteContactField extends CustomField<Contact> implements
 
   private final ComboBox<Contact> contactSelection;
   private final Button selfSelect;
-  private final ComboBox<String> nameField;
-  private final ComboBox<String> emailField;
+  private final TextField nameField;
+  private final TextField emailField;
   private final Binder<Contact> binder;
   private Contact userAsContact;
 
@@ -49,22 +50,17 @@ public class AutocompleteContactField extends CustomField<Contact> implements
     contactSelection.setItemLabelGenerator(
         contact -> "%s - %s".formatted(contact.getFullName(), contact.getEmail()));
 
-    selfSelect = new Button("Select myself");
+    selfSelect = new Button("Myself");
+    selfSelect.setVisible(userAsContact!=null);
     selfSelect.addClassName("contact-self-select");
     selfSelect.addClickListener(this::onSelfSelected);
 
-    nameField = new ComboBox<>();
-    nameField.setAllowCustomValue(true);
-    nameField.addCustomValueSetListener(
-        customValueSet -> customValueSet.getSource().setValue(customValueSet.getDetail()));
+    nameField = new TextField();
     nameField.setRequired(false);
     nameField.addClassName("name-field");
     nameField.setPlaceholder("Please enter a name");
 
-    emailField = new ComboBox<>();
-    emailField.setAllowCustomValue(true);
-    emailField.addCustomValueSetListener(
-        customValueSet -> customValueSet.getSource().setValue(customValueSet.getDetail()));
+    emailField = new TextField();
     emailField.setRequired(false);
     emailField.addClassName("email-field");
     emailField.setPlaceholder("Please enter an email address");
@@ -137,26 +133,17 @@ public class AutocompleteContactField extends CustomField<Contact> implements
   
   public void setLoggedInUser(Contact contact) {
     userAsContact = contact;
+    selfSelect.setVisible(userAsContact!=null);
   }
 
   public void setContact(Contact contact) {
     binder.setBean(contact);
     updateValidationProperty();
+    setValue(contact);
   }
 
   public void setItems(List<Contact> contacts) {
-    List<String> fullNames = contacts.stream()
-        .map(Contact::getFullName)
-        .distinct()
-        .toList();
-    List<String> emails = contacts.stream()
-        .map(Contact::getEmail)
-        .distinct()
-        .toList();
-
     contactSelection.setItems(contacts);
-    nameField.setItems(fullNames);
-    emailField.setItems(emails);
   }
 
   @Override
@@ -194,5 +181,17 @@ public class AutocompleteContactField extends CustomField<Contact> implements
   @Override
   public Binder<Contact> getBinder() {
     return binder;
+  }
+
+  /**
+   * Runs all configured field level validators and returns whether any of the validators failed.
+   * <p>
+   * <b>Note:</b> Calling this method will not trigger status change events, unlike
+   * {@link #validate()} and will not modify the UI. Also updates error indicators on fields.
+   *
+   * @return true if the field is valid; false otherwise
+   */
+  public boolean isOk() {
+    return binder.validate().isOk();
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/contact/ContactField.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/contact/ContactField.java
@@ -1,5 +1,6 @@
 package life.qbic.datamanager.views.general.contact;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.customfield.CustomField;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.textfield.TextField;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/AddProjectDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/AddProjectDialog.java
@@ -31,7 +31,10 @@ import life.qbic.datamanager.views.projects.create.ProjectDesignLayout.ProjectDe
 import life.qbic.finances.api.FinanceService;
 import life.qbic.projectmanagement.application.ContactRepository;
 import life.qbic.projectmanagement.application.OntologyTermInformationService;
+import life.qbic.projectmanagement.application.authorization.QbicUserDetails;
 import life.qbic.projectmanagement.domain.model.project.Project;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Project Creation Dialog
@@ -79,6 +82,10 @@ public class AddProjectDialog extends Dialog {
     this.experimentalInformationLayout = new ExperimentalInformationLayout(
         ontologyTermInformationService);
 
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    QbicUserDetails details = (QbicUserDetails) authentication.getPrincipal();
+
+    collaboratorsLayout.setLoggedInUser(new Contact(details.fullName(), details.getEmailAddress()));
     collaboratorsLayout.setPrincipalInvestigators(contactRepository.findAll().stream()
         .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList());
     collaboratorsLayout.setProjectManagers(contactRepository.findAll().stream()

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/AddProjectDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/AddProjectDialog.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.spring.annotation.SpringComponent;
 import com.vaadin.flow.spring.annotation.UIScope;
 import java.io.Serial;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import life.qbic.datamanager.views.general.HasBinderValidation;
 import life.qbic.datamanager.views.general.Stepper;
@@ -86,10 +87,11 @@ public class AddProjectDialog extends Dialog {
     QbicUserDetails details = (QbicUserDetails) authentication.getPrincipal();
 
     collaboratorsLayout.setLoggedInUser(new Contact(details.fullName(), details.getEmailAddress()));
-    collaboratorsLayout.setPrincipalInvestigators(contactRepository.findAll().stream()
-        .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList());
-    collaboratorsLayout.setProjectManagers(contactRepository.findAll().stream()
-        .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList());
+    List<Contact> knownContacts = contactRepository.findAll().stream()
+        .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList();
+    collaboratorsLayout.setPrincipalInvestigators(knownContacts);
+    collaboratorsLayout.setResponsiblePersons(knownContacts);
+    collaboratorsLayout.setProjectManagers(knownContacts);
 
     stepContent = new HashMap<>();
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 public class CollaboratorsLayout extends Div implements HasBinderValidation<ProjectCollaborators> {
 
   private final AutocompleteContactField principalInvestigatorField;
-  private final ContactField responsiblePersonField;
+  private final AutocompleteContactField responsiblePersonField;
   private final AutocompleteContactField projectManagerField;
   private final Binder<ProjectCollaborators> collaboratorsBinder;
 
@@ -46,12 +46,12 @@ public class CollaboratorsLayout extends Div implements HasBinderValidation<Proj
         .bind(ProjectCollaborators::getPrincipalInvestigator,
             ProjectCollaborators::setPrincipalInvestigator);
 
-    responsiblePersonField = new ContactField("Project Responsible/Co-Investigator (optional)");
+    responsiblePersonField = new AutocompleteContactField("Project Responsible/Co-Investigator (optional)");
     responsiblePersonField.setRequired(false);
     responsiblePersonField.setHelperText("Should be contacted about project-related questions");
     collaboratorsBinder.forField(responsiblePersonField)
         .withNullRepresentation(responsiblePersonField.getEmptyValue())
-        .withValidator(it -> responsiblePersonField.validate().isOk(), "")
+        .withValidator(it -> responsiblePersonField.isOk(), "")
         .bind(bean -> bean.getResponsiblePerson().orElse(null),
             ProjectCollaborators::setResponsiblePerson);
 
@@ -91,6 +91,9 @@ public class CollaboratorsLayout extends Div implements HasBinderValidation<Proj
     projectManagerField.setItems(projectManagers);
   }
 
+  public void setResponsiblePersons(List<Contact> contactPersons) {
+    responsiblePersonField.setItems(contactPersons);
+  }
   public void setPrincipalInvestigators(List<Contact> principalInvestigators) {
     principalInvestigatorField.setItems(principalInvestigators);
   }
@@ -118,6 +121,7 @@ public class CollaboratorsLayout extends Div implements HasBinderValidation<Proj
 
   public void setLoggedInUser(Contact contact) {
     projectManagerField.setLoggedInUser(contact);
+    responsiblePersonField.setLoggedInUser(contact);
     principalInvestigatorField.setLoggedInUser(contact);
   }
 
@@ -168,13 +172,13 @@ public class CollaboratorsLayout extends Div implements HasBinderValidation<Proj
 
       ProjectCollaborators that = (ProjectCollaborators) o;
 
-      if (!principalInvestigator.equals(that.principalInvestigator)) {
+      if (!Objects.equals(principalInvestigator, that.principalInvestigator)) {
         return false;
       }
       if (!Objects.equals(responsiblePerson, that.responsiblePerson)) {
         return false;
       }
-      return projectManager.equals(that.projectManager);
+      return (!Objects.equals(projectManager, that.projectManager));
     }
 
     @Override

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/CollaboratorsLayout.java
@@ -116,6 +116,11 @@ public class CollaboratorsLayout extends Div implements HasBinderValidation<Proj
     return projectCollaborators;
   }
 
+  public void setLoggedInUser(Contact contact) {
+    projectManagerField.setLoggedInUser(contact);
+    principalInvestigatorField.setLoggedInUser(contact);
+  }
+
 
   public static final class ProjectCollaborators implements Serializable {
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/edit/EditProjectInformationDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/edit/EditProjectInformationDialog.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.spring.annotation.UIScope;
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -20,6 +21,9 @@ import life.qbic.datamanager.views.general.DialogWindow;
 import life.qbic.datamanager.views.general.contact.Contact;
 import life.qbic.datamanager.views.general.funding.FundingEntry;
 import life.qbic.projectmanagement.application.ContactRepository;
+import life.qbic.projectmanagement.application.authorization.QbicUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * <b>Project Information Dialog</b>
@@ -48,11 +52,17 @@ public class EditProjectInformationDialog extends DialogWindow {
     setConfirmButtonLabel("Save");
     setCancelButtonLabel("Cancel");
 
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    QbicUserDetails details = (QbicUserDetails) authentication.getPrincipal();
+
     formLayout = new EditProjectInformationForm();
-    formLayout.setPrincipalInvestigators(contactRepository.findAll().stream()
-        .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList());
-    formLayout.setProjectManagers(contactRepository.findAll().stream()
-        .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList());
+    formLayout.setLoggedInUser(new Contact(details.fullName(), details.getEmailAddress()));
+
+    List<Contact> knownContacts = contactRepository.findAll().stream()
+        .map(contact -> new Contact(contact.fullName(), contact.emailAddress())).toList();
+    formLayout.setPrincipalInvestigators(knownContacts);
+    formLayout.setResponsiblePersons(knownContacts);
+    formLayout.setProjectManagers(knownContacts);
 
 
     binder = formLayout.getBinder();

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/edit/EditProjectInformationForm.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/edit/EditProjectInformationForm.java
@@ -25,7 +25,7 @@ public class EditProjectInformationForm extends FormLayout {
   private static final long serialVersionUID = 972380320581239752L;
   private final Binder<ProjectInformation> binder;
   private final AutocompleteContactField principalInvestigatorField;
-  private final ContactField responsiblePersonField;
+  private final AutocompleteContactField responsiblePersonField;
   private final AutocompleteContactField projectManagerField;
 
   private final FundingField fundingField;
@@ -94,7 +94,7 @@ public class EditProjectInformationForm extends FormLayout {
         .bind((ProjectInformation::getPrincipalInvestigator),
             ProjectInformation::setPrincipalInvestigator);
 
-    responsiblePersonField = new ContactField("Project Responsible (optional)");
+    responsiblePersonField = new AutocompleteContactField("Project Responsible (optional)");
     responsiblePersonField.setRequired(false);
     responsiblePersonField.setId("responsible-person");
     responsiblePersonField.setHelperText("Should be contacted about project-related questions");
@@ -135,6 +135,10 @@ public class EditProjectInformationForm extends FormLayout {
     projectManagerField.setItems(projectManagers);
   }
 
+  public void setResponsiblePersons(List<Contact> responsiblePersons) {
+    responsiblePersonField.setItems(responsiblePersons);
+  }
+
   public void setPrincipalInvestigators(List<Contact> principalInvestigators) {
     principalInvestigatorField.setItems(principalInvestigators);
   }
@@ -173,4 +177,9 @@ public class EditProjectInformationForm extends FormLayout {
     return binder;
   }
 
+  public void setLoggedInUser(Contact loggedInUser) {
+    principalInvestigatorField.setLoggedInUser(loggedInUser);
+    responsiblePersonField.setLoggedInUser(loggedInUser);
+    projectManagerField.setLoggedInUser(loggedInUser);
+  }
 }


### PR DESCRIPTION
* In project creation/edit, users can press the "Myself" button to add their name and email (from login) as a collaborator of the project (PI, responsible, or manager)
* allow dropdown selection of predefined persons for "responsible" category, as well
* Name and email of selected people are now stored in normal text fields instead of dropdowns
* fixes issue where persons not selected via dropdown would not correctly be set/registered