### PR TITLE
Feature/dm 407 provide UI for sample measurement information

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementLookupImplementation.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementLookupImplementation.java
@@ -1,0 +1,210 @@
+package life.qbic.projectmanagement.infrastructure.experiment.measurement;
+
+import static life.qbic.logging.service.LoggerFactory.logger;
+
+import java.util.Collection;
+import java.util.List;
+import life.qbic.logging.api.Logger;
+import life.qbic.projectmanagement.application.SortOrder;
+import life.qbic.projectmanagement.application.measurement.MeasurementLookup;
+import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
+import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
+import life.qbic.projectmanagement.infrastructure.OffsetBasedRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+@Repository
+public class MeasurementLookupImplementation implements MeasurementLookup {
+
+  private static final Logger log = logger(MeasurementLookupImplementation.class);
+  private final NGSMeasurementJpaRepo ngsMeasurementJpaRepo;
+  private final ProteomicsMeasurementJpaRepo pxpMeasurementJpaRepo;
+  private final MeasurementDataRepo measurementDataRepo;
+
+  public MeasurementLookupImplementation(NGSMeasurementJpaRepo ngsMeasurementJpaRepo,
+      ProteomicsMeasurementJpaRepo pxpMeasurementJpaRepo,
+      MeasurementDataRepo measurementDataRepo) {
+    this.ngsMeasurementJpaRepo = ngsMeasurementJpaRepo;
+    this.pxpMeasurementJpaRepo = pxpMeasurementJpaRepo;
+    this.measurementDataRepo = measurementDataRepo;
+  }
+
+  @Override
+  public List<ProteomicsMeasurement> queryProteomicsMeasurementsBySampleIds(String filter,
+      Collection<SampleId> sampleIds, int offset,
+      int limit, List<SortOrder> sortOrders) {
+    List<Order> orders = sortOrders.stream().map(it -> {
+      Order order;
+      if (it.isDescending()) {
+        order = Order.desc(it.propertyName());
+      } else {
+        order = Order.asc(it.propertyName());
+      }
+      return order;
+    }).toList();
+    Specification<ProteomicsMeasurement> filterSpecification = generateProteomicsFilterSpecification(
+        sampleIds, filter);
+    return pxpMeasurementJpaRepo.findAll(filterSpecification,
+        new OffsetBasedRequest(offset, limit, Sort.by(orders))).getContent();
+  }
+
+  private Specification<ProteomicsMeasurement> generateProteomicsFilterSpecification(
+      Collection<SampleId> sampleIds, String filter) {
+    Specification<ProteomicsMeasurement> isBlankSpec = ProteomicsMeasurementSpec.isBlank(filter);
+    Specification<ProteomicsMeasurement> isDistinctSpec = ProteomicsMeasurementSpec.isDistinct();
+    Specification<ProteomicsMeasurement> containsSampleId = ProteomicsMeasurementSpec.containsSampleId(
+        sampleIds);
+    Specification<ProteomicsMeasurement> measurementCodeContains = ProteomicsMeasurementSpec.isMeasurementCode(
+        filter);
+    Specification<ProteomicsMeasurement> organisationLabelContains = ProteomicsMeasurementSpec.isOrganisationLabel(
+        filter);
+    Specification<ProteomicsMeasurement> ontologyNameContains = ProteomicsMeasurementSpec.isOntologyTermName(
+        filter);
+    Specification<ProteomicsMeasurement> ontologyDescriptionContains = ProteomicsMeasurementSpec.isOntologyTermDescription(
+        filter);
+    Specification<ProteomicsMeasurement> filterSpecification = Specification.anyOf(
+        measurementCodeContains,
+        organisationLabelContains, ontologyNameContains, ontologyDescriptionContains);
+    return Specification.where(isBlankSpec).and(containsSampleId).and(filterSpecification)
+        .and(isDistinctSpec);
+  }
+
+  @Override
+  public List<NGSMeasurement> queryNGSMeasurementsBySampleIds(String filter,
+      Collection<SampleId> sampleIds, int offset,
+      int limit, List<SortOrder> sortOrders) {
+    List<Order> orders = sortOrders.stream().map(it -> {
+      Order order;
+      if (it.isDescending()) {
+        order = Order.desc(it.propertyName());
+      } else {
+        order = Order.asc(it.propertyName());
+      }
+      return order;
+    }).toList();
+    Specification<NGSMeasurement> filterSpecification = generateNGSFilterSpecification(
+        sampleIds, filter);
+    return ngsMeasurementJpaRepo.findAll(filterSpecification,
+        new OffsetBasedRequest(offset, limit, Sort.by(orders))).getContent();
+  }
+
+  private Specification<NGSMeasurement> generateNGSFilterSpecification(
+      Collection<SampleId> sampleIds, String filter) {
+    Specification<NGSMeasurement> isBlankSpec = NgsMeasurementSpec.isBlank(filter);
+    Specification<NGSMeasurement> isDistinctSpec = NgsMeasurementSpec.isDistinct();
+    Specification<NGSMeasurement> containsSampleId = NgsMeasurementSpec.containsSampleId(
+        sampleIds);
+    Specification<NGSMeasurement> measurementCodeContains = NgsMeasurementSpec.isMeasurementCode(
+        filter);
+    //ToDo Extend with ngs property specs
+    Specification<NGSMeasurement> filterSpecification = Specification.anyOf(
+        measurementCodeContains);
+    return Specification.where(isBlankSpec).and(containsSampleId).and(filterSpecification)
+        .and(isDistinctSpec);
+  }
+
+
+  private static class ProteomicsMeasurementSpec {
+
+    //We need to ensure that we only count and retrieve unique samplePreviews
+    public static Specification<ProteomicsMeasurement> isDistinct() {
+      return (root, query, builder) -> {
+        query.distinct(true);
+        return null;
+      };
+    }
+
+    //We are only interested in measurements which contain at least one of the provided sampleIds
+    public static Specification<ProteomicsMeasurement> containsSampleId(
+        Collection<SampleId> sampleIds) {
+      return (root, query, builder) -> {
+        if (sampleIds.isEmpty()) {
+          //If no sampleId is in the experiment then there can also be no measurement
+          return builder.disjunction();
+        } else {
+          return root.join("measuredSamples").in(sampleIds);
+        }
+      };
+    }
+
+    //If no filter was provided return all SamplePreviews
+    public static Specification<ProteomicsMeasurement> isBlank(String filter) {
+      return (root, query, builder) -> {
+        if (filter != null && filter.isBlank()) {
+          return builder.conjunction();
+        }
+        return null;
+      };
+    }
+
+    public static Specification<ProteomicsMeasurement> isOrganisationLabel(String filter) {
+      return (root, query, builder) ->
+          builder.like(root.get("organisation").get("label"), "%" + filter + "%");
+    }
+
+    public static Specification<ProteomicsMeasurement> isOntologyTermName(String filter) {
+      return (root, query, builder) ->
+          builder.like(root.get("instrument").get("className"), "%" + filter + "%");
+    }
+
+    public static Specification<ProteomicsMeasurement> isOntologyTermDescription(String filter) {
+      return (root, query, builder) ->
+          builder.like(root.get("instrument").get("description"), "%" + filter + "%");
+    }
+
+    public static Specification<ProteomicsMeasurement> isMeasurementCode(String filter) {
+      return (root, query, builder) ->
+          builder.like(root.get("measurementCode").get("measurementCode"), "%" + filter + "%");
+    }
+  }
+
+  private static class NgsMeasurementSpec {
+
+    //We need to ensure that we only count and retrieve unique samplePreviews
+    public static Specification<NGSMeasurement> isDistinct() {
+      return (root, query, builder) -> {
+        query.distinct(true);
+        return null;
+      };
+    }
+
+    //We are only interested in measurements which contain at least one of the provided sampleIds
+    public static Specification<NGSMeasurement> containsSampleId(
+        Collection<SampleId> sampleIds) {
+      return (root, query, builder) -> {
+        if (sampleIds.isEmpty()) {
+          //If no sampleId is in the experiment then there can also be no measurement
+          return builder.disjunction();
+        } else {
+          return root.join("measuredSamples").in(sampleIds);
+        }
+      };
+    }
+
+    //If no filter was provided return all SamplePreviews
+    public static Specification<NGSMeasurement> isBlank(String filter) {
+      return (root, query, builder) -> {
+        if (filter != null && filter.isBlank()) {
+          return builder.conjunction();
+        }
+        return null;
+      };
+    }
+
+    public static Specification<NGSMeasurement> isMeasurementCode(String filter) {
+      return (root, query, builder) ->
+          builder.like(root.get("measurementCode").get("measurementCode"), "%" + filter + "%");
+    }
+    //ToDo extend with more property filters
+  }
+}

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementLookupImplementation.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementLookupImplementation.java
@@ -7,6 +7,7 @@ import java.util.List;
 import life.qbic.logging.api.Logger;
 import life.qbic.projectmanagement.application.SortOrder;
 import life.qbic.projectmanagement.application.measurement.MeasurementLookup;
+import life.qbic.projectmanagement.application.measurement.MeasurementMetadata;
 import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
@@ -17,11 +18,10 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 /**
- * <b><class short description - 1 Line!></b>
- *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
+ * Basic implementation to query measurement information
+ * <p></p>
+ * Employs JPA based {@link Specification} to provide the ability to filter each
+ * {@link MeasurementMetadata} with the provided string based searchTerm
  */
 @Repository
 public class MeasurementLookupImplementation implements MeasurementLookup {
@@ -106,7 +106,7 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
         sampleIds);
     Specification<NGSMeasurement> measurementCodeContains = NgsMeasurementSpec.isMeasurementCode(
         filter);
-    //ToDo Extend with ngs property specs
+    //ToDo Extend with required ngs property specs
     Specification<NGSMeasurement> filterSpecification = Specification.anyOf(
         measurementCodeContains);
     return Specification.where(isBlankSpec).and(containsSampleId).and(filterSpecification)
@@ -137,7 +137,7 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
       };
     }
 
-    //If no filter was provided return all SamplePreviews
+    //If no filter was provided return all proteomicsMeasurement
     public static Specification<ProteomicsMeasurement> isBlank(String filter) {
       return (root, query, builder) -> {
         if (filter != null && filter.isBlank()) {
@@ -170,7 +170,7 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
 
   private static class NgsMeasurementSpec {
 
-    //We need to ensure that we only count and retrieve unique samplePreviews
+    //We need to ensure that we only count and retrieve unique ngsMeasurements
     public static Specification<NGSMeasurement> isDistinct() {
       return (root, query, builder) -> {
         query.distinct(true);
@@ -191,7 +191,7 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
       };
     }
 
-    //If no filter was provided return all SamplePreviews
+    //If no filter was provided return all proteomicsMeasurement
     public static Specification<NGSMeasurement> isBlank(String filter) {
       return (root, query, builder) -> {
         if (filter != null && filter.isBlank()) {
@@ -205,6 +205,6 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
       return (root, query, builder) ->
           builder.like(root.get("measurementCode").get("measurementCode"), "%" + filter + "%");
     }
-    //ToDo extend with more property filters
+    //ToDo extend with required property filters
   }
 }

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementation.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementation.java
@@ -25,9 +25,7 @@ public class MeasurementRepositoryImplementation implements MeasurementRepositor
 
   private static final Logger log = logger(MeasurementRepositoryImplementation.class);
   private final NGSMeasurementJpaRepo measurementJpaRepo;
-
   private final ProteomicsMeasurementJpaRepo pxpMeasurementJpaRepo;
-
   private final MeasurementDataRepo measurementDataRepo;
 
   public MeasurementRepositoryImplementation(NGSMeasurementJpaRepo measurementJpaRepo,

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/NGSMeasurementJpaRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/NGSMeasurementJpaRepo.java
@@ -3,6 +3,7 @@ package life.qbic.projectmanagement.infrastructure.experiment.measurement;
 import life.qbic.projectmanagement.domain.model.measurement.MeasurementId;
 import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
  * <b><class short description - 1 Line!></b>
@@ -11,6 +12,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
  *
  * @since <version tag>
  */
-public interface NGSMeasurementJpaRepo extends JpaRepository<NGSMeasurement, MeasurementId> {
+public interface NGSMeasurementJpaRepo
+    extends JpaRepository<NGSMeasurement, MeasurementId>,
+    JpaSpecificationExecutor<NGSMeasurement> {
 
 }

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/NGSMeasurementJpaRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/NGSMeasurementJpaRepo.java
@@ -6,11 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
- * <b><class short description - 1 Line!></b>
- *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
+ * Simple NGS measurement JPA repository to query and filter concise
+ * {@link NGSMeasurement} information
  */
 public interface NGSMeasurementJpaRepo
     extends JpaRepository<NGSMeasurement, MeasurementId>,

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/ProteomicsMeasurementJpaRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/ProteomicsMeasurementJpaRepo.java
@@ -2,7 +2,8 @@ package life.qbic.projectmanagement.infrastructure.experiment.measurement;
 
 import life.qbic.projectmanagement.domain.model.measurement.MeasurementId;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
  * <b><interface short description - 1 Line!></b>
@@ -12,6 +13,7 @@ import org.springframework.data.repository.CrudRepository;
  * @since <version tag>
  */
 public interface ProteomicsMeasurementJpaRepo extends
-    CrudRepository<ProteomicsMeasurement, MeasurementId> {
+    JpaRepository<ProteomicsMeasurement, MeasurementId>,
+    JpaSpecificationExecutor<ProteomicsMeasurement> {
 
 }

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/ProteomicsMeasurementJpaRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/ProteomicsMeasurementJpaRepo.java
@@ -6,11 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
- * <b><interface short description - 1 Line!></b>
- *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
+ * Simple proteomics measurement JPA repository to query and filter concise
+ * {@link ProteomicsMeasurement} information
  */
 public interface ProteomicsMeasurementJpaRepo extends
     JpaRepository<ProteomicsMeasurement, MeasurementId>,

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookup.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookup.java
@@ -1,0 +1,38 @@
+package life.qbic.projectmanagement.application.measurement;
+
+import java.util.Collection;
+import java.util.List;
+import life.qbic.projectmanagement.application.SortOrder;
+import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
+import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public interface MeasurementLookup {
+
+  /**
+   * Queries {@link ProteomicsMeasurement} with a provided offset and limit that supports
+   * pagination.
+   *
+   * @param sampleIds  the list of {@link SampleId} for which the {@link ProteomicsMeasurement}
+   *                   should be fetched
+   * @param filter     the results fields will be checked for the value within this filter
+   * @param offset     the offset for the search result to start
+   * @param limit      the maximum number of results that should be returned
+   * @param sortOrders the ordering to sort by
+   * @return the results in the provided range
+   */
+  List<ProteomicsMeasurement> queryProteomicsMeasurementsBySampleIds(String filter,
+      Collection<SampleId> sampleIds, int offset,
+      int limit, List<SortOrder> sortOrders);
+
+  List<NGSMeasurement> queryNGSMeasurementsBySampleIds(String filter,
+      Collection<SampleId> sampleIds, int offset,
+      int limit, List<SortOrder> sortOrders);
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookup.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookup.java
@@ -7,13 +7,6 @@ import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
 
-/**
- * <class short description - One Line!>
- * <p>
- * <More detailed description - When to use, what it solves, etc.>
- *
- * @since <version tag>
- */
 public interface MeasurementLookup {
 
   /**

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookupService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookupService.java
@@ -1,0 +1,75 @@
+package life.qbic.projectmanagement.application.measurement;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import life.qbic.logging.api.Logger;
+import life.qbic.logging.service.LoggerFactory;
+import life.qbic.projectmanagement.application.SortOrder;
+import life.qbic.projectmanagement.application.ontology.OntologyClass;
+import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
+import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
+import life.qbic.projectmanagement.domain.repository.MeasurementRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * MeasurementLookupService
+ * <p>
+ * Service that provides an API to query measurement information
+ */
+@Service
+public class MeasurementLookupService {
+
+  private static final Logger log = LoggerFactory.logger(MeasurementLookupService.class);
+  private final MeasurementRepository measurementRepository;
+  private final MeasurementLookup measurementLookup;
+
+  public MeasurementLookupService(@Autowired MeasurementLookup measurementLookup,
+      @Autowired MeasurementRepository measurementRepository) {
+    this.measurementLookup = Objects.requireNonNull(measurementLookup);
+    this.measurementRepository = Objects.requireNonNull(measurementRepository);
+  }
+
+  /**
+   * Queries {@link OntologyClass}s with a provided offset and limit that supports pagination.
+   *
+   * @param termFilter the user's input will be applied to filter results
+   * @param offset     the offset for the search result to start
+   * @param limit      the maximum number of results that should be returned
+   * @param sortOrders the sort orders to apply
+   * @return the results in the provided range
+   * @since 1.0.0
+   */
+  public List<ProteomicsMeasurement> queryProteomicsMeasurementsBySampleIds(String termFilter,
+      List<SampleId> sampleIds, int offset, int limit, List<SortOrder> sortOrders) {
+    // returned by JPA -> UnmodifiableRandomAccessList
+    List<ProteomicsMeasurement> termList = measurementLookup.queryProteomicsMeasurementsBySampleIds(
+        termFilter, sampleIds, offset,
+        limit, sortOrders);
+    // the list must be modifiable for spring security to filter it
+    return new ArrayList<>(termList);
+  }
+
+  /**
+   * Queries {@link OntologyClass}s with a provided offset and limit that supports pagination.
+   *
+   * @param termFilter the user's input will be applied to filter results
+   * @param offset     the offset for the search result to start
+   * @param limit      the maximum number of results that should be returned
+   * @param sortOrders the sort orders to apply
+   * @return the results in the provided range
+   * @since 1.0.0
+   */
+  public List<NGSMeasurement> queryNGSMeasurementsBySampleIds(String termFilter,
+      List<SampleId> sampleIds, int offset, int limit, List<SortOrder> sortOrders) {
+    // returned by JPA -> UnmodifiableRandomAccessList
+    List<NGSMeasurement> termList = measurementLookup.queryNGSMeasurementsBySampleIds(termFilter,
+        sampleIds, offset,
+        limit, sortOrders);
+    // the list must be modifiable for spring security to filter it
+    return new ArrayList<>(termList);
+  }
+
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookupService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookupService.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import life.qbic.logging.api.Logger;
 import life.qbic.logging.service.LoggerFactory;
 import life.qbic.projectmanagement.application.SortOrder;
-import life.qbic.projectmanagement.application.ontology.OntologyClass;
 import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
@@ -17,7 +16,7 @@ import org.springframework.stereotype.Service;
 /**
  * MeasurementLookupService
  * <p>
- * Service that provides an API to query measurement information
+ * Service that provides an API to query and filter measurement information
  */
 @Service
 public class MeasurementLookupService {
@@ -33,14 +32,13 @@ public class MeasurementLookupService {
   }
 
   /**
-   * Queries {@link OntologyClass}s with a provided offset and limit that supports pagination.
+   * Queries {@link ProteomicsMeasurement}s with a provided offset and limit that supports pagination.
    *
    * @param termFilter the user's input will be applied to filter results
    * @param offset     the offset for the search result to start
    * @param limit      the maximum number of results that should be returned
    * @param sortOrders the sort orders to apply
    * @return the results in the provided range
-   * @since 1.0.0
    */
   public List<ProteomicsMeasurement> queryProteomicsMeasurementsBySampleIds(String termFilter,
       List<SampleId> sampleIds, int offset, int limit, List<SortOrder> sortOrders) {
@@ -53,14 +51,13 @@ public class MeasurementLookupService {
   }
 
   /**
-   * Queries {@link OntologyClass}s with a provided offset and limit that supports pagination.
+   * Queries {@link NGSMeasurement}s with a provided offset and limit that supports pagination.
    *
    * @param termFilter the user's input will be applied to filter results
    * @param offset     the offset for the search result to start
    * @param limit      the maximum number of results that should be returned
    * @param sortOrders the sort orders to apply
    * @return the results in the provided range
-   * @since 1.0.0
    */
   public List<NGSMeasurement> queryNGSMeasurementsBySampleIds(String termFilter,
       List<SampleId> sampleIds, int offset, int limit, List<SortOrder> sortOrders) {

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -3,22 +3,26 @@ package life.qbic.projectmanagement.application.measurement;
 import static life.qbic.logging.service.LoggerFactory.logger;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import life.qbic.application.commons.Result;
 import life.qbic.logging.api.Logger;
 import life.qbic.projectmanagement.application.OrganisationLookupService;
+import life.qbic.projectmanagement.application.SortOrder;
 import life.qbic.projectmanagement.application.ontology.OntologyLookupService;
 import life.qbic.projectmanagement.application.sample.SampleIdCodeEntry;
 import life.qbic.projectmanagement.application.sample.SampleInformationService;
 import life.qbic.projectmanagement.domain.Organisation;
 import life.qbic.projectmanagement.domain.model.OntologyTerm;
+import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.measurement.MeasurementCode;
 import life.qbic.projectmanagement.domain.model.measurement.MeasurementId;
 import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMethodMetadata;
 import life.qbic.projectmanagement.domain.model.sample.SampleCode;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
 import life.qbic.projectmanagement.domain.service.MeasurementDomainService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -49,6 +53,50 @@ public class MeasurementService {
     this.ontologyLookupService = Objects.requireNonNull(ontologyLookupService);
     this.organisationLookupService = Objects.requireNonNull(organisationLookupService);
   }
+
+
+  public Collection<NGSMeasurement> findNGSMeasurements(ExperimentId experimentId, int offset,
+      int limit,
+      List<SortOrder> sortOrders, String filter) {
+    //return new ArrayList<>();
+    //ToDo implement Lazy Loading in Backend
+    return List.of(
+        NGSMeasurement.create(List.of(SampleId.create(), SampleId.create(), SampleId.create()),
+            MeasurementCode.createNGS("ABCDE"),
+            new
+
+                OntologyTerm("ontA1", "ontV1", "ontI1", "ontL1", "ontN1", "ontD1", "ontCI1")),
+        NGSMeasurement.create(List.of(SampleId.create(), SampleId.create()),
+            MeasurementCode.createNGS("FGHIJ"),
+            new
+
+                OntologyTerm("ontA2", "ontV2", "ontI2", "ontL2", "ontN2", "ontD2", "ontCI2")));
+  }
+
+
+  public Collection<ProteomicsMeasurement> findProteomicsMeasurement(ExperimentId experimentId,
+      int offset, int limit,
+      List<SortOrder> sortOrders, String filter) {
+    //ToDo implement Lazy Loading in Backend
+    //return new ArrayList<>();
+    return List.of(
+        ProteomicsMeasurement.create(
+            List.of(SampleId.create(), SampleId.create(), SampleId.create()),
+            MeasurementCode.createMS("ABCDE"), new Organisation("ProtIri1", "ProtOrglabel1"),
+            new ProteomicsMethodMetadata(
+                new OntologyTerm("ontA1", "ontV1", "ontI1", "ontL1", "ontN1", "ontD1", "ontCI1"),
+                "ProtPSL1", "ProtFN1", "ProtFT1",
+                "ProtDM1", "ProtDE1", "ProtEM1", 1, "ProtIC1", "ProtLM1")
+        ), ProteomicsMeasurement.create(
+            List.of(SampleId.create(), SampleId.create(), SampleId.create()),
+            MeasurementCode.createMS("FGHIJ"), new Organisation("ProtIri2", "ProtOrgLabel2"),
+            new ProteomicsMethodMetadata(
+                new OntologyTerm("ontA2", "ontV2", "ontI2", "ontL2", "ontN2", "ontD2", "ontCI2"),
+                "ProtPSL2", "ProtFN2", "ProtFT2",
+                "ProtDM2", "ProtDE2", "ProtEM2", 2, "ProtIC2", "ProtLM2")
+        ));
+  }
+
 
   public Result<MeasurementId, ResponseCode> registerNGS(
       MeasurementRegistrationRequest<NGSMeasurementMetadata> registrationRequest) {
@@ -99,7 +147,8 @@ public class MeasurementService {
       return Result.fromError(ResponseCode.UNKNOWN_ONTOLOGY_TERM);
     }
 
-    var organisationQuery = organisationLookupService.organisation(registrationRequest.metadata().organisationId());
+    var organisationQuery = organisationLookupService.organisation(
+        registrationRequest.metadata().organisationId());
     if (organisationQuery.isEmpty()) {
       return Result.fromError(ResponseCode.UNKNOWN_ORGANISATION_ROR_ID);
     }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -26,12 +26,11 @@ import life.qbic.projectmanagement.domain.service.MeasurementDomainService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+
 /**
- * <b><class short description - 1 Line!></b>
- *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
+ * Measurement Service
+ * <p>
+ * Service that provides an API to manage and query measurement information
  */
 @Service
 public class MeasurementService {

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/measurement/NGSMeasurement.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/measurement/NGSMeasurement.java
@@ -11,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.Optional;
 import life.qbic.projectmanagement.application.measurement.MeasurementMetadata;
 import life.qbic.projectmanagement.domain.model.OntologyTerm;
 import life.qbic.projectmanagement.domain.model.sample.SampleId;
@@ -101,4 +100,11 @@ public class NGSMeasurement implements MeasurementMetadata {
     return id;
   }
 
+  public Collection<SampleId> measuredSamples() {
+    return measuredSamples;
+  }
+
+  public OntologyTerm instrument() {
+    return instrument;
+  }
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/measurement/ProteomicsMeasurement.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/measurement/ProteomicsMeasurement.java
@@ -57,7 +57,8 @@ public class ProteomicsMeasurement implements MeasurementMetadata {
     this.measurementCode = measurementCode;
   }
 
-  private ProteomicsMeasurement(Collection<SampleId> sampleIds, MeasurementCode measurementCode, Organisation organisation,
+  private ProteomicsMeasurement(Collection<SampleId> sampleIds, MeasurementCode measurementCode,
+      Organisation organisation,
       ProteomicsMethodMetadata method) {
     measuredSamples = new ArrayList<>();
     measuredSamples.addAll(sampleIds);
@@ -70,9 +71,9 @@ public class ProteomicsMeasurement implements MeasurementMetadata {
    * Creates a new {@link ProteomicsMeasurement} object instance, that describes an NGS measurement
    * entity with many describing properties about provenance and instrumentation.
    *
-   * @param sampleIds  the sample ids of the samples the measurement was performed on. If more than
-   *                   one sample id is provided, the measurement is considered to be performed on a
-   *                   pooled sample
+   * @param sampleIds the sample ids of the samples the measurement was performed on. If more than
+   *                  one sample id is provided, the measurement is considered to be performed on a
+   *                  pooled sample
    * @return
    * @since 1.0.0
    */
@@ -84,7 +85,7 @@ public class ProteomicsMeasurement implements MeasurementMetadata {
     }
     Objects.requireNonNull(method.instrument());
     Objects.requireNonNull(measurementCode);
-    if (!measurementCode.isNGSDomain()) {
+    if (!measurementCode.isMSDomain()) {
       throw new IllegalArgumentException(
           "Proteomics code is not from the Proteomics domain for: \"" + measurementCode + "\"");
     }
@@ -121,4 +122,15 @@ public class ProteomicsMeasurement implements MeasurementMetadata {
     return id;
   }
 
+  public Collection<SampleId> measuredSamples() {
+    return measuredSamples;
+  }
+
+  public OntologyTerm instrument() {
+    return instrument;
+  }
+
+  public Organisation organisation() {
+    return organisation;
+  }
 }

--- a/user-interface/frontend/themes/datamanager/components/icon.css
+++ b/user-interface/frontend/themes/datamanager/components/icon.css
@@ -9,3 +9,7 @@ vaadin-icon.error {
 vaadin-icon.clickable {
   cursor: pointer;
 }
+
+vaadin-icon.small {
+  width: var(--lumo-icon-size-s);
+}

--- a/user-interface/frontend/themes/datamanager/components/main.css
+++ b/user-interface/frontend/themes/datamanager/components/main.css
@@ -15,8 +15,8 @@
 }
 
 .main.measurement {
-  grid-template-columns: minmax(min-content, 70%) minmax(min-content, 30%);
-  grid-template-rows: minmax(min-content, 20%) minmax(min-content, 75%);
+  grid-template-columns: minmax(max-content, 70%) minmax(max-content, 30%);
+  grid-template-rows: minmax(max-content, 20%) minmax(max-content, 75%);
   grid-template-areas:
     ". measurementtemplatelist"
     "measurementdetails measurementdetails";
@@ -24,6 +24,33 @@
 
 .main.measurement .measurement-template-list-component {
   grid-area: measurementtemplatelist;
+}
+
+
+.main.measurement .measurement-details-component {
+  grid-area: measurementdetails
+}
+
+.main.measurement .measurement-main-content {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--lumo-space-m);
+  padding: var(--lumo-space-m);
+}
+
+
+.main.measurement .measurement-main-content .title {
+  font-weight: bold;
+  color: var(--lumo-secondary-text-color);
+  font-size: var(--lumo-font-size-xxl);
+  margin-bottom: 0.5rem;
+}
+
+.main.measurement .measurement-main-content .buttonAndField {
+  display: inline-flex;
+  justify-content: space-between;
+  /*Moves this bar to end of container*/
+  margin-top: auto;
 }
 
 .main.project {

--- a/user-interface/frontend/themes/datamanager/components/page-area.css
+++ b/user-interface/frontend/themes/datamanager/components/page-area.css
@@ -127,6 +127,47 @@
   gap: var(--lumo-space-m);
 }
 
+.measurement-details-component {
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.measurement-details-component .measurement-tabsheet {
+  height: 100%;
+  width: 100%;
+}
+
+.measurement-details-component .measurement-grid {
+  height: 100%;
+  width: 100%;
+}
+
+.measurement-details-component .measurement-grid .sample-code-column {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--lumo-space-s);
+}
+
+
+.measurement-details-component .no-measurements-registered-disclaimer {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--lumo-space-m);
+  align-items: center;
+}
+
+.measurement-details-component .no-measurements-registered-disclaimer .no-measurement-registered-title {
+  font-weight: bold;
+  font-size: var(--lumo-font-size-m);
+  margin-bottom: 0.5rem;
+}
+
+.measurement-details-component .no-measurements-registered-disclaimer .no-measurement-registered-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 
 .personal-access-token-component {
   row-gap: var(--lumo-space-l);

--- a/user-interface/frontend/themes/datamanager/components/span.css
+++ b/user-interface/frontend/themes/datamanager/components/span.css
@@ -13,6 +13,16 @@
   color: var(--lumo-error-text-color);
 }
 
+.info-box {
+  display: inline-flex;
+  column-gap: var(--lumo-space-m);
+  background-color: var(--lumo-contrast-10pct);
+  align-items: center;
+  width: fit-content;
+  padding-inline: var(--lumo-space-m);
+  padding-top: var(--lumo-space-xs);
+  padding-bottom: var(--lumo-space-xs);
+}
 /* ontology-link styling */
 .ontology-link {
   display: inline-flex;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/InfoBox.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/InfoBox.java
@@ -1,0 +1,41 @@
+package life.qbic.datamanager.views.general;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.theme.lumo.LumoIcon;
+
+/**
+ * Info box
+ * <p>
+ * Small Info box component based on the {@link Span} component to inform the user- Can be set to be
+ * closeable or have additional components if necessary to avoid
+ */
+public class InfoBox extends Span {
+
+  private final Icon infoIcon = VaadinIcon.INFO_CIRCLE.create();
+  private final Span infoText = new Span("");
+  private final Icon removeInfoIcon = LumoIcon.CROSS.create();
+
+  public InfoBox() {
+    infoIcon.addClassNames("primary", "small");
+    add(infoIcon);
+    add(infoText);
+    removeInfoIcon.addClassNames("clickable", "primary", "small");
+    removeInfoIcon.addClickListener(event -> this.setVisible(false));
+    addClassName("info-box");
+  }
+
+  public void setInfoText(String text) {
+    infoText.setText(text);
+  }
+
+  public void setClosable(boolean isClosable) {
+    if (isClosable && !getChildren().toList().contains(removeInfoIcon)) {
+      add(removeInfoIcon);
+    }
+    if (!isClosable && getChildren().toList().contains(removeInfoIcon)) {
+      remove(removeInfoIcon);
+    }
+  }
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
@@ -1,0 +1,229 @@
+package life.qbic.datamanager.views.projects.project.measurements;
+
+import static life.qbic.logging.service.LoggerFactory.logger;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.grid.dataview.GridLazyDataView;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.TabSheet;
+import com.vaadin.flow.data.provider.AbstractDataView;
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.spring.annotation.SpringComponent;
+import com.vaadin.flow.spring.annotation.UIScope;
+import jakarta.annotation.security.PermitAll;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import life.qbic.datamanager.views.Context;
+import life.qbic.datamanager.views.general.InfoBox;
+import life.qbic.datamanager.views.general.PageArea;
+import life.qbic.logging.api.Logger;
+import life.qbic.projectmanagement.application.SortOrder;
+import life.qbic.projectmanagement.application.measurement.MeasurementMetadata;
+import life.qbic.projectmanagement.application.measurement.MeasurementService;
+import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
+import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
+import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
+import life.qbic.projectmanagement.domain.model.sample.SampleId;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Enables the user to manage the registered {@link MeasurementMetadata} by providing the ability to
+ * register new measurements, search already registered measurements and view measurements dependent
+ * on the lab facility (Proteomics, Genomics, Imaging...)
+ */
+@SpringComponent
+@UIScope
+@PermitAll
+public class MeasurementDetailsComponent extends PageArea implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 5086686432247130622L;
+  private static final Logger log = logger(MeasurementDetailsComponent.class);
+  private final TabSheet registerMeasurementTabSheet = new TabSheet();
+  private final Div noMeasurementDisclaimer = new Div();
+  private String searchTerm = "";
+  private final Grid<NGSMeasurement> ngsMeasurementGrid = new Grid<>();
+  private final Grid<ProteomicsMeasurement> proteomicsMeasurementGrid = new Grid<>();
+  private final Collection<GridLazyDataView<?>> measurementsGridDataViews = new ArrayList<>();
+  private final transient MeasurementService measurementService;
+  private final List<Tab> tabsInTabSheet = new ArrayList<>();
+  private transient Context context;
+
+  public MeasurementDetailsComponent(@Autowired MeasurementService measurementService) {
+    this.measurementService = Objects.requireNonNull(measurementService);
+    initNoMeasurementDisclaimer();
+    createProteomicsGrid();
+    createNGSMeasurementGrid();
+    add(noMeasurementDisclaimer);
+    add(registerMeasurementTabSheet);
+    registerMeasurementTabSheet.addClassName("measurement-tabsheet");
+    addClassName("measurement-details-component");
+  }
+
+  public void setExperimentId(ExperimentId experimentId) {
+    resetTabsInTabsheet();
+    context = new Context().with(experimentId);
+    List<GridLazyDataView<?>> dataViewsWithItems = measurementsGridDataViews.stream()
+        .filter(gridLazyDataView -> gridLazyDataView.getItems()
+            .findAny().isPresent()).toList();
+    /*If none of the measurement types have items show default state with noMeasurement Disclaimer*/
+    if (dataViewsWithItems.isEmpty()) {
+      noMeasurementDisclaimer.setVisible(true);
+      return;
+    }
+    noMeasurementDisclaimer.setVisible(false);
+    dataViewsWithItems.forEach(this::addMeasurementTab);
+    registerMeasurementTabSheet.setVisible(true);
+  }
+
+  public void setSearchedMeasurementValue(String value) {
+    searchTerm = value;
+    measurementsGridDataViews.forEach(AbstractDataView::refreshAll);
+  }
+
+  public void addRegisterMeasurementClickedListener(
+      ComponentEventListener<MeasurementAddClickEvent> addMeasurementListener) {
+    addListener(MeasurementAddClickEvent.class, addMeasurementListener);
+  }
+
+  /*Vaadin provides no easy way to remove all tabs in a tabSheet*/
+  private void resetTabsInTabsheet() {
+    if (!tabsInTabSheet.isEmpty()) {
+      tabsInTabSheet.forEach(registerMeasurementTabSheet::remove);
+      tabsInTabSheet.clear();
+    }
+  }
+
+  private void addMeasurementTab(GridLazyDataView<?> gridLazyDataView) {
+    if (gridLazyDataView.getItem(0) instanceof ProteomicsMeasurement) {
+      tabsInTabSheet.add(registerMeasurementTabSheet.add("Proteomics", proteomicsMeasurementGrid));
+    }
+    if (gridLazyDataView.getItem(0) instanceof NGSMeasurement) {
+      tabsInTabSheet.add(registerMeasurementTabSheet.add("Genomics", ngsMeasurementGrid));
+    }
+  }
+
+  private void createNGSMeasurementGrid() {
+    ngsMeasurementGrid.addClassName("measurement-grid");
+    ngsMeasurementGrid.addColumn(ngsMeasurement -> ngsMeasurement.measurementCode().value())
+        .setHeader("Measurement Code");
+    ngsMeasurementGrid.addComponentColumn(
+            ngsMeasurement -> renderSampleCodes().createComponent(ngsMeasurement.measuredSamples()))
+        .setHeader("Sample Codes");
+    ngsMeasurementGrid.addColumn(ngsMeasurement -> ngsMeasurement.instrument().getLabel())
+        .setHeader("Instrument");
+    ngsMeasurementGrid.addColumn(ngsMeasurement -> ngsMeasurement.instrument().getDescription())
+        .setHeader("Description");
+    ngsMeasurementGrid.addColumn(ngsMeasurement -> ngsMeasurement.instrument().getName())
+        .setHeader("Name");
+    ngsMeasurementGrid.addThemeVariants(GridVariant.LUMO_WRAP_CELL_CONTENT);
+    GridLazyDataView<NGSMeasurement> ngsGridDataView = ngsMeasurementGrid.setItems(query -> {
+      List<SortOrder> sortOrders = query.getSortOrders().stream().map(
+              it -> new SortOrder(it.getSorted(), it.getDirection().equals(SortDirection.ASCENDING)))
+          .collect(Collectors.toList());
+      // if no order is provided by the grid order by last modified (least priority)
+      sortOrders.add(SortOrder.of("measurementCode").ascending());
+      return measurementService.findNGSMeasurements(context.experimentId().orElseThrow(),
+          query.getOffset(), query.getLimit(), sortOrders, searchTerm).stream();
+    });
+    measurementsGridDataViews.add(ngsGridDataView);
+  }
+
+  private void createProteomicsGrid() {
+    proteomicsMeasurementGrid.addClassName("measurement-grid");
+    proteomicsMeasurementGrid.addColumn(
+            proteomicsMeasurement -> proteomicsMeasurement.measurementCode().value())
+        .setHeader("Measurement Code");
+    proteomicsMeasurementGrid.addComponentColumn(
+        proteomicsMeasurement -> renderSampleCodes().createComponent(
+            proteomicsMeasurement.measuredSamples())).setHeader("Sample Codes");
+    proteomicsMeasurementGrid.addColumn(
+            proteomicsMeasurement -> proteomicsMeasurement.organisation().label())
+        .setHeader("Organisation");
+    proteomicsMeasurementGrid.addColumn(
+            proteomicsMeasurement -> proteomicsMeasurement.instrument().getLabel())
+        .setHeader("Instrument");
+    proteomicsMeasurementGrid.addColumn(
+            proteomicsMeasurement -> proteomicsMeasurement.instrument().getDescription())
+        .setHeader("Description");
+    proteomicsMeasurementGrid.addColumn(
+            proteomicsMeasurement -> proteomicsMeasurement.instrument().getName())
+        .setHeader("Name");
+    proteomicsMeasurementGrid.addThemeVariants(GridVariant.LUMO_WRAP_CELL_CONTENT);
+    GridLazyDataView<ProteomicsMeasurement> proteomicsGridDataView = proteomicsMeasurementGrid.setItems(
+        query -> {
+          List<SortOrder> sortOrders = query.getSortOrders().stream().map(
+                  it -> new SortOrder(it.getSorted(),
+                      it.getDirection().equals(SortDirection.ASCENDING)))
+              .collect(Collectors.toList());
+          // if no order is provided by the grid order by last modified (least priority)
+          sortOrders.add(SortOrder.of("measurementCode").ascending());
+          return measurementService.findProteomicsMeasurement(context.experimentId().orElseThrow(),
+              query.getOffset(), query.getLimit(), sortOrders, searchTerm).stream();
+        });
+    measurementsGridDataViews.add(proteomicsGridDataView);
+  }
+
+  //ToDo Replace with SampleCode
+  private static ComponentRenderer<Div, Collection<SampleId>> renderSampleCodes() {
+    return new ComponentRenderer<>(sampleCodes -> {
+      Div showSampleCodes = new Div();
+      showSampleCodes.addClassName("sample-code-column");
+      sampleCodes.forEach(sampleId -> showSampleCodes.add(new Span(sampleId.value())));
+      return showSampleCodes;
+    });
+  }
+
+  private void initNoMeasurementDisclaimer() {
+    Span disclaimerTitle = new Span("Manage your measurement metadata");
+    disclaimerTitle.addClassName("no-measurement-registered-title");
+    noMeasurementDisclaimer.add(disclaimerTitle);
+    Div noMeasurementDisclaimerContent = new Div();
+    noMeasurementDisclaimerContent.addClassName("no-measurement-registered-content");
+    Span noMeasurementText1 = new Span("Start by downloading the required metadata template");
+    Span noMeasurementText2 = new Span(
+        "Fill the metadata sheet and register your measurement metadata.");
+    noMeasurementDisclaimerContent.add(noMeasurementText1);
+    noMeasurementDisclaimerContent.add(noMeasurementText2);
+    noMeasurementDisclaimer.add(noMeasurementDisclaimerContent);
+    InfoBox availableTemplatesInfo = new InfoBox();
+    availableTemplatesInfo.setInfoText(
+        "You can download the measurement metadata template from the Templates component above");
+    availableTemplatesInfo.setClosable(false);
+    noMeasurementDisclaimer.add(availableTemplatesInfo);
+    Button registerMeasurements = new Button("Register Measurements");
+    registerMeasurements.addClassName("primary");
+    noMeasurementDisclaimer.add(registerMeasurements);
+    registerMeasurements.addClickListener(
+        event -> fireEvent(new MeasurementAddClickEvent(this, event.isFromClient())));
+    noMeasurementDisclaimer.addClassName("no-measurements-registered-disclaimer");
+  }
+
+  public static class MeasurementAddClickEvent extends
+      ComponentEvent<MeasurementDetailsComponent> {
+
+    /**
+     * Creates a new event using the given source and indicator whether the event originated from
+     * the client side or the server side.
+     *
+     * @param source     the source component
+     * @param fromClient <code>true</code> if the event originated from the client
+     *                   side, <code>false</code> otherwise
+     */
+    public MeasurementAddClickEvent(MeasurementDetailsComponent source, boolean fromClient) {
+      super(source, fromClient);
+    }
+  }
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
@@ -72,6 +72,13 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
     addClassName("measurement-details-component");
   }
 
+  /**
+   * Provides the {@link ExperimentId} to the {@link GridLazyDataView}s to query the
+   * {@link MeasurementMetadata} shown in the grids of this component
+   *
+   * @param experimentId ExperimentId of the experiment containing the samples for which
+   *                     measurements could be registered
+   */
   public void setExperimentId(ExperimentId experimentId) {
     resetTabsInTabsheet();
     context = new Context().with(experimentId);
@@ -89,11 +96,28 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
     registerMeasurementTabSheet.setVisible(true);
   }
 
-  public void setSearchedMeasurementValue(String value) {
-    searchTerm = value;
+  /**
+   * Propagates the search Term provided by the user
+   * <p>
+   * The string based search term is used to filter the {@link MeasurementMetadata} shown in the
+   * grid of each individual tab of the Tabsheet within this component
+   *
+   * @param searchTerm String based searchTerm for which the properties of each measurement should
+   *                   be filtered for
+   */
+  public void setSearchedMeasurementValue(String searchTerm) {
+    this.searchTerm = searchTerm;
     measurementsGridDataViews.forEach(AbstractDataView::refreshAll);
   }
 
+
+  /**
+   * Informs the listener that a {@link MeasurementAddClickEvent} has occurred within the disclaimer
+   * of this component
+   *
+   * @param addMeasurementListener listener which will be informed if a
+   *                               {@link MeasurementAddClickEvent} has been fired
+   */
   public void addRegisterMeasurementClickedListener(
       ComponentEventListener<MeasurementAddClickEvent> addMeasurementListener) {
     addListener(MeasurementAddClickEvent.class, addMeasurementListener);
@@ -216,6 +240,13 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
     noMeasurementDisclaimer.addClassName("no-measurements-registered-disclaimer");
   }
 
+
+  /**
+   * Measurement Add Click Event
+   * <p></p>
+   * ComponentEvent which informs the system that {@link MeasurementMetadata} is intended to be
+   * added to the system
+   */
   public static class MeasurementAddClickEvent extends
       ComponentEvent<MeasurementDetailsComponent> {
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
@@ -81,6 +81,7 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
     /*If none of the measurement types have items show default state with noMeasurement Disclaimer*/
     if (dataViewsWithItems.isEmpty()) {
       noMeasurementDisclaimer.setVisible(true);
+      registerMeasurementTabSheet.setVisible(false);
       return;
     }
     noMeasurementDisclaimer.setVisible(false);
@@ -135,8 +136,9 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
           .collect(Collectors.toList());
       // if no order is provided by the grid order by last modified (least priority)
       sortOrders.add(SortOrder.of("measurementCode").ascending());
-      return measurementService.findNGSMeasurements(context.experimentId().orElseThrow(),
-          query.getOffset(), query.getLimit(), sortOrders, searchTerm).stream();
+      return measurementService.findNGSMeasurements(searchTerm,
+          context.experimentId().orElseThrow(),
+          query.getOffset(), query.getLimit(), sortOrders).stream();
     });
     measurementsGridDataViews.add(ngsGridDataView);
   }
@@ -146,9 +148,11 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
     proteomicsMeasurementGrid.addColumn(
             proteomicsMeasurement -> proteomicsMeasurement.measurementCode().value())
         .setHeader("Measurement Code");
-    proteomicsMeasurementGrid.addComponentColumn(
+    //ToDo figure out how to best load this
+   /* proteomicsMeasurementGrid.addComponentColumn(
         proteomicsMeasurement -> renderSampleCodes().createComponent(
             proteomicsMeasurement.measuredSamples())).setHeader("Sample Codes");
+    */
     proteomicsMeasurementGrid.addColumn(
             proteomicsMeasurement -> proteomicsMeasurement.organisation().label())
         .setHeader("Organisation");
@@ -170,8 +174,9 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
               .collect(Collectors.toList());
           // if no order is provided by the grid order by last modified (least priority)
           sortOrders.add(SortOrder.of("measurementCode").ascending());
-          return measurementService.findProteomicsMeasurement(context.experimentId().orElseThrow(),
-              query.getOffset(), query.getLimit(), sortOrders, searchTerm).stream();
+          return measurementService.findProteomicsMeasurement(searchTerm,
+              context.experimentId().orElseThrow(),
+              query.getOffset(), query.getLimit(), sortOrders).stream();
         });
     measurementsGridDataViews.add(proteomicsGridDataView);
   }


### PR DESCRIPTION
**What was changed**
This PR provides a UI implementation for showing the measurement data with lazy loading.

**ToDo**
1.) Decide on the properties to be filtered 
2.) Introduce frontend records hosting these properties to avoid leaking "entity" information
3.) Update Measurement validation in uploadDialog

**How to test**
A) Go to a measurement page without registered measurements --> disclaimer is shown
B) Go to the measurement main component for project `3997943c-4a08-4990-8df9-312230118445` and its experiment `68e55d0f-053e-4ac1-a346-2e4edc73e0aa` to see the registered proteomics measurements