### PR TITLE
Increase size of stored offers

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/project/purchase/Offer.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/project/purchase/Offer.java
@@ -31,7 +31,7 @@ public class Offer {
   private String fileName;
 
   @Lob
-  @Column(name = "file_content", columnDefinition="BLOB")
+  @Column(name = "file_content", columnDefinition = "LONGBLOB")
   @Basic(fetch=LAZY)
   private byte[] fileContent;
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/qualitycontrol/QualityControlUpload.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/sample/qualitycontrol/QualityControlUpload.java
@@ -35,7 +35,7 @@ public class QualityControlUpload {
   private ExperimentId experimentId;
   private String fileName;
   @Lob
-  @Column(name = "file_content", columnDefinition = "BLOB")
+  @Column(name = "file_content", columnDefinition = "LONGBLOB")
   @Basic(fetch = LAZY)
   private byte[] fileContent;
 


### PR DESCRIPTION
Blob only stores 65,535 bytes.
Medium blob stores  16,777,215 bytes
long blob stores 4 GB

As offers are expected to be larger than 15,9MB we need a bigger type.

```
org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "alter table purchase_offer modify column file_content BLOB" via JDBC [Data truncation: Data too long for column 'file_content' at row 2]
        at org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase.accept(GenerationTargetToDatabase.java:94)
        at org.hibernate.tool.schema.internal.AbstractSchemaMigrator.applySqlString(AbstractSchemaMigrator.java:574)
        at org.hibernate.tool.schema.internal.AbstractSchemaMigrator.applySqlStrings(AbstractSchemaMigrator.java:514)
        at org.hibernate.tool.schema.internal.AbstractSchemaMigrator.migrateTable(AbstractSchemaMigrator.java:333)
```