### PR TITLE
Fix Project Overview entity

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectOverview.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectOverview.java
@@ -11,10 +11,9 @@ import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
-import org.springframework.data.annotation.Immutable;
+import org.hibernate.annotations.Immutable;
 
 /**
  * A limited view of the more complex {@link Project}.
@@ -23,6 +22,7 @@ import org.springframework.data.annotation.Immutable;
  */
 //Views are aggregates which cannot be changed
 @Immutable
+@org.springframework.data.annotation.Immutable
 @Entity
 @Table(name = "project_overview")
 public class ProjectOverview {
@@ -54,33 +54,12 @@ public class ProjectOverview {
   @Column(name = "amountPxpMeasurements")
   private String pxpMeasurementCount;
 
-  @Column(name = "userName")
   @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
   @CollectionTable(name = "project_usernames", joinColumns = @JoinColumn(name = "projectId"))
   private Collection<String> collaboratorUserNames = new ArrayList<>();
 
   protected ProjectOverview() {
 
-  }
-
-  public ProjectOverview(ProjectId id, String projectTitle, String projectCode,
-      Instant lastModified, String principalInvestigatorName, String projectManagerName,
-      String projectResponsibleName,
-      String ngsMeasurementCount, String pxpMeasurementCount,
-      Collection<String> usernames) {
-    this.id = Objects.requireNonNull(id, "project Id cannot be null");
-    this.projectTitle = Objects.requireNonNull(projectTitle, "projectTitle cannot be null");
-    this.projectCode = Objects.requireNonNull(projectCode, "project code cannot be null");
-    this.lastModified = Objects.requireNonNull(lastModified, "lastModified date cannot be null");
-    this.principalInvestigatorName = Objects.requireNonNull(principalInvestigatorName,
-        "principal investigator name cannot be null");
-    this.projectManagerName = Objects.requireNonNull(projectManagerName,
-        "project manager name cannot be null");
-    this.projectResponsibleName = projectResponsibleName;
-    this.ngsMeasurementCount = ngsMeasurementCount;
-    this.pxpMeasurementCount = pxpMeasurementCount;
-    this.collaboratorUserNames = Objects.requireNonNull(usernames,
-        "The collaborator user names cannot be null");
   }
 
   public ProjectId projectId() {


### PR DESCRIPTION
The project overview entity idicated to JPA a confusing setup with a column and join table for an element collection on the same field. This does always throw exceptions when hibernate is trying to set up the database. Further the wrong '@Immutable` annotation was used.