### PR TITLE
hide offer search from anyone but admin and project-manager

### DIFF
--- a/finances-infrastructure/pom.xml
+++ b/finances-infrastructure/pom.xml
@@ -23,6 +23,16 @@
       <version>0.34.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>life.qbic.identity</groupId>
+      <artifactId>project-management-infrastructure</artifactId>
+      <version>0.34.0</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/finances-infrastructure/src/main/java/life/qbic/finance/infrastructure/SimpleOfferSearchService.java
+++ b/finances-infrastructure/src/main/java/life/qbic/finance/infrastructure/SimpleOfferSearchService.java
@@ -7,6 +7,7 @@ import life.qbic.finance.domain.model.Offer;
 import life.qbic.finance.domain.model.OfferId;
 import life.qbic.finance.domain.model.OfferPreview;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 /**
@@ -23,13 +24,16 @@ public class SimpleOfferSearchService implements OfferSearchService {
 
   private final OfferRepository offerRepository;
 
+
   @Override
+  @PreAuthorize("hasAnyAuthority('ROLE_PROJECT_MANAGER', 'ROLE_ADMIN')")
   public List<OfferPreview> findByProjectTitleOrOfferId(String projectTitle, String offerId) {
     return offerPreviewRepository.findByProjectTitleContainingIgnoreCaseOrOfferIdContainingIgnoreCase(
         projectTitle, offerId);
   }
 
   @Override
+  @PreAuthorize("hasAnyAuthority('ROLE_PROJECT_MANAGER', 'ROLE_ADMIN')")
   public List<OfferPreview> findByProjectTitleOrOfferId(String projectTitle, String offerId,
       int offset, int limit) {
     return offerPreviewRepository.findByProjectTitleContainingIgnoreCaseOrOfferIdContainingIgnoreCase(
@@ -37,6 +41,7 @@ public class SimpleOfferSearchService implements OfferSearchService {
   }
 
   @Override
+  @PreAuthorize("hasAnyAuthority('ROLE_PROJECT_MANAGER', 'ROLE_ADMIN')")
   public Optional<Offer> findByOfferId(String offerId) {
     return Optional.ofNullable(offerRepository.findByOfferId(OfferId.from(offerId)));
   }

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
@@ -74,7 +74,7 @@ public class ProjectRepositoryImpl implements ProjectRepository {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     QbicUserDetails details = (QbicUserDetails) authentication.getPrincipal();
     projectAccessService.grant(details.getUserId(), project.getId(),
-        List.of(READ, WRITE));
+        List.of(READ, WRITE, ADMINISTRATION));//administration of this project, only
     projectAccessService.grantToAuthority(ADMIN.auth(), project.getId(), ADMIN.permissions());
     projectAccessService.grantToAuthority(PROJECT_MANAGER.auth(), project.getId(),
         PROJECT_MANAGER.permissions());

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
@@ -74,7 +74,7 @@ public class ProjectRepositoryImpl implements ProjectRepository {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     QbicUserDetails details = (QbicUserDetails) authentication.getPrincipal();
     projectAccessService.grant(details.getUserId(), project.getId(),
-        List.of(READ, WRITE, ADMINISTRATION));//administration of this project, only
+        List.of(READ, WRITE));
     projectAccessService.grantToAuthority(ADMIN.auth(), project.getId(), ADMIN.permissions());
     projectAccessService.grantToAuthority(PROJECT_MANAGER.auth(), project.getId(),
         PROJECT_MANAGER.permissions());

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
@@ -52,7 +52,6 @@ public class ProjectRepositoryImpl implements ProjectRepository {
   private static final Logger log = logger(ProjectRepositoryImpl.class);
   private final QbicProjectRepo projectRepo;
   private final QbicProjectDataRepo projectDataRepo;
-
   private final ProjectAccessService projectAccessService;
 
   @Autowired

--- a/user-interface/pom.xml
+++ b/user-interface/pom.xml
@@ -250,6 +250,10 @@
       <version>0.34.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/user-interface/src/main/java/life/qbic/datamanager/security/UserPermissionsImpl.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/security/UserPermissionsImpl.java
@@ -29,10 +29,8 @@ public class UserPermissionsImpl implements UserPermissions {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     boolean hasReadPermission = aclPermissionEvaluator.hasPermission(authentication, projectId,
         "life.qbic.projectmanagement.domain.model.project.Project", "READ");
-    boolean hasCreatedProject = aclPermissionEvaluator.hasPermission(authentication, projectId,
-        "life.qbic.projectmanagement.domain.model.project.Project", "ADMINISTRATION");
     boolean canChangeAclAccess = authentication.getAuthorities().stream()
         .anyMatch(it -> it.getAuthority().equals("acl:change-access"));
-    return (hasReadPermission && (canChangeAclAccess || hasCreatedProject));
+    return (hasReadPermission && canChangeAclAccess);
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/security/UserPermissionsImpl.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/security/UserPermissionsImpl.java
@@ -29,8 +29,10 @@ public class UserPermissionsImpl implements UserPermissions {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     boolean hasReadPermission = aclPermissionEvaluator.hasPermission(authentication, projectId,
         "life.qbic.projectmanagement.domain.model.project.Project", "READ");
+    boolean hasCreatedProject = aclPermissionEvaluator.hasPermission(authentication, projectId,
+        "life.qbic.projectmanagement.domain.model.project.Project", "ADMINISTRATION");
     boolean canChangeAclAccess = authentication.getAuthorities().stream()
         .anyMatch(it -> it.getAuthority().equals("acl:change-access"));
-    return (hasReadPermission && canChangeAclAccess);
+    return (hasReadPermission && (canChangeAclAccess || hasCreatedProject));
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/AddProjectDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/AddProjectDialog.java
@@ -137,6 +137,12 @@ public class AddProjectDialog extends Dialog {
     adaptFooterButtons(stepper.getFirstStep());
   }
 
+  /**
+   * Allows user to search the offer database to prefill some project information
+   */
+  public void enableOfferSearch() {
+    projectDesignLayout.enableOfferSearch();
+  }
 
   private void onCancelClicked(ClickEvent<Button> clickEvent) {
     fireEvent(new CancelEvent(this, clickEvent.isFromClient()));

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
@@ -43,7 +43,7 @@ public class ProjectDesignLayout extends Div implements HasBinderValidation<Proj
 
   private static final Logger log = logger(ProjectDesignLayout.class);
   private static final String TITLE = "Project Design";
-  private final ComboBox<OfferSummary> offerSearchField = new ComboBox<>("Offer");;
+  private final ComboBox<OfferSummary> offerSearchField = new ComboBox<>("Offer");
   private final TextField codeField = new TextField("Code");
   private final TextField titleField = new TextField("Title");
   private final TextArea projectDescription = new TextArea("Description");

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
@@ -43,13 +43,15 @@ public class ProjectDesignLayout extends Div implements HasBinderValidation<Proj
 
   private static final Logger log = logger(ProjectDesignLayout.class);
   private static final String TITLE = "Project Design";
-  final ComboBox<OfferSummary> offerSearchField = new ComboBox<>("Offer");
+  private final ComboBox<OfferSummary> offerSearchField = new ComboBox<>("Offer");;
   private final TextField codeField = new TextField("Code");
   private final TextField titleField = new TextField("Title");
   private final TextArea projectDescription = new TextArea("Description");
   private final Button generateCodeButton = new Button(new Icon(VaadinIcon.REFRESH));
   private final Binder<ProjectDesign> projectDesignBinder = new Binder<>(ProjectDesign.class);
   private final FinanceService financeService;
+  private final Span projectDesignDescription = new Span(
+      "Specify the name and objective of the research project.");
 
   public ProjectDesignLayout(FinanceService financeService) {
     this.financeService = financeService;
@@ -61,11 +63,7 @@ public class ProjectDesignLayout extends Div implements HasBinderValidation<Proj
   private void initLayout() {
     Span projectDesignTitle = new Span(TITLE);
     projectDesignTitle.addClassName("title");
-    Span projectDesignDescription = new Span(
-        "Specify the name and objective of the research project. You can either select a project from the offer list or create a new one.");
-    offerSearchField.setClassName("search-field");
-    offerSearchField.setPlaceholder("Search for offers");
-    offerSearchField.setPrefixComponent(VaadinIcon.SEARCH.create());
+
     codeField.setHelperText("Q and 4 letters/numbers");
     codeField.setValue(ProjectCode.random().value());
     codeField.addClassName("code-field");
@@ -76,9 +74,22 @@ public class ProjectDesignLayout extends Div implements HasBinderValidation<Proj
     codeTitleAndButtonSpan.addClassNames("code-and-title");
     projectDescription.setPlaceholder("Please enter a description for your project");
     projectDescription.addClassName("description-field");
+
+    // disable offer access until user authority is known
+    offerSearchField.setEnabled(false);
+    offerSearchField.setVisible(false);
+    offerSearchField.setClassName("search-field");
+    offerSearchField.setPlaceholder("Search for offers");
+    offerSearchField.setPrefixComponent(VaadinIcon.SEARCH.create());
     add(projectDesignTitle, projectDesignDescription, offerSearchField, codeTitleAndButtonSpan,
         projectDescription);
     addClassName("project-design-layout");
+  }
+
+  public void enableOfferSearch() {
+    offerSearchField.setEnabled(true);
+    offerSearchField.setVisible(true);
+    projectDesignDescription.add(" You can either select a project from the offer list or create a new one.");
   }
 
   private void initCodeGenerationButton() {
@@ -208,7 +219,6 @@ public class ProjectDesignLayout extends Div implements HasBinderValidation<Proj
   public String getDefaultErrorMessage() {
     return "Invalid Input found in Project Design";
   }
-
 
   public static final class ProjectDesign implements Serializable {
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/overview/ProjectOverviewMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/overview/ProjectOverviewMain.java
@@ -6,6 +6,9 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 import java.io.Serial;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import life.qbic.application.commons.ApplicationException;
 import life.qbic.application.commons.Result;
 import life.qbic.datamanager.views.AppRoutes.Projects;
@@ -26,6 +29,7 @@ import life.qbic.projectmanagement.application.ProjectCreationService;
 import life.qbic.projectmanagement.domain.model.project.Funding;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Project overview {@link Main} component that shows project information and additional components to manage project
@@ -63,6 +67,9 @@ public class ProjectOverviewMain extends Main {
     this.projectCollectionComponent.addCreateClickedListener(projectCreationClickedEvent -> {
       AddProjectDialog addProjectDialog = new AddProjectDialog(this.financeService,
           this.ontologyTermInformationService, this.contactRepository);
+      if(isOfferSearchAllowed()) {
+        addProjectDialog.enableOfferSearch();
+      }
       addProjectDialog.addConfirmListener(this::createProject);
       addProjectDialog.addCancelListener(it -> it.getSource().close());
       addProjectDialog.open();
@@ -73,6 +80,12 @@ public class ProjectOverviewMain extends Main {
         this.getClass().getSimpleName(), System.identityHashCode(this),
         projectCollectionComponent.getClass().getSimpleName(),
         System.identityHashCode(projectCollectionComponent)));
+  }
+
+  private boolean isOfferSearchAllowed() {
+    Set<String> allowedRoles = new HashSet<>(Arrays.asList("ROLE_ADMIN", "ROLE_PROJECT_MANAGER"));
+    return SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+        .anyMatch(r -> allowedRoles.contains(r.getAuthority()));
   }
 
   private void createProject(ConfirmEvent confirmEvent) {


### PR DESCRIPTION
* when adding a project, only adds offer search field to the interface if the user has admin or project_manager role
* disables search methods for offers for normal users (maybe unnecessary?)