### PR TITLE
Show pooling specific measurement information in dedicated dialog

### DIFF
--- a/user-interface/frontend/themes/datamanager/components/dialog.css
+++ b/user-interface/frontend/themes/datamanager/components/dialog.css
@@ -11,7 +11,7 @@ vaadin-dialog-overlay::part(footer) {
 }
 
 vaadin-dialog-overlay::part(header) {
-  padding: 2rem 1rem 1rem 4rem;
+  padding: 2rem 4rem 1rem 4rem;
 }
 
 vaadin-dialog-overlay::part(title) {
@@ -432,6 +432,32 @@ vaadin-dialog-overlay::part(title) {
 
 .change-user-details-dialog .change-user-name {
   width: 100%;
+}
+
+.measurement-pooled-samples-dialog::part(overlay) {
+  min-width: 50vw;
+}
+
+.measurement-pooled-samples-dialog::part(content) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--lumo-space-l);
+}
+
+.measurement-pooled-samples-dialog .pooled-measurement-details {
+  gap: var(--lumo-space-xs);
+  display: flex;
+  flex-direction: column;
+}
+
+.measurement-pooled-samples-dialog .pooled-measurement-details .pooled-detail {
+  gap: var(--lumo-space-s);
+  display: inline-flex;
+}
+
+.measurement-pooled-samples-dialog .pooled-measurement-details .pooled-detail .label {
+  color: var(--lumo-secondary-text-color);
+  font-weight: bold;
 }
 
 .measurement-upload-dialog::part(overlay) {

--- a/user-interface/frontend/themes/datamanager/components/page-area.css
+++ b/user-interface/frontend/themes/datamanager/components/page-area.css
@@ -145,13 +145,19 @@
 
 .measurement-details-component .measurement-grid {
   height: 100%;
-  width: 100%;
 }
 
-.measurement-details-component .measurement-grid .sample-code-column {
-  display: flex;
-  flex-direction: column;
-  row-gap: var(--lumo-space-s);
+.measurement-details-component .measurement-grid .sample-column-cell {
+  display: inline-flex;
+  column-gap: var(--lumo-space-s);
+  align-items: center;
+}
+
+.measurement-details-component .measurement-grid .sample-column-cell .expand-icon {
+  width: 1em;
+  height: 1em;
+  color: var(--lumo-primary-color);
+  cursor: pointer;
 }
 
 .measurement-details-component .measurement-grid .organisation-entry {
@@ -177,17 +183,6 @@
   row-gap: var(--lumo-space-s);
   cursor: default;
 }
-
-/*We want to style the cells within the rows containing the components and values within the measurement grid to be clickable*/
-.measurement-details-component .measurement-grid > * {
-  cursor: pointer;
-}
-
-/*We want to style the rows within the measurement grid to be clickable without the items showing the pointer cursor*/
-.measurement-details-component .measurement-grid::part(row) {
-  cursor: pointer;
-}
-
 
 .measurement-details-component .measurement-grid .measurement-item .entry {
   display: inline-flex;


### PR DESCRIPTION
**What was changed**
1.) Moved pooling information into a distinct dialog, openable via extendable icon in sample ID column in measurmentgrid 
2.) Remove GridItemDetails within measurement grid and move information into columns within the grid

**Open Questions**
1.) What should be shown in NGS pooling dialog? 
(Currently there is nothing implemented as sample specific metadata information for NGS)
2.) Are all fields still relevant as columns within NGS and proteomics? The grid is horizontally scrollable, but this is cumbersome. 

**Technical Issues**
1.) There is a lot of duplicate code which could be moved into a distinct outer class. 
2.) A dedicated SQL View might be a lot faster and host the frontend information directly, making the grid filterable as well. Currently the database is queried a lot since e.g. the sample information has to be gathered seperately