### PR TITLE
Batch update must be idempotent with respect to sample ids

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/batch/Batch.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/batch/Batch.java
@@ -90,8 +90,15 @@ public class Batch {
   }
 
   public void addSample(SampleId sampleId) {
-    this.sampleIds.add(sampleId);
+    addSampleIfNotExists(sampleId);
     this.lastModified = Instant.now();
+  }
+
+  private void addSampleIfNotExists(SampleId sampleId) {
+    if (sampleIds.contains(sampleId)) {
+      return;
+    }
+    sampleIds.add(sampleId);
   }
 
   public void removeSample(SampleId sampleToRemove) {


### PR DESCRIPTION
Ensures that sample IDs already referenced in the sample batch are not added again, which led to duplicates.