### PR TITLE
Prevent flickering of announcements

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/announcements/AnnouncementComponent.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/announcements/AnnouncementComponent.java
@@ -31,6 +31,7 @@ public class AnnouncementComponent extends Div {
   public AnnouncementComponent(AnnouncementService announcementService) {
     this.announcementService = announcementService;
     this.setId("announcements");
+    this.setVisible(false); //without subscribing to announcements nothing is displayed
   }
 
   private void subscribeToAnnouncements() {


### PR DESCRIPTION
On initial loading, the empty announcements component is shown as styled in the css. This is fixed by initially hiding the component until announcements are shown.