### PR TITLE
Increase number of default generated rows within measurement excel sheets

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/NgsEditFactory.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/NgsEditFactory.java
@@ -19,7 +19,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 
 public class NgsEditFactory implements WorkbookFactory {
 
-  private static final int DEFAULT_GENERATED_ROW_COUNT = 200;
+  private static final int DEFAULT_GENERATED_ROW_COUNT = 2000;
   private final List<NGSMeasurementEntry> measurements;
 
   public NgsEditFactory(List<NGSMeasurementEntry> measurements) {

--- a/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/NgsRegisterFactory.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/NgsRegisterFactory.java
@@ -12,7 +12,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 
 public class NgsRegisterFactory implements WorkbookFactory {
 
-  private static final int DEFAULT_GENERATED_ROW_COUNT = 200;
+  private static final int DEFAULT_GENERATED_ROW_COUNT = 2000;
 
   @Override
   public Column[] getColumns() {

--- a/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/ProteomicsEditFactory.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/ProteomicsEditFactory.java
@@ -18,7 +18,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 
 public class ProteomicsEditFactory implements WorkbookFactory {
 
-  private static final int DEFAULT_GENERATED_ROW_COUNT = 200;
+  private static final int DEFAULT_GENERATED_ROW_COUNT = 2000;
   private final List<ProteomicsMeasurementEntry> measurements;
 
   public ProteomicsEditFactory(List<ProteomicsMeasurementEntry> measurements) {

--- a/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/ProteomicsRegisterFactory.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/files/export/measurement/ProteomicsRegisterFactory.java
@@ -12,7 +12,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 
 public class ProteomicsRegisterFactory implements WorkbookFactory {
 
-  private static final int DEFAULT_GENERATED_ROW_COUNT = 200;
+  private static final int DEFAULT_GENERATED_ROW_COUNT = 2000;
 
   @Override
   public int numberOfRowsToGenerate() {


### PR DESCRIPTION
Set the default generated row count to 2000 to avoid skipping of measurements if more than 200 measurements are registered