### PR TITLE
Provide default value for fraction

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/measurement/ProteomicsMeasurement.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/measurement/ProteomicsMeasurement.java
@@ -80,6 +80,9 @@ public class ProteomicsMeasurement implements MeasurementMetadata {
   @Column(name = "measurementLabel")
   private String label = "";
 
+  @Column(name = "fraction")
+  private String fraction = "";
+
   @ElementCollection(targetClass = SampleId.class, fetch = FetchType.EAGER)
   @CollectionTable(name = "measurement_samples", joinColumns = @JoinColumn(name = "measurement_id"))
   private Collection<SampleId> measuredSamples;


### PR DESCRIPTION
On our test system, the registration of measurements currently fails.

Since in a development feature branch, the new column fraction was introduced, we need to provide a default value for it.