### PR TITLE
Propagate to user if a project with the provided code already exists during project creation

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
@@ -1,7 +1,6 @@
 package life.qbic.projectmanagement.application;
 
 import static java.util.Objects.requireNonNull;
-import static life.qbic.logging.service.LoggerFactory.logger;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -9,7 +8,6 @@ import life.qbic.application.commons.ApplicationException;
 import life.qbic.application.commons.ApplicationException.ErrorCode;
 import life.qbic.application.commons.ApplicationException.ErrorParameters;
 import life.qbic.application.commons.Result;
-import life.qbic.logging.api.Logger;
 import life.qbic.projectmanagement.domain.model.project.Contact;
 import life.qbic.projectmanagement.domain.model.project.Funding;
 import life.qbic.projectmanagement.domain.model.project.OfferIdentifier;
@@ -18,9 +16,7 @@ import life.qbic.projectmanagement.domain.model.project.ProjectCode;
 import life.qbic.projectmanagement.domain.model.project.ProjectIntent;
 import life.qbic.projectmanagement.domain.model.project.ProjectObjective;
 import life.qbic.projectmanagement.domain.model.project.ProjectTitle;
-import life.qbic.projectmanagement.domain.repository.ProjectRepository;
 import life.qbic.projectmanagement.domain.service.ProjectDomainService;
-import life.qbic.projectmanagement.domain.service.ProjectDomainService.ResponseCode;
 import org.springframework.stereotype.Service;
 
 /**
@@ -29,14 +25,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ProjectCreationService {
 
-  private static final Logger log = logger(ProjectCreationService.class);
-
-  private final ProjectRepository projectRepository;
   private final ProjectDomainService projectDomainService;
 
-  public ProjectCreationService(ProjectRepository projectRepository,
-      ProjectDomainService projectDomainService) {
-    this.projectRepository = requireNonNull(projectRepository);
+  public ProjectCreationService(ProjectDomainService projectDomainService) {
     this.projectDomainService = requireNonNull(projectDomainService);
   }
 
@@ -64,7 +55,6 @@ public class ProjectCreationService {
     if (Objects.isNull(projectManager)) {
       return Result.fromError(new ApplicationException("project manager is null"));
     }
-
     try {
       Project project = createProject(code, title, objective, projectManager,
           principalInvestigator, responsiblePerson, funding);
@@ -84,29 +74,13 @@ public class ProjectCreationService {
     ProjectCode projectCode;
     try {
       projectCode = ProjectCode.parse(code);
-      if (!projectRepository.find(projectCode).isEmpty()) {
-        throw new ApplicationException("Project code: " + code + " is already in use.",
-            ErrorCode.DUPLICATE_PROJECT_CODE,
-            ErrorParameters.of(code));
-      }
     } catch (IllegalArgumentException exception) {
       throw new ApplicationException("Project code: " + code + " is invalid.", exception,
           ErrorCode.INVALID_PROJECT_CODE,
           ErrorParameters.of(code, ProjectCode.getPREFIX(), ProjectCode.getLENGTH()));
     }
-
-    var registrationResult = projectDomainService.registerProject(intent, projectCode, projectManager, principalInvestigator, responsiblePerson, funding);
-
-    registrationResult.onError(responseCode -> {
-      if (responseCode.equals(ResponseCode.PROJECT_ALREADY_EXISTS)) {
-        throw new ApplicationException("Project code is already in use.",
-            ErrorCode.DUPLICATE_PROJECT_CODE, ErrorParameters.of(code));
-      } else {
-        throw new ApplicationException("Project registration failed.", ErrorCode.GENERAL,
-            ErrorParameters.of(code));
-      }
-    });
-    return registrationResult.getValue();
+    return projectDomainService.registerProject(intent, projectCode,
+        projectManager, principalInvestigator, responsiblePerson, funding);
   }
 
   private static ProjectIntent getProjectIntent(String title, String objective) {

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectCreationService.java
@@ -97,10 +97,15 @@ public class ProjectCreationService {
 
     var registrationResult = projectDomainService.registerProject(intent, projectCode, projectManager, principalInvestigator, responsiblePerson, funding);
 
-    if (registrationResult.isError() && registrationResult.getError().equals(ResponseCode.PROJECT_REGISTRATION_FAILED)) {
-      throw new ApplicationException("Project registration failed.", ErrorCode.GENERAL, ErrorParameters.of(code));
-    }
-
+    registrationResult.onError(responseCode -> {
+      if (responseCode.equals(ResponseCode.PROJECT_ALREADY_EXISTS)) {
+        throw new ApplicationException("Project code is already in use.",
+            ErrorCode.DUPLICATE_PROJECT_CODE, ErrorParameters.of(code));
+      } else {
+        throw new ApplicationException("Project registration failed.", ErrorCode.GENERAL,
+            ErrorParameters.of(code));
+      }
+    });
     return registrationResult.getValue();
   }
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/service/ProjectDomainService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/service/ProjectDomainService.java
@@ -12,6 +12,7 @@ import life.qbic.projectmanagement.domain.model.project.ProjectCode;
 import life.qbic.projectmanagement.domain.model.project.ProjectIntent;
 import life.qbic.projectmanagement.domain.model.project.event.ProjectRegisteredEvent;
 import life.qbic.projectmanagement.domain.repository.ProjectRepository;
+import life.qbic.projectmanagement.domain.repository.ProjectRepository.ProjectExistsException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -55,9 +56,12 @@ public class ProjectDomainService {
         projectManager, principalInvestigator,
         responsiblePerson);
     project.setFunding(funding);
-
     try {
       projectRepository.add(project);
+    } catch (ProjectExistsException projectExistsException) {
+      log.error("Project with code " + project.getProjectCode() + "already exists",
+          projectExistsException);
+      return Result.fromError(ResponseCode.PROJECT_ALREADY_EXISTS);
     } catch (Exception e) {
       log.error("Project with code " + project.getProjectCode() + " registration failed.", e);
       return Result.fromError(ResponseCode.PROJECT_REGISTRATION_FAILED);
@@ -70,7 +74,8 @@ public class ProjectDomainService {
   }
 
   public enum ResponseCode {
-    PROJECT_REGISTRATION_FAILED
+    PROJECT_REGISTRATION_FAILED,
+    PROJECT_ALREADY_EXISTS
   }
 
 }

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/ProjectCreationServiceSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/ProjectCreationServiceSpec.groovy
@@ -21,7 +21,7 @@ class ProjectCreationServiceSpec extends Specification {
   ProjectRepository projectRepositoryStub = Stub()
   AddExperimentToProjectService addExperimentToProjectServiceStub = Stub()
     ProjectDomainService projectDomainServiceStub = new ProjectDomainService(projectRepositoryStub)
-  ProjectCreationService projectCreationServiceWithStubs = new ProjectCreationService(projectRepositoryStub, projectDomainServiceStub)
+  ProjectCreationService projectCreationServiceWithStubs = new ProjectCreationService(projectDomainServiceStub)
 
   def "invalid project title leads to INVALID_PROJECT_TITLE code"() {
     given:


### PR DESCRIPTION
**What was changed**
Handle duplicate project exception in domain service and propagate the error message to the user in application service 