### PR TITLE
Enable ACL cache

### DIFF
--- a/user-interface/pom.xml
+++ b/user-interface/pom.xml
@@ -123,6 +123,11 @@
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
     </dependency>

--- a/user-interface/src/main/java/life/qbic/datamanager/CacheLogger.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/CacheLogger.java
@@ -5,21 +5,16 @@ import static life.qbic.logging.service.LoggerFactory.logger;
 import life.qbic.logging.api.Logger;
 import org.ehcache.event.CacheEvent;
 import org.ehcache.event.CacheEventListener;
+import org.springframework.security.acls.domain.ObjectIdentityImpl;
+import org.springframework.security.acls.model.MutableAcl;
 
-/**
- * <b><class short description - 1 Line!></b>
- *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
- */
-public class CacheLogger implements CacheEventListener {
+public class CacheLogger implements CacheEventListener<ObjectIdentityImpl, MutableAcl> {
 
   private static final Logger log = logger(CacheLogger.class);
 
   @Override
   public void onEvent(CacheEvent cacheEvent) {
-    log.info("Key: %s | EventType: %s | Old value: %s | New value: %s".formatted(
+    log.debug("Key: %s | EventType: %s | Old value: %s | New value: %s".formatted(
         cacheEvent.getKey(), cacheEvent.getType(), cacheEvent.getOldValue(),
         cacheEvent.getNewValue()));
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/CacheLogger.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/CacheLogger.java
@@ -1,0 +1,26 @@
+package life.qbic.datamanager;
+
+import static life.qbic.logging.service.LoggerFactory.logger;
+
+import life.qbic.logging.api.Logger;
+import org.ehcache.event.CacheEvent;
+import org.ehcache.event.CacheEventListener;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public class CacheLogger implements CacheEventListener {
+
+  private static final Logger log = logger(CacheLogger.class);
+
+  @Override
+  public void onEvent(CacheEvent cacheEvent) {
+    log.info("Key: %s | EventType: %s | Old value: %s | New value: %s".formatted(
+        cacheEvent.getKey(), cacheEvent.getType(), cacheEvent.getOldValue(),
+        cacheEvent.getNewValue()));
+  }
+}

--- a/user-interface/src/main/resources/ehcache3.xml
+++ b/user-interface/src/main/resources/ehcache3.xml
@@ -9,9 +9,19 @@
       <!-- cache expires after 10 minutes-->
       <ttl>600</ttl>
     </expiry>
+    <listeners>
+      <listener>
+        <class>life.qbic.datamanager.CacheLogger</class>
+        <event-firing-mode>ASYNCHRONOUS</event-firing-mode>
+        <event-ordering-mode>UNORDERED</event-ordering-mode>
+        <events-to-fire-on>CREATED</events-to-fire-on>
+        <events-to-fire-on>EXPIRED</events-to-fire-on>
+        <events-to-fire-on>EVICTED</events-to-fire-on>
+      </listener>
+    </listeners>
     <resources>
       <!-- heap allows for caching of up to 200 entries-->
-      <heap>200</heap>
+      <heap unit="entries">20000</heap>
       <offheap unit="MB">10</offheap>
     </resources>
   </cache>

--- a/user-interface/src/main/resources/ehcache3.xml
+++ b/user-interface/src/main/resources/ehcache3.xml
@@ -20,8 +20,8 @@
       </listener>
     </listeners>
     <resources>
-      <!-- heap allows for caching of up to 200 entries-->
-      <heap unit="entries">20000</heap>
+      <!-- heap allows for caching of up to 2000 entries-->
+      <heap unit="entries">2000</heap>
       <offheap unit="MB">10</offheap>
     </resources>
   </cache>


### PR DESCRIPTION
Previously, the cache was not active and therefore we did not make actual use of the perfomance boost of cached ACL queries, which is especially helpful when users are navigating within the same project.

This PR enables the cache and also introduces a cache logger for debugging purposes.