### PR TITLE
Only allow creation of complete experimental groups

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -416,11 +416,13 @@ public class ExperimentDetailsComponent extends PageArea {
   private void onExperimentalGroupAddConfirmed(
       ConfirmEvent<ExperimentalGroupsDialog> confirmEvent) {
     ExperimentalGroupsDialog dialog = confirmEvent.getSource();
-    var groupContents = dialog.experimentalGroups();
-    addExperimentalGroups(groupContents);
+    if(dialog.isValid()) {
+      var groupContents = dialog.experimentalGroups();
+      addExperimentalGroups(groupContents);
 
-    reloadExperimentalGroups();
-    dialog.close();
+      reloadExperimentalGroups();
+      dialog.close();
+    }
   }
 
   private void openExperimentalGroupEditDialog() {
@@ -442,12 +444,15 @@ public class ExperimentDetailsComponent extends PageArea {
 
   private void onExperimentalGroupEditConfirmed(
       ConfirmEvent<ExperimentalGroupsDialog> confirmEvent) {
-    var groupDTOs = confirmEvent.getSource().experimentalGroups().stream()
-        .map(this::toExperimentalGroupDTO).toList();
-    ExperimentId experimentId = context.experimentId().orElseThrow();
-    experimentInformationService.updateExperimentalGroupsOfExperiment(experimentId, groupDTOs);
-    reloadExperimentalGroups();
-    confirmEvent.getSource().close();
+    ExperimentalGroupsDialog dialog = confirmEvent.getSource();
+    if(dialog.isValid()) {
+      var groupDTOs = dialog.experimentalGroups().stream()
+          .map(this::toExperimentalGroupDTO).toList();
+      ExperimentId experimentId = context.experimentId().orElseThrow();
+      experimentInformationService.updateExperimentalGroupsOfExperiment(experimentId, groupDTOs);
+      reloadExperimentalGroups();
+      confirmEvent.getSource().close();
+    }
   }
 
   private void addExperimentalGroups(

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExperimentalGroupsDialog.java
@@ -190,6 +190,12 @@ public class ExperimentalGroupsDialog extends DialogWindow {
         .toList();
   }
 
+  public boolean isValid() {
+    return this.experimentalGroupsCollection.getChildren()
+        .filter(component -> component.getClass().equals(ExperimentalGroupInput.class))
+        .noneMatch(g -> ((ExperimentalGroupInput) g).isInvalid());
+  }
+
   public record ExperimentalGroupContent(long id, String name, int size, List<VariableLevel> variableLevels) {}
 
   public static class ConfirmEvent extends


### PR DESCRIPTION
Fixes an issue where the test for incomplete groups - those without all defined variables - would not be checked upon edit or creation of groups