### PR TITLE
Allow to add new groups even if samples are registered

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ExperimentInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ExperimentInformationService.java
@@ -350,8 +350,6 @@ public class ExperimentInformationService {
 
   private List<Long> getGroupIdsToDelete(List<ExperimentalGroup> existingGroups,
       List<ExperimentalGroupDTO> newGroups) {
-    System.err.println(existingGroups.stream().map(ExperimentalGroup::id).toList());
-    System.err.println(newGroups.stream().map(ExperimentalGroupDTO::id).toList());
     Set<Long> newIds = newGroups.stream().map(ExperimentalGroupDTO::id).collect(Collectors.toSet());
     return existingGroups.stream()
         .map(ExperimentalGroup::id)

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ExperimentInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ExperimentInformationService.java
@@ -350,6 +350,8 @@ public class ExperimentInformationService {
 
   private List<Long> getGroupIdsToDelete(List<ExperimentalGroup> existingGroups,
       List<ExperimentalGroupDTO> newGroups) {
+    System.err.println(existingGroups.stream().map(ExperimentalGroup::id).toList());
+    System.err.println(newGroups.stream().map(ExperimentalGroupDTO::id).toList());
     Set<Long> newIds = newGroups.stream().map(ExperimentalGroupDTO::id).collect(Collectors.toSet());
     return existingGroups.stream()
         .map(ExperimentalGroup::id)

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/Condition.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/Condition.java
@@ -3,6 +3,7 @@ package life.qbic.projectmanagement.domain.model.experiment;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -76,7 +77,7 @@ public class Condition {
       throw new IllegalArgumentException(
           "Variable levels are not from distinct experimental variables.");
     }
-    this.variableLevels = List.copyOf(variableLevels);
+    this.variableLevels = new ArrayList<>(variableLevels);
   }
 
   /**

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -401,6 +401,9 @@ public class ExperimentDetailsComponent extends PageArea {
         .toList();
     var groups = experimentInformationService.getExperimentalGroups(experimentId)
         .stream().map(this::toContent).toList();
+    System.err.println(groups.stream().map(ExperimentalGroupContent::name).toList());
+    System.err.println(groups.stream().map(ExperimentalGroupContent::id).toList());
+
     ExperimentalGroupsDialog dialog;
     if(groups.isEmpty()) {
       dialog = ExperimentalGroupsDialog.empty(levels);

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -401,8 +401,6 @@ public class ExperimentDetailsComponent extends PageArea {
         .toList();
     var groups = experimentInformationService.getExperimentalGroups(experimentId)
         .stream().map(this::toContent).toList();
-    System.err.println(groups.stream().map(ExperimentalGroupContent::name).toList());
-    System.err.println(groups.stream().map(ExperimentalGroupContent::id).toList());
 
     ExperimentalGroupsDialog dialog;
     if(groups.isEmpty()) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentalGroupInput.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentalGroupInput.java
@@ -49,7 +49,7 @@ public class ExperimentalGroupInput extends CustomField<ExperimentalGroupBean> {
 
   private final List<ComponentEventListener<RemoveEvent>> removeEventListeners;
   private final TextField nameField;
-  private final long id = -1;
+  private long id = -1;
   private final MultiSelectComboBox<VariableLevel> variableLevelSelect;
   private final NumberField replicateCountField;
   int variableCount = 0;
@@ -236,6 +236,10 @@ public class ExperimentalGroupInput extends CustomField<ExperimentalGroupBean> {
     boolean variableNameContainsFilterString = level.variableName().value().toLowerCase()
         .contains(filterString.toLowerCase());
     return variableNameContainsFilterString || levelValueContainsFilterString;
+  }
+
+  public void setGroupId(long id) {
+    this.id = id;
   }
 
   public static class ExperimentalGroupBean {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
@@ -58,6 +58,7 @@ public class ExperimentalGroupsDialog extends DialogWindow {
     experimentalGroupContents.stream().map(group -> {
       var groupEntry = new ExperimentalGroupInput(experimentalVariableLevels, editMode);
       groupEntry.setGroupName(group.name());
+      groupEntry.setGroupId(group.id());
       groupEntry.setCondition(group.variableLevels());
       groupEntry.setReplicateCount(group.size());
       groupEntry.setEnabled(editMode);


### PR DESCRIPTION
* Fixes issue where adding experimental groups would delete and recreate old groups
* Allows users to add (**not edit**) experiment groups, even if samples are already registered