### PR TITLE
Remove duplicate hits in ontology search

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ontology/OntologyClass.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ontology/OntologyClass.java
@@ -110,17 +110,12 @@ public class OntologyClass {
       return false;
     }
     OntologyClass that = (OntologyClass) o;
-    return Objects.equals(ontologyAbbreviation, that.ontologyAbbreviation) && Objects.equals(
-        ontologyVersion, that.ontologyVersion) && Objects.equals(ontologyIri,
-        that.ontologyIri) && Objects.equals(classLabel, that.classLabel) && Objects.equals(
-        curie, that.curie) && Objects.equals(description, that.description)
-        && Objects.equals(classIri, that.classIri);
+    return Objects.equals(classIri, that.classIri);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ontologyAbbreviation, ontologyVersion, ontologyIri, classLabel, curie,
-        description, classIri);
+    return Objects.hash(classIri);
   }
 
   public Long getId() {
@@ -130,4 +125,5 @@ public class OntologyClass {
   public void setId(Long id) {
     this.id = id;
   }
+
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ontology/OntologyLookupService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ontology/OntologyLookupService.java
@@ -41,8 +41,8 @@ public class OntologyLookupService {
       int offset, int limit, List<SortOrder> sortOrders) {
     // returned by JPA -> UnmodifiableRandomAccessList
     List<OntologyClass> termList = ontologyTermLookup.query(new FilterTerm(filterTerm),
-        ontologyAbbreviations, offset,
-        limit, sortOrders);
+        ontologyAbbreviations, offset, limit, sortOrders)
+        .stream().distinct().toList();
     // the list must be modifiable for spring security to filter it
     return new ArrayList<>(termList);
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.theme.lumo.LumoIcon;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -493,8 +492,7 @@ public class ExperimentDetailsComponent extends PageArea {
     List<ExperimentalGroup> groups = experimentInformationService.experimentalGroupsFor(
         context.experimentId().orElseThrow());
     List<ExperimentalGroupCard> experimentalGroupsCards = groups.stream()
-        .sorted(Comparator.comparing(ExperimentalGroup::name)).map(ExperimentalGroupCard::new)
-        .toList();
+        .map(ExperimentalGroupCard::new).toList();
     experimentalGroupsCollection.setContent(experimentalGroupsCards);
     this.experimentalGroupCount = experimentalGroupsCards.size();
   }
@@ -538,9 +536,7 @@ public class ExperimentDetailsComponent extends PageArea {
     // We load the experimental variables of the experiment and render them as cards
     List<ExperimentalVariable> variables = experiment.variables();
     List<ExperimentalVariableCard> experimentalVariableCards = variables.stream()
-        .sorted(Comparator.comparing((ExperimentalVariable h) -> h.name().value()))
         .map(ExperimentalVariableCard::new).toList();
-
     experimentalVariableCollection.setContent(experimentalVariableCards);
 
     if (variables.isEmpty()) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.theme.lumo.LumoIcon;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -492,7 +493,8 @@ public class ExperimentDetailsComponent extends PageArea {
     List<ExperimentalGroup> groups = experimentInformationService.experimentalGroupsFor(
         context.experimentId().orElseThrow());
     List<ExperimentalGroupCard> experimentalGroupsCards = groups.stream()
-        .map(ExperimentalGroupCard::new).toList();
+        .sorted(Comparator.comparing(ExperimentalGroup::name)).map(ExperimentalGroupCard::new)
+        .toList();
     experimentalGroupsCollection.setContent(experimentalGroupsCards);
     this.experimentalGroupCount = experimentalGroupsCards.size();
   }
@@ -536,7 +538,9 @@ public class ExperimentDetailsComponent extends PageArea {
     // We load the experimental variables of the experiment and render them as cards
     List<ExperimentalVariable> variables = experiment.variables();
     List<ExperimentalVariableCard> experimentalVariableCards = variables.stream()
+        .sorted(Comparator.comparing((ExperimentalVariable h) -> h.name().value()))
         .map(ExperimentalVariableCard::new).toList();
+
     experimentalVariableCollection.setContent(experimentalVariableCards);
 
     if (variables.isEmpty()) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/ontology/OntologyLookupComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/ontology/OntologyLookupComponent.java
@@ -51,7 +51,7 @@ public class OntologyLookupComponent extends PageArea {
   private final Div ontologyGridSection = new Div();
   private GridLazyDataView<OntologyClass> ontologyGridLazyDataView;
   private String searchTerm = "";
-  private final Span foundResults = new Span();
+  private final Span numberOfHitsInfo = new Span();
   private final transient OntologyLookupService ontologyTermInformationService;
   private static final int ONTOLOGY_SEARCH_LOWER_LIMIT = 2;
 
@@ -99,8 +99,8 @@ public class OntologyLookupComponent extends PageArea {
     ontologyGrid.addClassName("ontology-grid");
     ontologyGrid.addThemeVariants(GridVariant.LUMO_NO_BORDER, GridVariant.LUMO_NO_ROW_BORDERS);
     setLazyDataProviderForOntologyGrid(ontologyGrid);
-    ontologyGridSection.add(foundResults, ontologyGrid);
-    foundResults.addClassName("secondary");
+    ontologyGridSection.add(numberOfHitsInfo, ontologyGrid);
+    numberOfHitsInfo.addClassName("secondary");
     ontologyGridSection.addClassName("ontology-grid-section");
   }
 
@@ -132,8 +132,8 @@ public class OntologyLookupComponent extends PageArea {
   }
 
   private void showResultSection(boolean isVisible) {
-    foundResults.setVisible(isVisible);
-    foundResults.setText(
+    numberOfHitsInfo.setVisible(isVisible);
+    numberOfHitsInfo.setText(
         "%s results found".formatted(ontologyGridLazyDataView.getItems().count()));
     ontologyGridSection.setVisible(isVisible);
   }


### PR DESCRIPTION
* changes equals/hashcode methods of OntologyClass to only check classIRI (as it's unique!)
* makes list of hits returned by ontology search distinct