### PR TITLE
Optimise ontology query

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermRepository.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermRepository.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import life.qbic.application.commons.OffsetBasedRequest;
 import life.qbic.application.commons.SortOrder;
 import life.qbic.projectmanagement.application.ontology.OntologyClass;
@@ -67,17 +66,24 @@ public class OntologyTermRepository implements OntologyRepository, OntologyLooku
    */
   private String buildSearchTerm(String searchString) {
     StringBuilder searchTermBuilder = new StringBuilder();
-    String[] words = searchString.split(" ");
+    String[] words = searchString.split("\\s+");
+    String quot = "\"";
 
     if (words.length > 1) {
-      var wordsRemaining = Arrays.stream(words).skip(1).toList();
-      var allWords = Arrays.stream(words).toList();
-      searchTermBuilder.append("\"").append(words[0] + " " + String.join(" ", wordsRemaining)).append("\"").append(" < ")
-          .append("\"").append(String.join(" ", new ArrayList<>(allWords).remove(allWords.size() - 1))).append("\"").append(" < ")
-          .append("+").append(String.join(" ", allWords)).append("*");
+      var completedWords = String.join(" ", Arrays.copyOf(words, words.length - 1));
+      var lastWord = words[words.length-1];
+      var fullTermCleaned = completedWords+" "+lastWord;
+
+      // first part
+      searchTermBuilder.append(quot).append(fullTermCleaned).append(quot).append(" < ");
+      // middle part
+      searchTermBuilder.append(quot).append(completedWords).append(quot).append(" < ");
+      // last part
+      searchTermBuilder.append("+").append(fullTermCleaned).append("*");
+
     } else {
       searchTermBuilder
-          .append("\"").append(words[0]).append("\"").append(" < ")
+          .append(quot).append(words[0]).append(quot).append(" < ")
           .append("+").append(words[0]).append("*");
     }
     return searchTermBuilder.toString();

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermRepositoryJpaInterface.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermRepositoryJpaInterface.java
@@ -15,8 +15,8 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface OntologyTermRepositoryJpaInterface extends
     PagingAndSortingRepository<OntologyClass, Long> {
 
-  @Query(value = "SELECT * FROM ontology_classes WHERE MATCH(label) AGAINST(?1 IN BOOLEAN MODE) AND ontology in (?2) ORDER BY length(label);",
-      countQuery = "SELECT count(*) FROM ontology_classes WHERE MATCH(label) AGAINST(?1 IN BOOLEAN MODE) AND ontology in (?2);",
+  @Query(value = "SELECT *, MATCH(label) AGAINST(?1 IN BOOLEAN MODE) relevancy FROM ontology_classes WHERE MATCH(label) AGAINST(?1 IN BOOLEAN MODE) AND ontology in (?2) ORDER BY relevancy desc, length(label);",
+      countQuery = "SELECT count(*), MATCH(label) AGAINST(?1 IN BOOLEAN MODE) relevancy FROM ontology_classes WHERE MATCH(label) AGAINST(?1 IN BOOLEAN MODE) AND ontology in (?2) ORDER BY relevancy desc, length(label);",
       nativeQuery = true)
   Page<OntologyClass> findByLabelFulltextMatching(
       String termFilter, List<String> ontologyAbbreviations, Pageable pageable);

--- a/project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermRepositorySpec.groovy
+++ b/project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/ontology/OntologyTermRepositorySpec.groovy
@@ -1,0 +1,48 @@
+package life.qbic.projectmanagement.infrastructure.ontology
+
+import spock.lang.Specification
+
+/**
+ * Tests for the sample code service implementation
+ *
+ * @since 1.0.0
+ */
+class OntologyTermRepositorySpec extends Specification{
+
+    def "Given a one-word search, the correct ontology searchterm is created"() {
+        given:
+        def searchWord = "Mus"
+        def repo = new OntologyTermRepository(Mock(OntologyTermRepositoryJpaInterface.class))
+
+        when:
+        def result = repo.buildSearchTerm(searchWord).replace("  "," ")
+
+        then:
+        result.equals('"Mus" < +Mus*')
+    }
+
+    def "Given a two-word search, the correct ontology searchterm is created"() {
+        given:
+        def searchWord = "Mus musc"
+        def repo = new OntologyTermRepository(Mock(OntologyTermRepositoryJpaInterface.class))
+
+        when:
+        def result = repo.buildSearchTerm(searchWord).replace("  "," ")
+
+        then:
+        result.equals('"Mus musc" < "Mus" < +Mus musc*')
+    }
+
+    def "Given a three-word search, the correct ontology searchterm is created"() {
+        given:
+        def searchWord = "Mus musculus domesticus"
+        def repo = new OntologyTermRepository(Mock(OntologyTermRepositoryJpaInterface.class))
+
+        when:
+        def result = repo.buildSearchTerm(searchWord).replace("  "," ")
+
+        then:
+        result.equals('"Mus musculus domesticus" < "Mus musculus" < +Mus musculus domesticus*')
+    }
+
+}


### PR DESCRIPTION
The query is omptimzed, such that we introduce a relevancy ranking based on a series of ranked expressions in the boolean mode query.

We also rank complete genus and species name now highest, so that complete class name entries will result as first hit result.