### PR TITLE
Fix redundant ontology terms that are actually the same

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/OntologyComboboxFactory.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/create/OntologyComboboxFactory.java
@@ -40,9 +40,8 @@ public class OntologyComboboxFactory {
     return box;
   }
 
-  private FetchCallback<OntologyTerm, String> speciesFetchCallback(
-      List<Ontology> ontologies) {
-    return query -> OntologyFilterConnector.loadOntologyTerms(ontologies, query,
+  private FetchCallback<OntologyTerm, String> speciesFetchCallback() {
+    return query -> OntologyFilterConnector.loadOntologyTerms(query,
         speciesLookupService);
   }
 
@@ -51,10 +50,9 @@ public class OntologyComboboxFactory {
   }
 
   public MultiSelectComboBox<OntologyTerm> speciesBox() {
-    List<Ontology> speciesOntologies = List.of(Ontology.NCBI_TAXONOMY);
 
     MultiSelectComboBox<OntologyTerm> box = newBox();
-    box.setItems(speciesFetchCallback(speciesOntologies));
+    box.setItems(speciesFetchCallback());
 
     box.setPlaceholder("Search and select one or more species for your samples");
     box.setLabel("Species");

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/OntologyFilterConnector.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/experiments/OntologyFilterConnector.java
@@ -24,15 +24,12 @@ public class OntologyFilterConnector {
   public static Stream<OntologyTerm> loadOntologyTerms(Query<OntologyTerm, String> query,
       TerminologyService terminologyService) {
     return terminologyService.query(query.getFilter().orElse(""), query.getOffset(),
-        query.getLimit()).stream();
+        query.getLimit()).stream().distinct();
   }
 
-  public static Stream<OntologyTerm> loadOntologyTerms(List<Ontology> ontologies,
+  public static Stream<OntologyTerm> loadOntologyTerms(
       Query<OntologyTerm, String> query,
       SpeciesLookupService ontologyTermInformationService) {
-    List<String> ontologyAbbreviations = ontologies.stream()
-        .map(Ontology::getAbbreviation)
-        .toList();
     List<SortOrder> sortOrders = query.getSortOrders().stream()
         .map(querySortOrder -> new SortOrder(querySortOrder.getSorted(),
             querySortOrder.getDirection().equals(SortDirection.DESCENDING)))


### PR DESCRIPTION
Due to the improvement of the OntologyTerm comparison by considering equal terms when they have the same IRI, the combobox showed empty rows for a term that was referenced in more than two ontologies.

This contribution filters them out.

Also, an unused ontology term list is removed. The NCBI Taxon filtering happens in the SpeciesSearchService and should also not be knowledgable by the client.