### PR TITLE
Deactivate search functionality in the measurements view

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementLookupImplementation.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementLookupImplementation.java
@@ -70,9 +70,8 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
       }
       return order;
     }).toList();
-    Specification<ProteomicsMeasurement> filterSpecification = generateProteomicsFilterSpecification(
-        sampleIds, filter);
-    return pxpMeasurementJpaRepo.findAll(filterSpecification,
+    //FIXME ignores the filter
+    return pxpMeasurementJpaRepo.findAll(ProteomicsMeasurementSpec.containsSampleId(sampleIds),
         new OffsetBasedRequest(offset, limit, Sort.by(orders))).getContent();
   }
 
@@ -156,9 +155,8 @@ public class MeasurementLookupImplementation implements MeasurementLookup {
       }
       return order;
     }).toList();
-    Specification<NGSMeasurement> filterSpecification = generateNGSFilterSpecification(
-        sampleIds, filter);
-    return ngsMeasurementJpaRepo.findAll(filterSpecification,
+    //FIXME ignores the filter
+    return ngsMeasurementJpaRepo.findAll(NgsMeasurementSpec.containsSampleId(sampleIds),
         new OffsetBasedRequest(offset, limit, Sort.by(orders))).getContent();
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -209,7 +209,8 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
 
     Span buttonBar = new Span(downloadButton, editButton, deleteButton, registerMeasurementButton);
     buttonBar.addClassName("button-bar");
-    Span buttonsAndSearch = new Span(measurementSearchField, buttonBar);
+    // measurementSearchField disabled as the search functionality is turned off due to efficiency reasons
+    Span buttonsAndSearch = new Span(/*measurementSearchField,*/ buttonBar);
     buttonsAndSearch.addClassName("buttonAndField");
     measurementsSelectedInfoBox.addClassName("info");
     setSelectedMeasurementsInfo(0);


### PR DESCRIPTION
Pooled measurements with large sample numbers (100+) lead to a non-responsive view and breakage of the frontend. This PR simplifies the database queries by disabling user filtering on each property of a measurement.