### PR TITLE
Extending project code to avoid collisions with legacy QBiC project codes

### DIFF
--- a/project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/sample/SampleCodeJpaRepositorySpec.groovy
+++ b/project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/sample/SampleCodeJpaRepositorySpec.groovy
@@ -19,7 +19,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
         ProjectId projectId = ProjectId.create()
 
         and:
-        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("QTEST"))
+        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("Q2TEST"))
 
         and:
         sampleStatistic.findByProjectId(projectId) >> [sampleStatisticEntry]
@@ -32,7 +32,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
 
         then:
         result.isValue()
-        result.getValue().code().equals("QTEST001AL")
+        result.getValue().code().equals("Q2TEST001A5")
     }
 
     def "Given 998 sample statistic entry, generate the next available sample code with no letter jump and counter starting with 999"() {
@@ -43,7 +43,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
         ProjectId projectId = ProjectId.create()
 
         and:
-        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("QTEST"))
+        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("Q2TEST"))
         // Prime to 999 sample numbers that have been drawn already
         for (int i = 1; i <= 998; i++) {
             sampleStatisticEntry.drawNextSampleNumber()
@@ -60,7 +60,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
 
         then:
         result.isValue()
-        result.getValue().code().equals("QTEST999AW")
+        result.getValue().code().equals("Q2TEST999A8")
     }
 
 
@@ -72,7 +72,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
         ProjectId projectId = ProjectId.create()
 
         and:
-        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("QTEST"))
+        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("Q2TEST"))
         // Prime to 999 sample numbers that have been drawn already
         for (int i = 1; i <= 999; i++) {
             sampleStatisticEntry.drawNextSampleNumber()
@@ -89,7 +89,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
 
         then:
         result.isValue()
-        result.getValue().code().equals("QTEST001BU")
+        result.getValue().code().equals("Q2TEST001BF")
     }
 
     def "Given a 1998 sample statistic entry, generate the next available sample code with letter jump and counter starting with 001"() {
@@ -100,7 +100,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
         ProjectId projectId = ProjectId.create()
 
         and:
-        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("QTEST"))
+        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("Q2TEST"))
         for (int i = 1; i <= 1998; i++) {
             sampleStatisticEntry.drawNextSampleNumber()
         }
@@ -116,7 +116,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
 
         then:
         result.isValue()
-        result.getValue().code().equals("QTEST001C5")
+        result.getValue().code().equals("Q2TEST001CP")
     }
 
     def "Given a 1997 sample statistic entry, generate the next available sample code with letter jump and counter starting with 001"() {
@@ -127,7 +127,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
         ProjectId projectId = ProjectId.create()
 
         and:
-        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("QTEST"))
+        SampleStatisticEntry sampleStatisticEntry = SampleStatisticEntry.create(projectId, ProjectCode.parse("Q2TEST"))
         for (int i = 1; i <= 1997; i++) {
             sampleStatisticEntry.drawNextSampleNumber()
         }
@@ -143,7 +143,7 @@ class SampleCodeJpaRepositorySpec extends Specification{
 
         then:
         result.isValue()
-        result.getValue().code().equals("QTEST999B7")
+        result.getValue().code().equals("Q2TEST999BI")
     }
 
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/project/ProjectCode.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/project/ProjectCode.java
@@ -23,9 +23,9 @@ public class ProjectCode {
   @Column(name = "projectCode")
   private String value;
 
-  private static final int LENGTH = 5;
+  private static final int LENGTH_RANDOM_PART = 4;
 
-  private static final String PREFIX = "Q";
+  private static final String PREFIX = "Q2";
 
   public static final char[] ALLOWED_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWX".toCharArray();
 
@@ -46,9 +46,9 @@ public class ProjectCode {
    */
   public static ProjectCode random() {
     var randomCodeGenerator = new RandomCodeGenerator(ALLOWED_LETTERS, ALLOWED_NUMBERS);
-    String code = randomCodeGenerator.next(LENGTH - 1);
+    String code = randomCodeGenerator.next(LENGTH_RANDOM_PART);
     while (isBlackListed(code)) {
-      code = randomCodeGenerator.next(LENGTH - 1);
+      code = randomCodeGenerator.next(LENGTH_RANDOM_PART);
     }
     return new ProjectCode(PREFIX + code);
   }
@@ -81,7 +81,7 @@ public class ProjectCode {
   }
 
   private static boolean isGeneralFormatValid(String code) {
-    return code.startsWith(PREFIX) && (code.length() == LENGTH);
+    return code.startsWith(PREFIX) && (code.length() == LENGTH_RANDOM_PART + PREFIX.length());
   }
 
   private static boolean containsInvalidCharacters(String code) {
@@ -181,7 +181,7 @@ public class ProjectCode {
   }
 
   public static int getLENGTH() {
-    return LENGTH;
+    return LENGTH_RANDOM_PART + PREFIX.length();
   }
 
   public static String getPREFIX() {

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/ProjectCreationServiceSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/ProjectCreationServiceSpec.groovy
@@ -32,7 +32,7 @@ class ProjectCreationServiceSpec extends Specification {
 
 
     Result<Project, ApplicationException> resultWithExperimentalDesign = projectCreationServiceWithStubs.createProject(
-            "source offer", "QABCD",
+            "source offer", "Q2ABCD",
             null,
             "objective",
             personReference,
@@ -50,7 +50,7 @@ class ProjectCreationServiceSpec extends Specification {
     def contact = new Contact("Mustermann", "some@notavailable.zxü")
 
     when: "create is called without a project manager"
-    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "QABCD",
+    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "Q2ABCD",
             "my title",
             "objective",
             contact,
@@ -88,7 +88,7 @@ class ProjectCreationServiceSpec extends Specification {
     def contact = new Contact("Mustermann", "some@notavailable.zxü")
 
     when: "create is called without a project manager"
-    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "QABCD",
+    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "Q2ABCD",
             "my title",
             "objective",
             contact,
@@ -108,7 +108,7 @@ class ProjectCreationServiceSpec extends Specification {
     def contact = new Contact("Mustermann", "some@notavailable.zxü")
 
     when: "a project is created with a non-empty title"
-    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "QABCD",
+    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "Q2ABCD",
             "my title",
             "objective",
             contact,
@@ -126,7 +126,7 @@ class ProjectCreationServiceSpec extends Specification {
     def contact = new Contact("Mustermann", "some@notavailable.zxü")
 
     when:
-    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "QABCD",
+    Result<Project, ApplicationException> result = projectCreationServiceWithStubs.createProject("source offer", "Q2ABCD",
             "my title",
             "objective",
             contact,

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/domain/ProjectCodeSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/domain/ProjectCodeSpec.groovy
@@ -11,16 +11,16 @@ class ProjectCodeSpec extends Specification {
         ProjectCode code2 = ProjectCode.random();
 
         then:
-        code.value().length() == 5
-        code.value().startsWith("Q")
-        code2.value().length() == 5
-        code2.value().startsWith("Q")
+        code.value().length() == 6
+        code.value().startsWith("Q2")
+        code2.value().length() == 6
+        code2.value().startsWith("Q2")
         code != code2
     }
 
     def "Parsing a code with a blacklisted expression throws an IllegalArgumentException"() {
         when:
-        ProjectCode.parse("Q" + blacklistedExpression as String)
+        ProjectCode.parse("Q2" + blacklistedExpression as String)
 
         then:
         thrown(IllegalArgumentException)
@@ -31,7 +31,7 @@ class ProjectCodeSpec extends Specification {
 
     def "Parsing a project code with a valid expression returns its object oriented form"() {
         when:
-        ProjectCode code = ProjectCode.parse("Q" + "ABCD")
+        ProjectCode code = ProjectCode.parse("Q2" + "ABCD")
 
         then:
         code.value().contains("ABCD")
@@ -39,7 +39,7 @@ class ProjectCodeSpec extends Specification {
 
     def "Parsing a project code with a invalid length throws an IllegalArgumentException"() {
         when:
-        ProjectCode.parse("Q" + wrongLength)
+        ProjectCode.parse("Q2" + wrongLength)
 
         then:
         thrown(IllegalArgumentException)
@@ -50,7 +50,7 @@ class ProjectCodeSpec extends Specification {
 
     def "Parsing a project code with a invalid character throws an IllegalArgumentException"() {
         when:
-        ProjectCode.parse("Q" + invalidChar)
+        ProjectCode.parse("Q2" + invalidChar)
 
         then:
         thrown(IllegalArgumentException)

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/ProjectDesignLayout.java
@@ -95,7 +95,7 @@ public class ProjectDesignLayout extends Div implements HasBinderValidation<Proj
     Span projectDesignTitle = new Span(TITLE);
     projectDesignTitle.addClassName("title");
 
-    codeField.setHelperText("Q and 4 letters/numbers");
+    codeField.setHelperText("Q2 and 4 letters/numbers");
     codeField.setValue(ProjectCode.random().value());
     codeField.addClassName("code-field");
     initCodeGenerationButton();


### PR DESCRIPTION
The legacy project codes are of length 5, so the data manager should not create codes that might be confused with legacy codes.

The most simple solution also discussed with project management is to extend the prefix from "Q" to "Q2".