### PR TITLE
Enable username for new user registrations

### DIFF
--- a/identity-api/src/main/java/life/qbic/identity/api/UserInfo.java
+++ b/identity-api/src/main/java/life/qbic/identity/api/UserInfo.java
@@ -7,7 +7,7 @@ package life.qbic.identity.api;
  *
  * @since 1.0.0
  */
-public record UserInfo(String id, String fullName, String emailAddress, String encryptedPassword,
+public record UserInfo(String id, String fullName, String emailAddress, String userName, String encryptedPassword,
                        boolean isActive) {
 
 }

--- a/identity-api/src/main/java/life/qbic/identity/api/UserInformationService.java
+++ b/identity-api/src/main/java/life/qbic/identity/api/UserInformationService.java
@@ -33,4 +33,13 @@ public interface UserInformationService {
    */
   Optional<UserInfo> findById(String userId);
 
+  /**
+   * Queries if a desired username is still available and not in use by another user already.
+   *
+   * @param userName the desired username
+   * @return true, if the username is still available, false if not
+   * @since 1.0.0
+   */
+  boolean userNameAvailable(String userName);
+
 }

--- a/identity-infrastructure/src/main/java/life/qbic/identity/infrastructure/QbicUserRepo.java
+++ b/identity-infrastructure/src/main/java/life/qbic/identity/infrastructure/QbicUserRepo.java
@@ -44,4 +44,6 @@ public interface QbicUserRepo extends CrudRepository<User, UserId> {
    * @return a list of matching users which are set to active in the data manager application
    */
   List<User> findUsersByActiveTrue();
+
+  User findUserByUserName(String userName);
 }

--- a/identity-infrastructure/src/main/java/life/qbic/identity/infrastructure/UserJpaRepository.java
+++ b/identity-infrastructure/src/main/java/life/qbic/identity/infrastructure/UserJpaRepository.java
@@ -16,12 +16,10 @@ import org.springframework.stereotype.Component;
  * <p>Implementation for the {@link UserDataStorage} interface.
  *
  * <p>This class serves as an adapter and proxies requests to an JPA implementation to interact
- * with
- * persistent {@link User} data in the storage layer.
+ * with persistent {@link User} data in the storage layer.
  *
  * <p>The actual JPA implementation is done by {@link QbicUserRepo}, which is injected as
- * dependency
- * upon creation.
+ * dependency upon creation.
  *
  * @since 1.0.0
  */
@@ -53,5 +51,10 @@ public class UserJpaRepository implements UserDataStorage {
   @Override
   public List<User> findAllActiveUsers() {
     return userRepo.findUsersByActiveTrue();
+  }
+
+  @Override
+  public Optional<User> findUserByUserName(String userName) {
+    return Optional.ofNullable(userRepo.findUserByUserName(userName));
   }
 }

--- a/identity/src/main/java/life/qbic/identity/application/service/BasicUserInformationService.java
+++ b/identity/src/main/java/life/qbic/identity/application/service/BasicUserInformationService.java
@@ -17,8 +17,7 @@ import life.qbic.logging.api.Logger;
  * <b>Basic user information service</b>
  *
  * <p>Implementation of the {@link UserInformationService}, provides a OHS via a Java interface to
- * query
- * user information</p>
+ * query user information</p>
  *
  * @since 1.0.0
  */
@@ -54,8 +53,14 @@ public class BasicUserInformationService implements UserInformationService {
     }
   }
 
+  @Override
+  public boolean userNameAvailable(String userName) {
+    return userRepository.findByUserName(userName).isEmpty();
+  }
+
   private UserInfo convert(User user) {
     return new UserInfo(user.id().get(), user.fullName().get(), user.emailAddress().get(),
+        user.userName(),
         user.getEncryptedPassword().get(),
         user.isActive());
   }

--- a/identity/src/main/java/life/qbic/identity/application/user/IdentityService.java
+++ b/identity/src/main/java/life/qbic/identity/application/user/IdentityService.java
@@ -45,13 +45,14 @@ public final class IdentityService {
    * client's responsibility to handle the raw password.
    *
    * @param fullName    the full name of the user
+   * @param userName
    * @param email       the mail address of the user
    * @param rawPassword the raw password provided by the user
    * @return a registration response with information about if the registration was successful or
    * not.
    * @since 1.0.0
    */
-  public ApplicationResponse registerUser(final String fullName, final String email,
+  public ApplicationResponse registerUser(final String fullName, String userName, final String email,
       final char[] rawPassword) {
 
     var registrationResponse = validateInput(fullName, email, rawPassword);
@@ -72,8 +73,12 @@ public final class IdentityService {
       return ApplicationResponse.failureResponse(new UserExistsException());
     }
 
+    if (userRepository.findByUserName(userName).isPresent()) {
+      return ApplicationResponse.failureResponse(new UserNameNotAvailableException());
+    }
+
     // Trigger the user creation in the domain service
-    userDomainService.get().createUser(userFullName, userEmail, userPassword);
+    userDomainService.get().createUser(userFullName, userName, userEmail, userPassword);
 
     // Overwrite the password
     Arrays.fill(rawPassword, '-');
@@ -187,6 +192,16 @@ public final class IdentityService {
 
     public UserExistsException() {
       super();
+    }
+  }
+
+  public static class UserNameNotAvailableException extends ApplicationException {
+
+
+    @Serial
+    private static final long serialVersionUID = 4409722243047442583L;
+
+    public UserNameNotAvailableException() {
     }
   }
 

--- a/identity/src/main/java/life/qbic/identity/application/user/registration/RegisterUserInput.java
+++ b/identity/src/main/java/life/qbic/identity/application/user/registration/RegisterUserInput.java
@@ -15,9 +15,10 @@ public interface RegisterUserInput {
    * @param fullName    the full name of the user
    * @param email       the user's mail address
    * @param rawPassword the user selected raw password for authentication
+   * @param userName
    * @since 1.0.0
    */
-  void register(String fullName, String email, char[] rawPassword);
+  void register(String fullName, String email, char[] rawPassword, String userName);
 
   /**
    * Set the output the use case shall call, when finished.

--- a/identity/src/main/java/life/qbic/identity/application/user/registration/Registration.java
+++ b/identity/src/main/java/life/qbic/identity/application/user/registration/Registration.java
@@ -35,7 +35,7 @@ public class Registration implements RegisterUserInput {
    *
    * <p>The default output implementation just prints to std out on success and std err on failure,
    * after the use case has been executed via
-   * {@link Registration#register(String, String, char[])}.
+   * {@link RegisterUserInput#register(String, String, char[], String)}.
    *
    * @param identityService the user registration service to save the new user to.
    * @since 1.0.0
@@ -59,13 +59,13 @@ public class Registration implements RegisterUserInput {
    * @inheritDocs
    */
   @Override
-  public void register(String fullName, String email, char[] rawPassword) {
+  public void register(String fullName, String email, char[] rawPassword, String userName) {
     if (registerUserOutput == null) {
       log.error("No use case output set.");
       return;
     }
     try {
-      identityService.registerUser(fullName, email, rawPassword)
+      identityService.registerUser(fullName, userName, email, rawPassword)
           .ifSuccessOrElse(this::reportSuccess,
               response -> registerUserOutput.onUnexpectedFailure(build(response)));
     } catch (Exception e) {

--- a/identity/src/main/java/life/qbic/identity/application/user/registration/Registration.java
+++ b/identity/src/main/java/life/qbic/identity/application/user/registration/Registration.java
@@ -3,6 +3,7 @@ package life.qbic.identity.application.user.registration;
 import life.qbic.application.commons.ApplicationResponse;
 import life.qbic.identity.application.user.IdentityService;
 import life.qbic.identity.application.user.IdentityService.UserExistsException;
+import life.qbic.identity.application.user.IdentityService.UserNameNotAvailableException;
 import life.qbic.identity.domain.model.EmailAddress.EmailValidationException;
 import life.qbic.identity.domain.model.EncryptedPassword.PasswordValidationException;
 import life.qbic.identity.domain.model.FullName.FullNameValidationException;
@@ -90,6 +91,8 @@ public class Registration implements RegisterUserInput {
         builder.withFullNameException((FullNameValidationException) e);
       } else if (e instanceof UserExistsException) {
         builder.withUserExistsException((UserExistsException) e);
+      } else if (e instanceof UserNameNotAvailableException) {
+        builder.withUserNameNotAvailableException((UserNameNotAvailableException) e);
       } else {
         builder.withUnexpectedException(e);
       }

--- a/identity/src/main/java/life/qbic/identity/application/user/registration/UserRegistrationException.java
+++ b/identity/src/main/java/life/qbic/identity/application/user/registration/UserRegistrationException.java
@@ -3,7 +3,9 @@ package life.qbic.identity.application.user.registration;
 import java.io.Serial;
 import java.util.Optional;
 import life.qbic.application.commons.ApplicationException;
+import life.qbic.identity.application.user.IdentityService;
 import life.qbic.identity.application.user.IdentityService.UserExistsException;
+import life.qbic.identity.application.user.IdentityService.UserNameNotAvailableException;
 import life.qbic.identity.domain.model.EmailAddress.EmailValidationException;
 import life.qbic.identity.domain.model.EncryptedPassword.PasswordValidationException;
 import life.qbic.identity.domain.model.FullName.FullNameValidationException;
@@ -30,6 +32,8 @@ public class UserRegistrationException extends ApplicationException {
   private final transient PasswordValidationException invalidPasswordException;
   private final transient FullNameValidationException fullNameException;
 
+  private final transient UserNameNotAvailableException userNameNotAvailableException;
+
   private final transient UserExistsException userExistsException;
   private final transient RuntimeException unexpectedException;
 
@@ -47,6 +51,7 @@ public class UserRegistrationException extends ApplicationException {
 
     private UserExistsException userExistsException;
     private RuntimeException unexpectedException;
+    private UserNameNotAvailableException userNameNotAvailableException;
 
     protected Builder() {
 
@@ -80,6 +85,11 @@ public class UserRegistrationException extends ApplicationException {
     public UserRegistrationException build() {
       return new UserRegistrationException(this);
     }
+
+    public Builder withUserNameNotAvailableException(UserNameNotAvailableException e) {
+      this.userNameNotAvailableException = e;
+      return this;
+    }
   }
 
   private UserRegistrationException(Builder builder) {
@@ -88,6 +98,7 @@ public class UserRegistrationException extends ApplicationException {
     invalidPasswordException = builder.invalidPasswordException;
     userExistsException = builder.userExistsException;
     unexpectedException = builder.unexpectedException;
+    userNameNotAvailableException = builder.userNameNotAvailableException;
   }
 
   public Optional<EmailValidationException> emailFormatException() {
@@ -104,6 +115,10 @@ public class UserRegistrationException extends ApplicationException {
 
   public Optional<UserExistsException> userExistsException() {
     return Optional.ofNullable(userExistsException);
+  }
+
+  public Optional<UserNameNotAvailableException> userNameNotAvailableException() {
+    return Optional.ofNullable(userNameNotAvailableException);
   }
 
   public Optional<RuntimeException> unexpectedException() {

--- a/identity/src/main/java/life/qbic/identity/domain/model/User.java
+++ b/identity/src/main/java/life/qbic/identity/domain/model/User.java
@@ -56,6 +56,7 @@ public class User implements Serializable {
     this.fullName = fullName;
     this.emailAddress = emailAddress;
     this.encryptedPassword = encryptedPassword;
+    this.userName = userName;
   }
 
   /**

--- a/identity/src/main/java/life/qbic/identity/domain/model/User.java
+++ b/identity/src/main/java/life/qbic/identity/domain/model/User.java
@@ -50,6 +50,14 @@ public class User implements Serializable {
   protected User() {
   }
 
+  private User(UserId id, FullName fullName, EmailAddress emailAddress,
+      String userName, EncryptedPassword encryptedPassword) {
+    this.id = id;
+    this.fullName = fullName;
+    this.emailAddress = emailAddress;
+    this.encryptedPassword = encryptedPassword;
+  }
+
   /**
    * Creates a new user account, with a unique identifier to unambiguously match the user within
    * QBiC's organisation.
@@ -62,25 +70,18 @@ public class User implements Serializable {
    *
    * @param fullName          the full name of the user
    * @param emailAddress      the email address value of the user
+   * @param userName          the desired username
    * @param encryptedPassword the encrypted password of the new user
    * @return the new user
    * @since 1.0.0
    */
   public static User create(FullName fullName, EmailAddress emailAddress,
-      EncryptedPassword encryptedPassword) {
+      String userName, EncryptedPassword encryptedPassword) {
     UserId id = UserId.create();
-    var user = new User(id, fullName, emailAddress, encryptedPassword);
+    var user = new User(id, fullName, emailAddress, userName, encryptedPassword);
     user.active = false;
 
     return user;
-  }
-
-  private User(UserId id, FullName fullName, EmailAddress emailAddress,
-      EncryptedPassword encryptedPassword) {
-    this.id = id;
-    this.fullName = fullName;
-    this.emailAddress = emailAddress;
-    this.encryptedPassword = encryptedPassword;
   }
 
   @Override
@@ -94,10 +95,6 @@ public class User implements Serializable {
         '}';
   }
 
-  private void setEncryptedPassword(EncryptedPassword encryptedPassword) {
-    this.encryptedPassword = encryptedPassword;
-  }
-
   /**
    * Get access to the encrypted password
    *
@@ -106,6 +103,10 @@ public class User implements Serializable {
    */
   public EncryptedPassword getEncryptedPassword() {
     return this.encryptedPassword;
+  }
+
+  private void setEncryptedPassword(EncryptedPassword encryptedPassword) {
+    this.encryptedPassword = encryptedPassword;
   }
 
   public UserId id() {

--- a/identity/src/main/java/life/qbic/identity/domain/model/User.java
+++ b/identity/src/main/java/life/qbic/identity/domain/model/User.java
@@ -35,6 +35,9 @@ public class User implements Serializable {
   @Convert(converter = FullNameConverter.class)
   private FullName fullName;
 
+  @Column(name = "userName")
+  private String userName;
+
   @Column(name = "email")
   @Convert(converter = EmailConverter.class)
   private EmailAddress emailAddress;
@@ -111,6 +114,10 @@ public class User implements Serializable {
 
   public EmailAddress emailAddress() {
     return this.emailAddress;
+  }
+
+  public String userName() {
+    return userName;
   }
 
   public FullName fullName() {

--- a/identity/src/main/java/life/qbic/identity/domain/repository/UserDataStorage.java
+++ b/identity/src/main/java/life/qbic/identity/domain/repository/UserDataStorage.java
@@ -55,5 +55,6 @@ public interface UserDataStorage {
    */
   List<User> findAllActiveUsers();
 
+  Optional<User> findUserByUserName(String userName);
 
 }

--- a/identity/src/main/java/life/qbic/identity/domain/repository/UserRepository.java
+++ b/identity/src/main/java/life/qbic/identity/domain/repository/UserRepository.java
@@ -22,6 +22,10 @@ public class UserRepository implements Serializable {
 
   private final UserDataStorage dataStorage;
 
+  protected UserRepository(UserDataStorage dataStorage) {
+    this.dataStorage = dataStorage;
+  }
+
   /**
    * Retrieves a Singleton instance of a user {@link UserRepository}. In case this method is called
    * the first time, a new instance is created.
@@ -36,10 +40,6 @@ public class UserRepository implements Serializable {
       instance = new UserRepository(dataStorage);
     }
     return instance;
-  }
-
-  protected UserRepository(UserDataStorage dataStorage) {
-    this.dataStorage = dataStorage;
   }
 
   /**
@@ -68,6 +68,10 @@ public class UserRepository implements Serializable {
     } else {
       return Optional.of(matchingUsers.get(0));
     }
+  }
+
+  public Optional<User> findByUserName(String userName) {
+    return dataStorage.findUserByUserName(userName);
   }
 
   /**

--- a/identity/src/main/java/life/qbic/identity/domain/service/UserDomainService.java
+++ b/identity/src/main/java/life/qbic/identity/domain/service/UserDomainService.java
@@ -37,16 +37,17 @@ public class UserDomainService {
    * will be created.
    *
    * @param fullName     the full name of the user
+   * @param userName
    * @param emailAddress a valid mail address
    * @param password     the password desired by the user
    * @since 1.0.0
    */
-  public void createUser(FullName fullName, EmailAddress emailAddress, EncryptedPassword password) {
+  public void createUser(FullName fullName, String userName, EmailAddress emailAddress, EncryptedPassword password) {
     // Ensure idempotent behaviour of the service
     if (userRepository.findByEmail(emailAddress).isPresent()) {
       return;
     }
-    var user = User.create(fullName, emailAddress, password);
+    var user = User.create(fullName, emailAddress, userName, password);
     userRepository.addUser(user);
     var userCreatedEvent = UserRegistered.create(user.id().get(), user.fullName().get(),
         user.emailAddress().get());

--- a/identity/src/test/groovy/life/qbic/identity/domain/user/UserSpec.groovy
+++ b/identity/src/test/groovy/life/qbic/identity/domain/user/UserSpec.groovy
@@ -24,7 +24,7 @@ class UserSpec extends Specification {
     @Unroll
     def "When a new user is created, a unique identifier is assigned to the user"() {
         when:
-        User user = User.create(FullName.from("Test User"), EmailAddress.from("my.name@example.com"), EncryptedPassword.from("test1234".toCharArray()))
+        User user = User.create(FullName.from("Test User"), EmailAddress.from("my.name@example.com"), "svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
 
         then:
         !generatedUserIds.contains(user.id())
@@ -36,7 +36,7 @@ class UserSpec extends Specification {
 
     def "When a password reset is requested, a password reset domain event is published"() {
         given:
-        User user = User.create(FullName.from("Test User"), EmailAddress.from("my.name@example.com"), EncryptedPassword.from("test1234".toCharArray()))
+        User user = User.create(FullName.from("Test User"), EmailAddress.from("my.name@example.com"),"svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
 
         and:
         boolean domainEventPublished = false

--- a/identity/src/test/groovy/life/qbic/identity/domain/usermanagement/registration/RegistrationSpec.groovy
+++ b/identity/src/test/groovy/life/qbic/identity/domain/usermanagement/registration/RegistrationSpec.groovy
@@ -34,21 +34,21 @@ class RegistrationSpec extends Specification {
 
     def "When a user is already registered with a given email address, abort the registration and communicate the failure"() {
         given: "A repository with one user entry"
-        def testUser = User.create(FullName.from("Mr Somebody"), EmailAddress.from("some@body.com"), EncryptedPassword.from("test1234".toCharArray()))
+        def testUser = User.create(FullName.from("Mr Somebody"), EmailAddress.from("some@body.com"), "svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
         testStorage.save(testUser)
 
         and:
         def useCaseOutput = Mock(RegisterUserOutput.class)
 
         and: "a new user to register"
-        def newUser = User.create(FullName.from("Mr Somebody"), EmailAddress.from("some@body.com"), EncryptedPassword.from("test1234".toCharArray()))
+        def newUser = User.create(FullName.from("Mr Somebody"), EmailAddress.from("some@body.com"), "svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
 
         and: "a the use case with output"
         def registration = new Registration(new IdentityService(UserRepository.getInstance(testStorage)))
         registration.setOutput(useCaseOutput)
 
         when: "a user is registered"
-        registration.register(newUser.fullName().get(), newUser.emailAddress().get(), "12345678".toCharArray())
+        registration.register(newUser.fullName().get(), newUser.emailAddress().get(), "12345678".toCharArray(), newUser.userName())
 
         then:
         0 * useCaseOutput.onUserRegistrationSucceeded()
@@ -59,21 +59,21 @@ class RegistrationSpec extends Specification {
 
     def "When a user is not yet registered with a given email address, register the user"() {
         given: "A repository with one user entry"
-        def testUser = User.create(FullName.from("Mr Somebody"), EmailAddress.from("some@body.com"), EncryptedPassword.from("test1234".toCharArray()))
+        def testUser = User.create(FullName.from("Mr Somebody"), EmailAddress.from("some@body.com"), "svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
         testStorage.save(testUser)
 
         and:
         def useCaseOutput = Mock(RegisterUserOutput.class)
 
         and: "a new user to register"
-        def newUser = User.create(FullName.from("Mr Nobody"), EmailAddress.from("no@body.com"), EncryptedPassword.from("test1234".toCharArray()))
+        def newUser = User.create(FullName.from("Mr Nobody"), EmailAddress.from("no@body.com"), "svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
 
         and: "a the use case with output"
         def registration = new Registration(new IdentityService(UserRepository.getInstance(Mock(UserDataStorage))))
         registration.setOutput(useCaseOutput)
 
         when: "a user is registered"
-        registration.register(newUser.fullName().get(), newUser.emailAddress().get(), "12345678".toCharArray())
+        registration.register(newUser.fullName().get(), newUser.emailAddress().get(), "12345678".toCharArray(), newUser.userName())
 
         then:
         1 * useCaseOutput.onUserRegistrationSucceeded()
@@ -108,6 +108,11 @@ class RegistrationSpec extends Specification {
         @Override
         List<User> findAllActiveUsers() {
             return users.findAll { it.active }
+        }
+
+        @Override
+        Optional<User> findUserByUserName(String userName) {
+            return Optional.ofNullable(users.find { it.userName() })
         }
     }
 

--- a/identity/src/test/groovy/life/qbic/identity/domain/usermanagement/registration/RegistrationSpec.groovy
+++ b/identity/src/test/groovy/life/qbic/identity/domain/usermanagement/registration/RegistrationSpec.groovy
@@ -66,7 +66,7 @@ class RegistrationSpec extends Specification {
         def useCaseOutput = Mock(RegisterUserOutput.class)
 
         and: "a new user to register"
-        def newUser = User.create(FullName.from("Mr Nobody"), EmailAddress.from("no@body.com"), "svenipopenni", EncryptedPassword.from("test1234".toCharArray()))
+        def newUser = User.create(FullName.from("Mr Nobody"), EmailAddress.from("no@body.com"), "svenipopenni2", EncryptedPassword.from("test1234".toCharArray()))
 
         and: "a the use case with output"
         def registration = new Registration(new IdentityService(UserRepository.getInstance(Mock(UserDataStorage))))
@@ -112,7 +112,7 @@ class RegistrationSpec extends Specification {
 
         @Override
         Optional<User> findUserByUserName(String userName) {
-            return Optional.ofNullable(users.find { it.userName() })
+            return Optional.ofNullable(users.find { it.userName() == userName })
         }
     }
 

--- a/identity/src/test/groovy/life/qbic/identity/domain/usermanagement/repository/UserRepositorySpec.groovy
+++ b/identity/src/test/groovy/life/qbic/identity/domain/usermanagement/repository/UserRepositorySpec.groovy
@@ -71,7 +71,7 @@ class UserRepositorySpec extends Specification {
 
 
     static User createDummyUser() {
-        def user = User.create(FullName.from("Test User"), EmailAddress.from("my.name@example.com"), EncryptedPassword.from("test1234".toCharArray()))
+        def user = User.create(FullName.from("Test User"), EmailAddress.from("my.name@example.com"), "svennipopenni", EncryptedPassword.from("test1234".toCharArray()))
         return user
     }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationHandler.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationHandler.java
@@ -62,7 +62,7 @@ public class UserRegistrationHandler
           registrationUseCase.register(
               userRegistrationLayout.fullName.getValue(),
               userRegistrationLayout.email.getValue(),
-              userRegistrationLayout.password.getValue().toCharArray());
+              userRegistrationLayout.password.getValue().toCharArray(), );
         });
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationHandler.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationHandler.java
@@ -52,7 +52,7 @@ public class UserRegistrationHandler
     userRegistrationLayout.password.setPattern(".{8,}");
     userRegistrationLayout.password.setErrorMessage("Password too short");
     userRegistrationLayout.username.setHelperText("Your unique username, visible to other users");
-    userRegistrationLayout.username.setErrorMessage("Username already in use, please try another one");
+    userRegistrationLayout.username.setErrorMessage("Please provide a username");
   }
 
   private void addListener() {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationHandler.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationHandler.java
@@ -25,8 +25,8 @@ public class UserRegistrationHandler
 
   private static final Logger log =
       LoggerFactory.logger(UserRegistrationHandler.class.getName());
-  private UserRegistrationLayout userRegistrationLayout;
   private final RegisterUserInput registrationUseCase;
+  private UserRegistrationLayout userRegistrationLayout;
 
   @Autowired
   UserRegistrationHandler(RegisterUserInput registrationUseCase) {
@@ -51,6 +51,8 @@ public class UserRegistrationHandler
     userRegistrationLayout.password.setHelperText("A password must be at least 8 characters");
     userRegistrationLayout.password.setPattern(".{8,}");
     userRegistrationLayout.password.setErrorMessage("Password too short");
+    userRegistrationLayout.username.setHelperText("Your unique username, visible to other users");
+    userRegistrationLayout.username.setErrorMessage("Username already in use, please try another one");
   }
 
   private void addListener() {
@@ -62,7 +64,8 @@ public class UserRegistrationHandler
           registrationUseCase.register(
               userRegistrationLayout.fullName.getValue(),
               userRegistrationLayout.email.getValue(),
-              userRegistrationLayout.password.getValue().toCharArray(), );
+              userRegistrationLayout.password.getValue().toCharArray(),
+              userRegistrationLayout.username.getValue());
         });
   }
 
@@ -114,8 +117,15 @@ public class UserRegistrationHandler
     if (userRegistrationException.userExistsException().isPresent()) {
       showAlreadyUsedEmailError();
     }
+    if (userRegistrationException.userNameNotAvailableException().isPresent()) {
+      showUserNameNotAvailableError();
+    }
     if (userRegistrationException.unexpectedException().isPresent()) {
       showUnexpectedError();
     }
+  }
+
+  private void showUserNameNotAvailableError() {
+    showError("Username already in use", "Please try another username");
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/register/UserRegistrationLayout.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
+import java.io.Serial;
 import java.util.stream.Stream;
 import life.qbic.datamanager.views.AppRoutes;
 import life.qbic.datamanager.views.landing.LandingPageLayout;
@@ -34,11 +35,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 @AnonymousAllowed
 public class UserRegistrationLayout extends VerticalLayout {
 
+  @Serial
+  private static final long serialVersionUID = 6995209728843801219L;
+
   public EmailField email;
 
   public PasswordField password;
 
   public TextField fullName;
+
+  public TextField username;
 
   public Button registerButton;
 
@@ -92,8 +98,13 @@ public class UserRegistrationLayout extends VerticalLayout {
     fieldLayout = new VerticalLayout();
     createEmailField();
     createNameField();
+    createUsernameField();
     createPasswordField();
-    fieldLayout.add(fullName, email, password);
+    fieldLayout.add(fullName, email, username, password);
+  }
+
+  private void createUsernameField() {
+    username = new TextField("Username");
   }
 
   private void createSpans() {
@@ -136,7 +147,8 @@ public class UserRegistrationLayout extends VerticalLayout {
     password.setWidthFull();
     email.setWidthFull();
     fullName.setWidthFull();
-    setRequiredIndicatorVisible(fullName, email, password);
+    username.setWidthFull();
+    setRequiredIndicatorVisible(fullName, email, username, password);
     fieldLayout.setSpacing(false);
     fieldLayout.setMargin(false);
     fieldLayout.setPadding(false);


### PR DESCRIPTION
This PR introduces the concept of usernames.

If a username already is in use, the user is getting the notification that they have to chose another one.

