### PR TITLE
Fix Link within documentation for data download

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataDownloadInformationComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataDownloadInformationComponent.java
@@ -77,7 +77,7 @@ public class RawDataDownloadInformationComponent extends PageArea implements Ser
 
   private Span generateAdditionalInformationSection() {
     Anchor downloadGuideLink = new Anchor(
-        "https://qbicsoftware.github.io/research-data-management/rawdata/raw_data_download/#download-raw-data",
+        "https://qbicsoftware.github.io/research-data-management/latest/rawdata/raw_data_download/#download-raw-data",
         "here", AnchorTarget.BLANK);
     Text additionalInformationText = new Text("Learn more about how to download the datasets ");
     return new Span(additionalInformationText, downloadGuideLink);


### PR DESCRIPTION
The data download section link is currently broken since it does not account for different version documentation in its URL