### PR TITLE
Fix ontology term parsing

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/TIBTerminologyServiceIntegration.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/ontology/TIBTerminologyServiceIntegration.java
@@ -85,7 +85,7 @@ public class TIBTerminologyServiceIntegration implements TerminologySelect {
    * @since 1.4.0
    */
   private static OntologyClass convert(TibTerm term) {
-    return new OntologyClass(term.ontologyPrefix, "", "", term.label, term.shortForm,
+    return new OntologyClass(term.ontologyName, "", "", term.label, term.shortForm,
         term.getDescription().orElse(""), term.iri);
   }
 


### PR DESCRIPTION
The API object from the terminology service contains an ontology name and an ontology prefix. Previously we used the ontology prefix which can be null but assumed we have the ontology name.