### PR TITLE
Restrict sample origin editing, if origin is used

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/ExperimentDetailsComponent.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -240,7 +241,7 @@ public class ExperimentDetailsComponent extends PageArea {
   }
 
   private Map<SampleOriginType, Set<OntologyTerm>> getOntologyTermsUsedInSamples(ExperimentId experimentId) {
-    Map<SampleOriginType, Set<OntologyTerm>> result = new HashMap<>();
+    Map<SampleOriginType, Set<OntologyTerm>> result = new EnumMap<>(SampleOriginType.class);
     result.put(SPECIES, new HashSet<>());
     result.put(SPECIMEN, new HashSet<>());
     result.put(ANALYTE, new HashSet<>());

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/SampleOriginType.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/SampleOriginType.java
@@ -1,0 +1,6 @@
+package life.qbic.datamanager.views.projects.project.experiments.experiment;
+
+public enum SampleOriginType {
+
+  SPECIES, SPECIMEN, ANALYTE;
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExistingSamplesPreventSampleOriginEdit.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExistingSamplesPreventSampleOriginEdit.java
@@ -2,7 +2,6 @@ package life.qbic.datamanager.views.projects.project.experiments.experiment.comp
 
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import life.qbic.datamanager.views.notifications.NotificationDialog;

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExistingSamplesPreventSampleOriginEdit.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/components/ExistingSamplesPreventSampleOriginEdit.java
@@ -1,0 +1,37 @@
+package life.qbic.datamanager.views.projects.project.experiments.experiment.components;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import life.qbic.datamanager.views.notifications.NotificationDialog;
+
+/**
+ * Notifies the user that samples exist in the experiment and reference the Ontology term the user
+ * wanted to delete
+ * <p>
+ * This dialog is to be shown when editing variables is impossible as samples are
+ * present.
+ */
+public class ExistingSamplesPreventSampleOriginEdit extends NotificationDialog {
+
+  public ExistingSamplesPreventSampleOriginEdit(String ontologyLabel) {
+    addClassName("existing-samples-prevent-variable-edit");
+    customizeHeader();
+    customizeContent(ontologyLabel);
+    setConfirmText("Okay");
+  }
+
+  private void customizeHeader() {
+    Icon errorIcon = new Icon(VaadinIcon.CLOSE_CIRCLE);
+    errorIcon.setClassName("error-icon");
+    setTitle("Cannot remove sample origin");
+    setHeaderIcon(errorIcon);
+  }
+
+  private void customizeContent(String ontologyLabel) {
+    content.add(
+        new Div(new Text("'%s' cannot be deleted, as it is referenced in samples of this experiment.".formatted(ontologyLabel))));
+  }
+}

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/update/EditExperimentDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/update/EditExperimentDialog.java
@@ -81,7 +81,7 @@ public class EditExperimentDialog extends DialogWindow {
               Set<OntologyTerm> missing = new HashSet<>();
               for (OntologyTerm species : usedSampleOrigins.get(SampleOriginType.SPECIES)) {
                 if (!valueChangeEvent.getValue().contains(species)
-                    & valueChangeEvent.isFromClient()) {
+                    && valueChangeEvent.isFromClient()) {
                   missing.add(species);
                   showSamplesPreventOriginEdit(species);
                 }
@@ -110,7 +110,7 @@ public class EditExperimentDialog extends DialogWindow {
               Set<OntologyTerm> missing = new HashSet<>();
               for (OntologyTerm specimen : usedSampleOrigins.get(SampleOriginType.SPECIMEN)) {
                 if (!valueChangeEvent.getValue().contains(specimen)
-                    & valueChangeEvent.isFromClient()) {
+                    && valueChangeEvent.isFromClient()) {
                   missing.add(specimen);
                   showSamplesPreventOriginEdit(specimen);
                 }
@@ -138,7 +138,7 @@ public class EditExperimentDialog extends DialogWindow {
               Set<OntologyTerm> missing = new HashSet<>();
               for (OntologyTerm analyte : usedSampleOrigins.get(SampleOriginType.ANALYTE)) {
                 if (!valueChangeEvent.getValue().contains(analyte)
-                    & valueChangeEvent.isFromClient()) {
+                    && valueChangeEvent.isFromClient()) {
                   missing.add(analyte);
                   showSamplesPreventOriginEdit(analyte);
                 }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/update/EditExperimentDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/update/EditExperimentDialog.java
@@ -75,22 +75,8 @@ public class EditExperimentDialog extends DialogWindow {
         .asRequired("Please select at least one species")
         .bind(experimentDraft -> new HashSet<>(experimentDraft.getSpecies()),
             ExperimentDraft::setSpecies);
-    speciesBox.addValueChangeListener(
-        (ValueChangeListener<ComponentValueChangeEvent<MultiSelectComboBox<OntologyTerm>, Set<OntologyTerm>>>)
-            valueChangeEvent -> {
-              Set<OntologyTerm> missing = new HashSet<>();
-              for (OntologyTerm species : usedSampleOrigins.get(SampleOriginType.SPECIES)) {
-                if (!valueChangeEvent.getValue().contains(species)
-                    && valueChangeEvent.isFromClient()) {
-                  missing.add(species);
-                  showSamplesPreventOriginEdit(species);
-                }
-              }
-              if (!missing.isEmpty()) {
-                missing.addAll(valueChangeEvent.getValue());
-                speciesBox.setValue(missing);
-              }
-            });
+    initOriginEditListener(speciesBox, usedSampleOrigins.get(SampleOriginType.SPECIES));
+
 
     ComboBox<BioIcon> speciesIconBox = bioIconComboboxFactory.iconBox(SampleSourceType.SPECIES,
     "Species icon");
@@ -104,25 +90,10 @@ public class EditExperimentDialog extends DialogWindow {
         .asRequired("Please select at least one specimen")
         .bind(experimentDraft -> new HashSet<>(experimentDraft.getSpecimens()),
             ExperimentDraft::setSpecimens);
-    specimenBox.addValueChangeListener(
-        (ValueChangeListener<ComponentValueChangeEvent<MultiSelectComboBox<OntologyTerm>, Set<OntologyTerm>>>)
-            valueChangeEvent -> {
-              Set<OntologyTerm> missing = new HashSet<>();
-              for (OntologyTerm specimen : usedSampleOrigins.get(SampleOriginType.SPECIMEN)) {
-                if (!valueChangeEvent.getValue().contains(specimen)
-                    && valueChangeEvent.isFromClient()) {
-                  missing.add(specimen);
-                  showSamplesPreventOriginEdit(specimen);
-                }
-              }
-              if (!missing.isEmpty()) {
-                missing.addAll(valueChangeEvent.getValue());
-                specimenBox.setValue(missing);
-              }
-            });
+    initOriginEditListener(specimenBox, usedSampleOrigins.get(SampleOriginType.SPECIMEN));
 
     ComboBox<BioIcon> specimenIconBox = bioIconComboboxFactory.iconBox(SampleSourceType.SPECIMEN,
-    "Specimen icon");
+        "Specimen icon");
     binder.forField(specimenIconBox)
         .bind(ExperimentDraft::getSpecimenIcon,
             ExperimentDraft::setSpecimenIcon);
@@ -132,22 +103,8 @@ public class EditExperimentDialog extends DialogWindow {
         .asRequired("Please select at least one analyte")
         .bind(experimentDraft -> new HashSet<>(experimentDraft.getAnalytes()),
             ExperimentDraft::setAnalytes);
-    analyteBox.addValueChangeListener(
-        (ValueChangeListener<ComponentValueChangeEvent<MultiSelectComboBox<OntologyTerm>, Set<OntologyTerm>>>)
-            valueChangeEvent -> {
-              Set<OntologyTerm> missing = new HashSet<>();
-              for (OntologyTerm analyte : usedSampleOrigins.get(SampleOriginType.ANALYTE)) {
-                if (!valueChangeEvent.getValue().contains(analyte)
-                    && valueChangeEvent.isFromClient()) {
-                  missing.add(analyte);
-                  showSamplesPreventOriginEdit(analyte);
-                }
-              }
-              if (!missing.isEmpty()) {
-                missing.addAll(valueChangeEvent.getValue());
-                analyteBox.setValue(missing);
-              }
-            });
+    initOriginEditListener(analyteBox, usedSampleOrigins.get(SampleOriginType.ANALYTE));
+
 
     addClassName("edit-experiment-dialog");
     setHeaderTitle("Experimental Design");
@@ -169,6 +126,26 @@ public class EditExperimentDialog extends DialogWindow {
         specimenRow,
         analyteBox);
     add(editExperimentContent);
+  }
+
+  private void initOriginEditListener(
+      MultiSelectComboBox<OntologyTerm> originBox, Set<OntologyTerm> ontologyTerms) {
+    ValueChangeListener<ComponentValueChangeEvent<MultiSelectComboBox<OntologyTerm>,
+        Set<OntologyTerm>>> valueChangeListener = valueChangeEvent -> {
+      Set<OntologyTerm> missing = new HashSet<>();
+      for (OntologyTerm term : ontologyTerms) {
+        if (!valueChangeEvent.getValue().contains(term)
+            && valueChangeEvent.isFromClient()) {
+          missing.add(term);
+          showSamplesPreventOriginEdit(term);
+        }
+      }
+      if (!missing.isEmpty()) {
+        missing.addAll(valueChangeEvent.getValue());
+        originBox.setValue(missing);
+      }
+    };
+    originBox.addValueChangeListener(valueChangeListener);
   }
 
   private void showSamplesPreventOriginEdit(OntologyTerm species) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/update/EditExperimentDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/experiment/update/EditExperimentDialog.java
@@ -1,5 +1,9 @@
 package life.qbic.datamanager.views.projects.project.experiments.experiment.update;
 
+import static life.qbic.datamanager.views.projects.project.experiments.experiment.SampleOriginType.ANALYTE;
+import static life.qbic.datamanager.views.projects.project.experiments.experiment.SampleOriginType.SPECIES;
+import static life.qbic.datamanager.views.projects.project.experiments.experiment.SampleOriginType.SPECIMEN;
+
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.ComponentEvent;
@@ -75,7 +79,7 @@ public class EditExperimentDialog extends DialogWindow {
         .asRequired("Please select at least one species")
         .bind(experimentDraft -> new HashSet<>(experimentDraft.getSpecies()),
             ExperimentDraft::setSpecies);
-    initOriginEditListener(speciesBox, usedSampleOrigins.get(SampleOriginType.SPECIES));
+    initOriginEditListener(speciesBox, SPECIES);
 
 
     ComboBox<BioIcon> speciesIconBox = bioIconComboboxFactory.iconBox(SampleSourceType.SPECIES,
@@ -90,7 +94,7 @@ public class EditExperimentDialog extends DialogWindow {
         .asRequired("Please select at least one specimen")
         .bind(experimentDraft -> new HashSet<>(experimentDraft.getSpecimens()),
             ExperimentDraft::setSpecimens);
-    initOriginEditListener(specimenBox, usedSampleOrigins.get(SampleOriginType.SPECIMEN));
+    initOriginEditListener(specimenBox, SPECIMEN);
 
     ComboBox<BioIcon> specimenIconBox = bioIconComboboxFactory.iconBox(SampleSourceType.SPECIMEN,
         "Specimen icon");
@@ -103,7 +107,7 @@ public class EditExperimentDialog extends DialogWindow {
         .asRequired("Please select at least one analyte")
         .bind(experimentDraft -> new HashSet<>(experimentDraft.getAnalytes()),
             ExperimentDraft::setAnalytes);
-    initOriginEditListener(analyteBox, usedSampleOrigins.get(SampleOriginType.ANALYTE));
+    initOriginEditListener(analyteBox, ANALYTE);
 
 
     addClassName("edit-experiment-dialog");
@@ -129,11 +133,11 @@ public class EditExperimentDialog extends DialogWindow {
   }
 
   private void initOriginEditListener(
-      MultiSelectComboBox<OntologyTerm> originBox, Set<OntologyTerm> ontologyTerms) {
+      MultiSelectComboBox<OntologyTerm> originBox, SampleOriginType originType) {
     ValueChangeListener<ComponentValueChangeEvent<MultiSelectComboBox<OntologyTerm>,
         Set<OntologyTerm>>> valueChangeListener = valueChangeEvent -> {
       Set<OntologyTerm> missing = new HashSet<>();
-      for (OntologyTerm term : ontologyTerms) {
+      for (OntologyTerm term : usedSampleOrigins.get(originType)) {
         if (!valueChangeEvent.getValue().contains(term)
             && valueChangeEvent.isFromClient()) {
           missing.add(term);


### PR DESCRIPTION
Tackles #683 


https://github.com/qbicsoftware/data-manager-app/assets/10232219/a40fbfa5-9e07-4a99-864c-7aa870e18087

