### PR TITLE
Enable download of URL file

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataMain.java
@@ -155,7 +155,7 @@ public class RawDataMain extends Main implements BeforeEnterObserver {
     }
     var downloadUrls = generateDownloadUrls(selectedMeasurements);
     var currentExperiment = experimentInformationService.find(
-            context.experimentId().orElseThrow().value(), context.experimentId().orElseThrow())
+            context.projectId().orElseThrow().value(), context.experimentId().orElseThrow())
         .orElseThrow();
     urlDownloadFormatter.updateContext(currentExperiment, downloadUrls);
     urlDownload.trigger();


### PR DESCRIPTION
The wrong ID type has been passed to the ACL protected service method (experiment ID instead of project ID).

Thus the authorization always failed.

This PR passes the project ID to enable the correct access policy.