### PR TITLE
Enable optimistic locking for concurrent sample batch updates

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/batch/BatchJpaRepository.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/batch/BatchJpaRepository.java
@@ -58,7 +58,7 @@ public class BatchJpaRepository implements BatchRepository {
 
   @Override
   public Result<Batch, ResponseCode> update(Batch batch) {
-    return Result.fromValue(this.qbicBatchRepo.save(batch));
+    return Result.fromValue(this.qbicBatchRepo.saveAndFlush(batch));
   }
 
   @Override

--- a/project-management/pom.xml
+++ b/project-management/pom.xml
@@ -91,5 +91,9 @@
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-orm</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/batch/BatchRegistrationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/batch/BatchRegistrationService.java
@@ -86,6 +86,7 @@ public class BatchRegistrationService {
   }
 
   public Result<BatchId, ResponseCode> addSampleToBatch(SampleId sampleId, BatchId batchId) {
+    var random = new Random();
     while (true) {
       try {
         return tryToUpdateBatch(sampleId, batchId);
@@ -95,7 +96,7 @@ public class BatchRegistrationService {
                 batchId.value()));
       }
       try {
-        Thread.sleep(new Random().nextInt(500));
+        Thread.sleep(random.nextInt(500));
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/batch/Batch.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/batch/Batch.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Version;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,6 +29,9 @@ public class Batch {
   @EmbeddedId
   @Column(name = "id")
   private BatchId id;
+
+  @Version
+  private int version;
 
   @Column(name = "batchLabel")
   private String label;


### PR DESCRIPTION
The current implementation allowed JobRunner processes to concurrently load batch entities upon the AddSampleToBatch directive execution.

However, this lead to unwanted side-effects, resulting in batch information with corrupted state. The samples connected to the batch were random after every batch registration.

The reason for this side-effect is the concurrent loading and manipulation of the batch entity. Multiple processes are competing to read and update the sample batch with the sample id they are assigned to add. 

Since this is a classical race condition on data base level, we enable optimistic locking for the batch update transaction.