### PR TITLE
Enable async service calls for measurements

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
@@ -17,6 +17,7 @@ import life.qbic.projectmanagement.domain.model.project.ProjectObjective;
 import life.qbic.projectmanagement.domain.model.project.ProjectTitle;
 import life.qbic.projectmanagement.domain.repository.ProjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementValidationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementValidationService.java
@@ -2,10 +2,13 @@ package life.qbic.projectmanagement.application.measurement.validation;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import life.qbic.projectmanagement.application.measurement.NGSMeasurementMetadata;
 import life.qbic.projectmanagement.application.measurement.ProteomicsMeasurementMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * <b>Validation Service</b>
@@ -70,9 +73,10 @@ public class MeasurementValidationService {
    * @return a detailed {@link ValidationResult} with information about the validation
    * @since 1.0.0
    */
-  public ValidationResult validateProteomicsUpdate(
+  @Async
+  public CompletableFuture<ValidationResult> validateProteomicsUpdate(
       ProteomicsMeasurementMetadata pxMeasurementMetadata) {
-    return pxpValidator.validateUpdate(pxMeasurementMetadata);
+    return CompletableFuture.supplyAsync(() -> pxpValidator.validateUpdate(pxMeasurementMetadata));
   }
 
   public ValidationResult validateNGSUpdate(NGSMeasurementMetadata ngsMeasurementMetadata) {

--- a/user-interface/src/main/java/life/qbic/datamanager/AppConfig.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/AppConfig.java
@@ -1,5 +1,6 @@
 package life.qbic.datamanager;
 
+import java.util.concurrent.RejectedExecutionHandler;
 import life.qbic.broadcasting.Exchange;
 import life.qbic.broadcasting.MessageBusSubmission;
 import life.qbic.domain.concepts.SimpleEventStore;
@@ -51,6 +52,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
 /**
  * <b>App bean configuration class</b>
@@ -63,6 +66,30 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan({"life.qbic.identity.infrastructure"})
 public class AppConfig {
+  /*
+  Global settings
+   */
+
+  @Bean
+  public ThreadPoolTaskExecutor threadPoolTaskExecutor(
+      RejectedExecutionHandler rejectedExecutionHandler) {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(100);
+    executor.setQueueCapacity(50);
+    executor.setThreadNamePrefix("async-");
+    executor.setRejectedExecutionHandler(rejectedExecutionHandler);
+    return executor;
+  }
+
+  @Bean
+  public DelegatingSecurityContextAsyncTaskExecutor taskExecutor(ThreadPoolTaskExecutor delegate) {
+    return new DelegatingSecurityContextAsyncTaskExecutor(delegate);
+  }
+
+  /*
+  end global settings
+   */
 
   /*
   Wiring up identity application core and policies

--- a/user-interface/src/main/java/life/qbic/datamanager/Application.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/Application.java
@@ -2,6 +2,7 @@ package life.qbic.datamanager;
 
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
 import java.io.Serial;
@@ -26,6 +27,7 @@ import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConf
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * The entry point of the Spring Boot application.
@@ -42,6 +44,8 @@ import org.springframework.context.annotation.ComponentScan;
 @NpmPackage(value = "line-awesome", version = "1.3.0")
 @ComponentScan({"life.qbic"})
 @EntityScan(basePackages = "life.qbic")
+@EnableAsync
+@Push
 public class Application extends SpringBootServletInitializer implements AppShellConfigurator {
 
   private static final Logger log = LoggerFactory.logger(Application.class.getName());

--- a/user-interface/src/main/java/life/qbic/datamanager/RejectedExecutionHandlerImplementation.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/RejectedExecutionHandlerImplementation.java
@@ -1,0 +1,44 @@
+package life.qbic.datamanager;
+
+import static life.qbic.logging.service.LoggerFactory.logger;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import life.qbic.logging.api.Logger;
+import org.springframework.stereotype.Component;
+
+/**
+ * <b>Rejected Execution Handler Implementation</b>
+ * <p>
+ * This implementation handles the case when a {@link ThreadPoolExecutor}'s queue is full and throws
+ * a {@link RejectedExecutionException}. Without explicit handling, the application would throw the
+ * exception and the task not executed.
+ * <p>
+ * This class
+ * {@link RejectedExecutionHandlerImplementation#rejectedExecution(Runnable, ThreadPoolExecutor)} is
+ * called by the thread pool executor, when it has been set via
+ * {@link ThreadPoolExecutor#setRejectedExecutionHandler(RejectedExecutionHandler)}.
+ * <p>
+ * The current implementation will use the {@link java.util.concurrent.BlockingQueue#put(Object)}
+ * method, which is by definition blocking in case the queue has reached its configured max
+ * capacity.
+ *
+ * @since 1.0.0
+ */
+@Component
+public class RejectedExecutionHandlerImplementation implements RejectedExecutionHandler {
+
+  private static final Logger log = logger(RejectedExecutionHandlerImplementation.class);
+
+  @Override
+  public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+    try {
+      log.debug(
+          "Thread " + Thread.currentThread().getId() + " rejected, because the queue was full.");
+      executor.getQueue().put(r);
+    } catch (InterruptedException e) {
+      throw new RejectedExecutionException("Unexpected InterruptedException", e);
+    }
+  }
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMetadataUploadDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMetadataUploadDialog.java
@@ -8,10 +8,12 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.ListItem;
+import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.html.OrderedList;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.progressbar.ProgressBar;
 import com.vaadin.flow.component.upload.FailedEvent;
 import com.vaadin.flow.component.upload.FileRejectedEvent;
 import com.vaadin.flow.component.upload.SucceededEvent;
@@ -32,6 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import life.qbic.application.commons.Result;
 import life.qbic.datamanager.views.general.DialogWindow;
@@ -54,8 +59,9 @@ import life.qbic.projectmanagement.domain.model.sample.SampleCode;
 /**
  * <b>Upload Measurement Metadata Dialog</b>
  *
- * <p>Component that provides the user with a dialog to upload files to edit or add {@link MeasurementMetadata}</p>
- * to an {@link Experiment} dependent on the provided {@link MODE} and {@link MeasurementValidationExecutor} with which it was initialized
+ * <p>Component that provides the user with a dialog to upload files to edit or add
+ * {@link MeasurementMetadata}</p> to an {@link Experiment} dependent on the provided {@link MODE}
+ * and {@link MeasurementValidationExecutor} with which it was initialized
  *
  * @since 1.0.0
  */
@@ -73,6 +79,11 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
   private final Div uploadedItemsDisplays;
   private final MODE mode;
 
+  private final Div taskInProgressDisplay;
+  private final NativeLabel progressbarLabelText;
+  private final Span progressbarDescriptionText;
+  private final Div uploadSection;
+
   public MeasurementMetadataUploadDialog(MeasurementValidationService measurementValidationService,
       MODE mode) {
     this.measurementValidationService = requireNonNull(measurementValidationService,
@@ -82,6 +93,16 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     this.uploadBuffer = new EditableMultiFileMemoryBuffer();
     this.measurementMetadataUploads = new ArrayList<>();
     this.measurementFileItems = new ArrayList<>();
+    this.taskInProgressDisplay = new Div();
+
+    this.progressbarLabelText = new NativeLabel("Work in progress...");
+    this.progressbarDescriptionText = new Span("Process might take a few moments");
+    ProgressBar progressBar = new ProgressBar();
+    progressBar.setIndeterminate(true);
+    taskInProgressDisplay.add(progressbarLabelText, progressBar, progressbarDescriptionText);
+
+    add(taskInProgressDisplay);
+    taskInProgressDisplay.setVisible(false);
 
     Upload upload = new Upload(uploadBuffer);
     upload.setAcceptedFileTypes("text/tab-separated-values", "text/plain");
@@ -101,7 +122,7 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     restrictions.add(new Span("Supported file formats: .txt, .tsv"));
     restrictions.add("Maximum file size: %s MB".formatted(MAX_FILE_SIZE_BYTES / Math.pow(1024, 2)));
 
-    var uploadSection = new Div();
+    this.uploadSection = new Div();
     uploadSection.add(uploadSectionTitle, saveYourFileInfo, upload, restrictions);
     uploadSection.addClassName("upload-section");
 
@@ -129,26 +150,6 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
         .addEventData(VAADIN_FILENAME_EVENT);
     addClassName("measurement-upload-dialog");
     toggleFileSectionIfEmpty();
-  }
-
-  private void setModeBasedLabels() {
-    switch (mode) {
-      case ADD -> {
-        setHeaderTitle("Register measurements");
-        confirmButton.setText("Register");
-      }
-      case EDIT -> {
-        setHeaderTitle("Edit measurements");
-        confirmButton.setText("Save");
-      }
-    }
-  }
-
-  /**
-   * Returns the {@link MODE} with which this dialog was initialized
-   */
-  public MODE getMode() {
-    return mode;
   }
 
   private static List<String> parseHeaderContent(String header) {
@@ -298,6 +299,26 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     }
   }
 
+  private void setModeBasedLabels() {
+    switch (mode) {
+      case ADD -> {
+        setHeaderTitle("Register measurements");
+        confirmButton.setText("Register");
+      }
+      case EDIT -> {
+        setHeaderTitle("Edit measurements");
+        confirmButton.setText("Save");
+      }
+    }
+  }
+
+  /**
+   * Returns the {@link MODE} with which this dialog was initialized
+   */
+  public MODE getMode() {
+    return mode;
+  }
+
   private void onFileRemoved(DomEvent domEvent) {
     JsonObject jsonObject = domEvent.getEventData();
     var fileName = jsonObject.getString(VAADIN_FILENAME_EVENT);
@@ -423,19 +444,20 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
               List.of("The metadata sheet seems to be empty")));
       return new MeasurementValidationReport(0, validationResult);
     }
+
+    HashMap<String, CompletableFuture<ValidationResult>> tasks = new HashMap<>();
     for (String row : content.rows().stream()
         .filter(MeasurementMetadataUploadDialog::isRowNotEmpty).toList()) {
-      ValidationResult result = validateNGSRow(propertyColumnMap, row);
-      validationResult = validationResult.combine(result);
-      evaluatedRows++;
+      tasks.put(row, validateNGSRow(propertyColumnMap, row));
     }
+
     return new MeasurementValidationReport(evaluatedRows, validationResult);
   }
+
   private MeasurementValidationReport validatePxP(MetadataContent content) {
 
     var validationResult = ValidationResult.successful(0);
     var propertyColumnMap = propertyColumnMap(parseHeaderContent(content.header()));
-    var evaluatedRows = 0;
     // we check if there are any rows provided or if we have only rows with empty content
     if (content.rows().isEmpty() || content.rows().stream()
         .noneMatch(MeasurementMetadataUploadDialog::isRowNotEmpty)) {
@@ -444,16 +466,28 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
               List.of("The metadata sheet seems to be empty")));
       return new MeasurementValidationReport(0, validationResult);
     }
+
+    List<CompletableFuture<ValidationResult>> tasks = new ArrayList<>();
     for (String row : content.rows().stream()
         .filter(MeasurementMetadataUploadDialog::isRowNotEmpty).toList()) {
-      ValidationResult result = validatePxPRow(propertyColumnMap, row);
-      validationResult = validationResult.combine(result);
-      evaluatedRows++;
+      tasks.add(validatePxPRow(propertyColumnMap, row));
     }
-    return new MeasurementValidationReport(evaluatedRows, validationResult);
+
+    ConcurrentLinkedDeque<ValidationResult> concurrentLinkedDeque = new ConcurrentLinkedDeque<>();
+    AtomicInteger rowCounter = new AtomicInteger(0);
+
+    tasks.forEach(task -> task.thenAccept(result -> {
+      concurrentLinkedDeque.add(result);
+      rowCounter.incrementAndGet();
+      // Here we can update a progress bar in the future easily.
+    }));
+    CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
+
+    return new MeasurementValidationReport(rowCounter.get(), concurrentLinkedDeque.stream().reduce(
+        validationResult, ValidationResult::combine));
   }
 
-  private ValidationResult validateNGSRow(Map<String, Integer> propertyColumnMap,
+  private CompletableFuture<ValidationResult> validateNGSRow(Map<String, Integer> propertyColumnMap,
       String row) {
     var validationResult = ValidationResult.successful(0);
     var metaDataValues = row.split("\t"); // tab separated values
@@ -461,7 +495,7 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     if (metaDataValues.length == 0) {
       validationResult.combine(
           ValidationResult.successful(1, List.of("Empty row provided.")));
-      return validationResult;
+      return CompletableFuture.supplyAsync(() -> validationResult);
     }
     if (metaDataValues.length != propertyColumnMap.keySet().size()) {
       validationResult.combine(ValidationResult.withFailures(1, List.of("")));
@@ -491,8 +525,9 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     int maxPropertyIndex = IntStream.of(sampleCodeColumnIndex, organisationsColumnIndex,
         instrumentColumnIndex).max().orElseThrow();
     if (propertyColumnMap.size() <= maxPropertyIndex) {
-      return validationResult.combine(ValidationResult.withFailures(1,
-          List.of("Not enough columns provided for row: \"%s\"".formatted(row))));
+      return CompletableFuture.supplyAsync(
+          () -> validationResult.combine(ValidationResult.withFailures(1,
+              List.of("Not enough columns provided for row: \"%s\"".formatted(row)))));
     }
     var sampleCodes = SampleCode.create(
         safeArrayAccess(metaDataValues, sampleCodeColumnIndex).orElse(""));
@@ -519,7 +554,7 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     return finalValidationResult;
   }
 
-  private ValidationResult validatePxPRow(Map<String, Integer> propertyColumnMap,
+  private CompletableFuture<ValidationResult> validatePxPRow(Map<String, Integer> propertyColumnMap,
       String row) {
     var validationResult = ValidationResult.successful(0);
     var metaDataValues = row.split("\t"); // tab separated values
@@ -527,7 +562,7 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     if (metaDataValues.length == 0) {
       validationResult.combine(
           ValidationResult.successful(1, List.of("Empty row provided.")));
-      return validationResult;
+      return CompletableFuture.supplyAsync(() -> validationResult);
     }
     if (metaDataValues.length != propertyColumnMap.keySet().size()) {
       validationResult.combine(ValidationResult.withFailures(1, List.of("")));
@@ -560,8 +595,9 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     int maxPropertyIndex = IntStream.of(sampleCodeColumnIndex, organisationsColumnIndex,
         instrumentColumnIndex).max().orElseThrow();
     if (propertyColumnMap.size() <= maxPropertyIndex) {
-      return validationResult.combine(ValidationResult.withFailures(1,
-          List.of("Not enough columns provided for row: \"%s\"".formatted(row))));
+      return CompletableFuture.supplyAsync(
+          () -> validationResult.combine(ValidationResult.withFailures(1,
+              List.of("Not enough columns provided for row: \"%s\"".formatted(row)))));
     }
 
     var measurementId = safeArrayAccess(metaDataValues, measurementIdIndex).orElse("");
@@ -586,7 +622,8 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     var metadata = new ProteomicsMeasurementMetadata(measurementId, List.of(sampleCodes),
         organisationRoRId, instrumentCURIE, samplePoolGroup, facility, fractionName,
         digestionEnzyme,
-        digestionMethod, enrichmentMethod, injectionVolume, lcColumn, lcmsMethod, List.of(new Labeling(sampleCodes.code(), labelingType, label)), note);
+        digestionMethod, enrichmentMethod, injectionVolume, lcColumn, lcmsMethod,
+        List.of(new Labeling(sampleCodes.code(), labelingType, label)), note);
     var measurementProteomicsValidationExecutor = new MeasurementProteomicsValidationExecutor(
         measurementValidationService);
     var finalValidationResult = generateModeDependentValidationResult(
@@ -594,10 +631,11 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     return finalValidationResult;
   }
 
-  private ValidationResult generateModeDependentValidationResult(
+  private CompletableFuture<ValidationResult> generateModeDependentValidationResult(
       MeasurementValidationExecutor measurementValidationExecutor, MeasurementMetadata metadata) {
     return switch (mode) {
-      case ADD -> measurementValidationExecutor.validateRegistration(metadata);
+      case ADD -> CompletableFuture.supplyAsync(
+          () -> measurementValidationExecutor.validateRegistration(metadata));
       case EDIT -> measurementValidationExecutor.validateUpdate(metadata);
     };
   }
@@ -615,6 +653,20 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
 
   public Registration addConfirmListener(ComponentEventListener<ConfirmEvent> listener) {
     return addListener(ConfirmEvent.class, listener);
+  }
+
+  public void showTaskInProgress(String label, String description) {
+    this.taskInProgressDisplay.setVisible(true);
+    progressbarLabelText.setText(label);
+    progressbarDescriptionText.setText(description);
+    this.uploadSection.setVisible(false);
+    this.uploadedItemsSection.setVisible(false);
+  }
+
+  public void hideTaskInProgress() {
+    taskInProgressDisplay.setVisible(false);
+    uploadSection.setVisible(true);
+    this.uploadedItemsSection.setVisible(true);
   }
 
   @Override
@@ -665,6 +717,11 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     for (MeasurementFileDisplay measurementFileDisplay : fileDisplaysWithFileName(filename)) {
       measurementFileDisplay.addError(error);
     }
+  }
+
+  public enum MODE {
+    ADD, EDIT
+
   }
 
   record MeasurementValidationReport(int validatedRows,
@@ -812,10 +869,5 @@ public class MeasurementMetadataUploadDialog extends DialogWindow {
     public CancelEvent(MeasurementMetadataUploadDialog source, boolean fromClient) {
       super(source, fromClient);
     }
-  }
-
-  public enum MODE {
-    ADD, EDIT
-
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementNGSValidationExecutor.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementNGSValidationExecutor.java
@@ -1,6 +1,7 @@
 package life.qbic.datamanager.views.projects.project.measurements;
 
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import life.qbic.projectmanagement.application.measurement.NGSMeasurementMetadata;
 import life.qbic.projectmanagement.application.measurement.validation.MeasurementValidationService;
 import life.qbic.projectmanagement.application.measurement.validation.ValidationResult;
@@ -30,7 +31,7 @@ public class MeasurementNGSValidationExecutor implements
     return measurementValidationService.validateNGS(metadata);
   }
   @Override
-  public ValidationResult validateUpdate(NGSMeasurementMetadata metadata) {
+  public CompletableFuture<ValidationResult> validateUpdate(NGSMeasurementMetadata metadata) {
     //Todo provide edit validation for ngs;
     return null;
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementProteomicsValidationExecutor.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementProteomicsValidationExecutor.java
@@ -1,6 +1,7 @@
 package life.qbic.datamanager.views.projects.project.measurements;
 
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import life.qbic.projectmanagement.application.measurement.ProteomicsMeasurementMetadata;
 import life.qbic.projectmanagement.application.measurement.validation.MeasurementValidationService;
 import life.qbic.projectmanagement.application.measurement.validation.ValidationResult;
@@ -33,7 +34,7 @@ public class MeasurementProteomicsValidationExecutor implements
   }
 
   @Override
-  public ValidationResult validateUpdate(ProteomicsMeasurementMetadata metadata) {
+  public CompletableFuture<ValidationResult> validateUpdate(ProteomicsMeasurementMetadata metadata) {
     return measurementValidationService.validateProteomicsUpdate(metadata);
   }
 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementValidationExecutor.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementValidationExecutor.java
@@ -1,5 +1,6 @@
 package life.qbic.datamanager.views.projects.project.measurements;
 
+import java.util.concurrent.CompletableFuture;
 import life.qbic.projectmanagement.application.measurement.validation.MeasurementValidationService;
 import life.qbic.projectmanagement.application.measurement.validation.ValidationResult;
 
@@ -18,6 +19,6 @@ public interface MeasurementValidationExecutor<MeasurementMetadata> {
 
   ValidationResult validateRegistration(MeasurementMetadata metadata);
 
-  ValidationResult validateUpdate(MeasurementMetadata metadata);
+  CompletableFuture<ValidationResult> validateUpdate(MeasurementMetadata metadata);
 
 }


### PR DESCRIPTION
Enables async service method calls for measurement updates and registrations.

The current implementation also shows a intermediate progress bar to the user, until the task is finished.