### PR TITLE
Show helper box only in the header cells of all sample and measurement excel templates

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/NGSMeasurementEditTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/NGSMeasurementEditTemplate.java
@@ -189,18 +189,6 @@ public class NGSMeasurementEditTemplate implements DownloadContentProvider {
           DEFAULT_GENERATED_ROW_COUNT - 1,
           sequencingReadTypeArea);
 
-      for (NGSMeasurementEditColumn column : NGSMeasurementEditColumn.values()) {
-        column.getFillHelp().ifPresent(
-            helper -> XLSXTemplateHelper.addInputHelper(sheet,
-                column.columnIndex(),
-                startIndex,
-                column.columnIndex(),
-                DEFAULT_GENERATED_ROW_COUNT - 1,
-                helper.exampleValue(),
-                helper.description())
-        );
-      }
-
       setAutoWidth(sheet);
       workbook.setActiveSheet(0);
 

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/NGSMeasurementRegisterTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/NGSMeasurementRegisterTemplate.java
@@ -122,17 +122,6 @@ public class NGSMeasurementRegisterTemplate extends Template implements Download
           DEFAULT_GENERATED_ROW_COUNT - 1,
           sequencingReadTypeArea);
 
-      for (NGSMeasurementRegisterColumn column : NGSMeasurementRegisterColumn.values()) {
-        column.getFillHelp().ifPresent(
-            helper -> XLSXTemplateHelper.addInputHelper(sheet,
-                column.columnIndex(),
-                startIndex,
-                column.columnIndex(),
-                DEFAULT_GENERATED_ROW_COUNT - 1,
-                helper.exampleValue(),
-                helper.description()));
-      }
-
       // add property information order of columns matters!!
       for (NGSMeasurementRegisterColumn column : Arrays.stream(
               NGSMeasurementRegisterColumn.values())

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementEditTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementEditTemplate.java
@@ -111,7 +111,7 @@ public class ProteomicsMeasurementEditTemplate implements DownloadContentProvide
     }
 
     try (Workbook workbook = new XSSFWorkbook();
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();) {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
 
       CellStyle readOnlyHeaderStyle = XLSXTemplateHelper.createReadOnlyHeaderCellStyle(workbook);
       CellStyle boldStyle = createBoldCellStyle(workbook);

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementEditTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementEditTemplate.java
@@ -193,18 +193,6 @@ public class ProteomicsMeasurementEditTemplate implements DownloadContentProvide
           DEFAULT_GENERATED_ROW_COUNT - 1,
           digestionMethodArea);
 
-      for (ProteomicsMeasurementEditColumn column : ProteomicsMeasurementEditColumn.values()) {
-        column.getFillHelp().ifPresent(
-            helper -> XLSXTemplateHelper.addInputHelper(sheet,
-                column.columnIndex(),
-                startIndex,
-                column.columnIndex(),
-                DEFAULT_GENERATED_ROW_COUNT - 1,
-                helper.exampleValue(),
-                helper.description())
-        );
-      }
-
       setAutoWidth(sheet);
       workbook.setActiveSheet(0);
 

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementRegisterTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementRegisterTemplate.java
@@ -135,18 +135,6 @@ public class ProteomicsMeasurementRegisterTemplate extends Template {
           DEFAULT_GENERATED_ROW_COUNT - 1,
           digestionMethodArea);
 
-      for (ProteomicsMeasurementRegisterColumn column : ProteomicsMeasurementRegisterColumn.values()) {
-        column.getFillHelp().ifPresent(
-            helper -> XLSXTemplateHelper.addInputHelper(sheet,
-                column.columnIndex(),
-                startIndex,
-                column.columnIndex(),
-                DEFAULT_GENERATED_ROW_COUNT - 1,
-                helper.exampleValue(),
-                helper.description())
-        );
-      }
-
       setAutoWidth(sheet);
 
       workbook.setActiveSheet(0);

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementRegisterTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/measurement/ProteomicsMeasurementRegisterTemplate.java
@@ -62,7 +62,7 @@ public class ProteomicsMeasurementRegisterTemplate extends Template {
   @Override
   public byte[] getContent() {
     try (Workbook workbook = new XSSFWorkbook();
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();) {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
 
       CellStyle readOnlyHeaderStyle = XLSXTemplateHelper.createReadOnlyHeaderCellStyle(workbook);
       CellStyle boldStyle = createBoldCellStyle(workbook);

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/sample/SampleBatchRegistrationTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/sample/SampleBatchRegistrationTemplate.java
@@ -159,18 +159,6 @@ public class SampleBatchRegistrationTemplate {
         MAX_ROW_INDEX_TO,
         specimenOptions);
 
-    for (var column : RegisterColumn.values()) {
-      column.getFillHelp().ifPresent(
-          helper -> XLSXTemplateHelper.addInputHelper(sheet,
-              column.columnIndex(),
-              startIndex,
-              column.columnIndex(),
-              MAX_ROW_INDEX_TO,
-              helper.exampleValue(),
-              helper.description())
-      );
-    }
-
     setColumnAutoWidth(sheet, 0, RegisterColumn.maxColumnIndex());
     // Auto width ignores cell validation values (e.g. a list of valid entries). So we need
     // to set them explicit

--- a/user-interface/src/main/java/life/qbic/datamanager/templates/sample/SampleBatchUpdateTemplate.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/templates/sample/SampleBatchUpdateTemplate.java
@@ -155,18 +155,6 @@ public class SampleBatchUpdateTemplate {
         MAX_ROW_INDEX_TO,
         specimenOptions);
 
-    for (var column : EditColumn.values()) {
-      column.getFillHelp().ifPresent(
-          helper -> XLSXTemplateHelper.addInputHelper(sheet,
-              column.columnIndex(),
-              startIndex,
-              column.columnIndex(),
-              MAX_ROW_INDEX_TO,
-              helper.exampleValue(),
-              helper.description())
-      );
-    }
-
     setColumnAutoWidth(sheet, 0, EditColumn.maxColumnIndex());
     workbook.setActiveSheet(0);
     lockSheet(hiddenSheet);


### PR DESCRIPTION
Same Content as PR #976 but reopened from Main to apply it as a hotfix

**What was changed**

Addresses #975, by restraining the helper box only to the header of the templates. This is done so users can easily drag and drop the values within the cells. 

**Open Questions**

1.) Should there be a highlight that there is a helper box hidden within the helper cell?
2.) There are header cells with links, which direct the user to their respective homepage (Organization to RoR Homepage, Instrument to Ontology). Is this an issue if the user is solely interested in the helper box content? 