### PR TITLE
Provide UTF-16 support for measurement metadata

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMetadataUploadDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMetadataUploadDialog.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serial;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -128,7 +129,7 @@ public class MeasurementMetadataUploadDialog extends WizardDialogWindow {
   }
 
   private static MetadataContent read(InputStream inputStream) {
-    var content = new BufferedReader(new InputStreamReader(inputStream)).lines().toList();
+    var content = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_16)).lines().toList();
 
     return new MetadataContent(content.isEmpty() ? null : content.get(0),
         content.size() > 1 ? content.subList(1, content.size()) : new ArrayList<>());


### PR DESCRIPTION
Microsoft Excel currently only supports exports to CSV UTF-8 format (which we do not support), TSV in an unknown format (thank you Microsoft) and Unicode UTF-16.

The latter uses the tab character as separator, which is exactly what we want. 

This PR reads in any file content for measurement metadata assuming UTF-16, which contains UTF-8 and thus should work for the most symbols used currently in production environments. 