### PR TITLE
Provide one button app dialog

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/demo/ComponentDemo.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/demo/ComponentDemo.java
@@ -220,6 +220,39 @@ public class ComponentDemo extends Div {
     return steps;
   }
 
+  private static Div dialogWithOneButton(AppDialog dialog, String dialogType) {
+    Div content = new Div();
+    Button showDialog = new Button("Show Dialog");
+    // Dialog set-up
+    DialogHeader.withIcon(dialog, dialogType, IconFactory.warningIcon());
+    DialogFooter.withConfirmOnly(dialog, "Close");
+    ExampleUserInput userInput = new ExampleUserInput("Expelliarmus");
+    DialogBody.with(dialog, userInput, userInput);
+
+    Div confirmBox = new Div("Click the button and press 'Cancel' or 'Save'");
+    showDialog.addClickListener(e -> {
+      dialog.open();
+      confirmBox.setText("Cancelled the dialog.");
+    });
+
+    dialog.registerCancelAction(() -> {
+      dialog.close();
+      if (dialog.hasChanges()) {
+        confirmBox.setText("Cancelled the dialog although there where changes made!");
+      } else {
+        confirmBox.setText("Cancelled the dialog. No changes.");
+      }
+    });
+    dialog.registerConfirmAction(() -> {
+      dialog.close();
+      confirmBox.setText("Confirmed the dialog.");
+    });
+
+    content.add(showDialog, confirmBox);
+    content.addClassNames(FLEX_VERTICAL, GAP_04);
+    return content;
+  }
+
   private static Div dialogShowCase(AppDialog dialog, String dialogType) {
     Div content = new Div();
     Button showDialog = new Button("Show Dialog");
@@ -368,6 +401,8 @@ public class ComponentDemo extends Div {
     container.add(dialogSectionShowCase());
     container.add(createHeading3("Three steps example"));
     container.add(stepperDialogShowCase(threeSteps(), "Three steps example"));
+    container.add(createHeading3("Dialog with one button"));
+    container.add(dialogWithOneButton(AppDialog.small(), "Dialog with one button"));
 
     return container;
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/dialog/DialogFooter.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/dialog/DialogFooter.java
@@ -19,19 +19,39 @@ public class DialogFooter extends Div {
     addClassNames("flex-horizontal", "gap-04", "footer");
     var buttonFactory = new ButtonFactory();
     var confirmButton = buttonFactory.createConfirmButton(confirmText);
-    var cancelButton = buttonFactory.createCancelButton(abortText);
-    add(cancelButton, confirmButton);
+    if (abortText != null) {
+      var cancelButton = buttonFactory.createCancelButton(abortText);
+      add(cancelButton, confirmButton);
+      cancelButton.addClickListener(e -> dialog.cancel());
+    } else {
+      add(confirmButton);
+    }
     dialog.setFooter(this);
     confirmButton.addClickListener(e -> dialog.confirm());
-    cancelButton.addClickListener(e -> dialog.cancel());
+  }
+
+  private DialogFooter() {
+    dialog = null;
   }
 
   public static DialogFooter with(AppDialog dialog, String abortText, String confirmText) {
     return new DialogFooter(dialog, abortText, confirmText);
   }
 
-  private DialogFooter() {
-    dialog = null;
+  /**
+   * Creates a footer with only one button, a confirm button that also triggers the
+   * {@link AppDialog#confirm()} action when clicked.
+   * <p>
+   * This footer can be used for dialogs that are for display purposes only and do not have any user
+   * input fields.
+   *
+   * @param dialog      the dialog to bind to
+   * @param confirmText the button text to display for the confirmation
+   * @return A dialog footer bound to the provided dialog with only one button
+   * @since 1.9.0
+   */
+  public static DialogFooter withConfirmOnly(AppDialog dialog, String confirmText) {
+    return new DialogFooter(dialog, null, confirmText);
   }
 
   public AppDialog getDialog() {


### PR DESCRIPTION
You can now call build a `DialogFooter` with only a confirm button:

```java
DialogFooter.withConfirmOnly(AppDialog dialog, String confirmText)
```
This will show only one button (the primary button, that executes the confirm action).

