### PR TITLE
Listing collaborators only requires READ role and more expressive access denied message

### DIFF
--- a/application-commons/pom.xml
+++ b/application-commons/pom.xml
@@ -19,5 +19,10 @@
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-core -->
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/application-commons/src/main/java/life/qbic/application/commons/ApplicationException.java
+++ b/application-commons/src/main/java/life/qbic/application/commons/ApplicationException.java
@@ -1,5 +1,6 @@
 package life.qbic.application.commons;
 
+import java.nio.file.AccessDeniedException;
 import java.util.Arrays;
 import java.util.StringJoiner;
 
@@ -104,7 +105,11 @@ public class ApplicationException extends RuntimeException {
     if (e instanceof ApplicationException applicationException) {
       return new ApplicationException(e, applicationException.errorCode(),
           applicationException.errorParameters());
-    } else {
+    }
+    if (e instanceof org.springframework.security.access.AccessDeniedException) {
+      return new ApplicationException(e, ErrorCode.ACCESS_DENIED, ErrorParameters.empty());
+    }
+    else {
       return new ApplicationException(e.getMessage(), e);
     }
   }
@@ -133,6 +138,7 @@ public class ApplicationException extends RuntimeException {
    */
   public enum ErrorCode {
     GENERAL,
+    ACCESS_DENIED,
     INVALID_EXPERIMENTAL_DESIGN,
     INVALID_PROJECT_OBJECTIVE,
     INVALID_PROJECT_TITLE,

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
@@ -18,6 +18,7 @@ import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,7 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @since 1.0.0
  */
-@Service
+@Component
 public class ProjectRepositoryImpl implements ProjectRepository {
 
   private static final Logger log = logger(ProjectRepositoryImpl.class);

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/authorization/acl/ProjectAccessServiceImpl.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/authorization/acl/ProjectAccessServiceImpl.java
@@ -373,7 +373,7 @@ public class ProjectAccessServiceImpl implements ProjectAccessService {
 
   @Override
   @Transactional(readOnly = true)
-  @PreAuthorize("hasPermission(#projectId, 'life.qbic.projectmanagement.domain.model.project.Project', 'WRITE')")
+  @PreAuthorize("hasPermission(#projectId, 'life.qbic.projectmanagement.domain.model.project.Project', 'READ')")
   public List<ProjectCollaborator> listCollaborators(ProjectId projectId) {
     Acl acl = aclService.readAclById(new ObjectIdentityImpl(Project.class, projectId), null);
 

--- a/user-interface/src/main/resources/messages.properties
+++ b/user-interface/src/main/resources/messages.properties
@@ -1,4 +1,5 @@
-GENERAL= Apologies, an error occurred! -> Looks like something went wrong! We track these errors, but if the problem persists feel free to contact us at support@qbic.zendesk.com. In the meantime, try refreshing.
+GENERAL=Apologies, an error occurred! -> Looks like something went wrong! We track these errors, but if the problem persists feel free to contact us at support@qbic.zendesk.com. In the meantime, try refreshing.
+ACCESS_DENIED=Insufficient rights. -> You don't have sufficient rights for this operation, please contact the project owner.
 INVALID_PROJECT_TITLE=The project title {1} is invalid. -> A valid project title is not empty and is shorter than {0} characters.
 INVALID_EXPERIMENTAL_DESIGN=The experimental design description is invalid -> A valid description of an experimental design must not be empty and contain at most {0} characters.
 INVALID_PROJECT_OBJECTIVE=The project objective {0} is invalid. -> A valid objective is not empty.


### PR DESCRIPTION
Listing collaborators is now allowed with READ permission in a project.

Also, I adjusted the exception handling, such that for ACCESS DENIED, the user no gets a more expressive message instead of a general error message.