### PR TITLE
Enable measurement registration NGS with the new dialog and service

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
@@ -1199,6 +1199,24 @@ public interface AsyncProjectService {
    */
   Mono<ExperimentalGroupUpdateResponse> update(ExperimentalGroupUpdateRequest request);
 
+
+  record MeasurementCreationRequestNGS(String projectId,
+                                       MeasurementRegistrationInformationNGS measurement,
+                                       String requestId) implements CacheableRequest {
+
+    public MeasurementCreationRequestNGS {
+      requireNonNull(projectId);
+      requireNonNull(measurement);
+      requireNonNull(requestId);
+    }
+
+    public MeasurementCreationRequestNGS(String projectId,
+        MeasurementRegistrationInformationNGS measurement) {
+      this(projectId, measurement, UUID.randomUUID().toString());
+    }
+
+  }
+
   /**
    * Submits an experimental group deletion request and returns a reactive
    * {@link Mono<ExperimentalGroupDeletionResponse>}.
@@ -1218,6 +1236,36 @@ public interface AsyncProjectService {
    */
   Mono<ExperimentalGroupDeletionResponse> delete(ExperimentalGroupDeletionRequest request);
   //</editor-fold>
+
+
+  record MeasurementCreationResponseNGS(String requestId,
+                                        MeasurementRegistrationInformationNGS measurement) {
+
+    public MeasurementCreationResponseNGS {
+      requireNonNull(requestId);
+      requireNonNull(measurement);
+    }
+  }
+
+  /**
+   * Submits a measurement registration request for NGS and returns a reactive
+   * {@link Flux<MeasurementRegistrationInformationNGS>} with the measurement information as
+   * {@link MeasurementRegistrationInformationNGS}.
+   *
+   * <p>
+   * <b>Exceptions</b>
+   * <p>
+   * Exceptions are wrapped as {@link Flux#error(Throwable)} and are one of the types described in
+   * the throw section below.
+   *
+   * @param requestStream the request with the measurement information as
+   *                {@link MeasurementRegistrationInformationNGS}.
+   * @return a {@link Flux<MeasurementRegistrationInformationNGS>} with the measurement information
+   * as {@link MeasurementRegistrationInformationNGS}.
+   * @since 1.11.0
+   */
+  Flux<MeasurementCreationResponseNGS> create(Flux<MeasurementCreationRequestNGS> requestStream);
+
 
   /**
    * Returns a reactive stream of a zipped RO-Crate encoded in UTF-8.
@@ -1483,6 +1531,7 @@ public interface AsyncProjectService {
   Mono<DigitalObject> sampleInformationTemplate(String projectId, String experimentId,
       MimeType mimeType);
 
+
   sealed interface ExperimentUpdateRequestBody permits ConfoundingVariableAdditions,
       ConfoundingVariableDeletions, ConfoundingVariableUpdates, ExperimentDescription {
 
@@ -1521,8 +1570,8 @@ public interface AsyncProjectService {
       ExperimentUpdateRequest, ExperimentalGroupCreationRequest, ExperimentalGroupDeletionRequest,
       ExperimentalGroupUpdateRequest, ExperimentalVariablesDeletionRequest,
       ExperimentalVariablesUpdateRequest, FundingInformationCreationRequest,
-      ProjectResponsibleCreationRequest, ProjectResponsibleDeletionRequest, ProjectUpdateRequest,
-      ValidationRequest {
+      MeasurementCreationRequestNGS, ProjectResponsibleCreationRequest,
+      ProjectResponsibleDeletionRequest, ProjectUpdateRequest, ValidationRequest {
 
     /**
      * Returns an ID that is unique to the request.
@@ -1796,9 +1845,9 @@ public interface AsyncProjectService {
    * @param sequencingRunProtocol the sequencing run protocol
    * @param samplePoolGroup       the name of the sample pool
    * @param specificMetadata      specific metadata that differentiates pooled samples as a
-   *                              {@link Map}, with the sample ids as keys and the
-   *                              sample-specific measurement annotations as values. Will have only one
-   *                              entry if no pooling was done. {@link MeasurementSpecificNGS}
+   *                              {@link Map}, with the sample ids as keys and the sample-specific
+   *                              measurement annotations as values. Will have only one entry if no
+   *                              pooling was done. {@link MeasurementSpecificNGS}
    * @since 1.10.0
    */
   record MeasurementRegistrationInformationNGS(
@@ -1820,6 +1869,8 @@ public interface AsyncProjectService {
       requireNonNull(specificMetadata);
       specificMetadata = new HashMap<>(specificMetadata);
     }
+
+
 
     /**
      * Returns the {@link List} of sample identifiers this measurement refers to.
@@ -1847,9 +1898,9 @@ public interface AsyncProjectService {
    * @param sequencingRunProtocol the sequencing run protocol
    * @param samplePoolGroup       the name of the sample pool
    * @param specificMetadata      specific metadata that differentiates pooled samples as a
-   *                              {@link Map}, with the sample ids as keys and the
-   *                              sample-specific measurement annotations as values. Will have only one
-   *                              entry if no pooling was done. {@link MeasurementSpecificNGS}
+   *                              {@link Map}, with the sample ids as keys and the sample-specific
+   *                              measurement annotations as values. Will have only one entry if no
+   *                              pooling was done. {@link MeasurementSpecificNGS}
    * @since 1.10.0
    */
   record MeasurementUpdateInformationNGS(
@@ -1921,9 +1972,9 @@ public interface AsyncProjectService {
    * @param lcmsMethod             the method used
    * @param labelingType           the type of the labeling used
    * @param specificMetadata       specific metadata that differentiates pooled samples as a
-   *                               {@link Map}, with the sample ids as keys and the
-   *                               sample-specific measurement annotations as values. Will have only one
-   *                               entry if no pooling was done. {@link MeasurementSpecificPxP}
+   *                               {@link Map}, with the sample ids as keys and the sample-specific
+   *                               measurement annotations as values. Will have only one entry if no
+   *                               pooling was done. {@link MeasurementSpecificPxP}
    * @since 1.10.0
    */
   record MeasurementRegistrationInformationPxP(
@@ -1972,9 +2023,9 @@ public interface AsyncProjectService {
    * @param lcmsMethod             the method used
    * @param labelingType           the type of the labeling used
    * @param specificMetadata       specific metadata that differentiates pooled samples as a
-   *                               {@link Map}, with the sample ids as keys and the
-   *                               sample-specific measurement annotations as values. Will have only one
-   *                               entry if no pooling was done. {@link MeasurementSpecificPxP}
+   *                               {@link Map}, with the sample ids as keys and the sample-specific
+   *                               measurement annotations as values. Will have only one entry if no
+   *                               pooling was done. {@link MeasurementSpecificPxP}
    * @since 1.10.0
    */
   record MeasurementUpdateInformationPxP(

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
@@ -1200,17 +1200,17 @@ public interface AsyncProjectService {
   Mono<ExperimentalGroupUpdateResponse> update(ExperimentalGroupUpdateRequest request);
 
 
-  record MeasurementCreationRequestNGS(String projectId,
-                                       MeasurementRegistrationInformationNGS measurement,
-                                       String requestId) implements CacheableRequest {
+  record MeasurementRegistrationRequest(String projectId,
+                                        MeasurementRegistrationRequestBody measurement,
+                                        String requestId) implements CacheableRequest {
 
-    public MeasurementCreationRequestNGS {
+    public MeasurementRegistrationRequest {
       requireNonNull(projectId);
       requireNonNull(measurement);
       requireNonNull(requestId);
     }
 
-    public MeasurementCreationRequestNGS(String projectId,
+    public MeasurementRegistrationRequest(String projectId,
         MeasurementRegistrationInformationNGS measurement) {
       this(projectId, measurement, UUID.randomUUID().toString());
     }
@@ -1238,10 +1238,10 @@ public interface AsyncProjectService {
   //</editor-fold>
 
 
-  record MeasurementCreationResponseNGS(String requestId,
-                                        MeasurementRegistrationInformationNGS measurement) {
+  record MeasurementRegistrationResponse(String requestId,
+                                         MeasurementRegistrationRequestBody measurement) {
 
-    public MeasurementCreationResponseNGS {
+    public MeasurementRegistrationResponse {
       requireNonNull(requestId);
       requireNonNull(measurement);
     }
@@ -1259,12 +1259,12 @@ public interface AsyncProjectService {
    * the throw section below.
    *
    * @param requestStream the request with the measurement information as
-   *                {@link MeasurementRegistrationInformationNGS}.
+   *                      {@link MeasurementRegistrationInformationNGS}.
    * @return a {@link Flux<MeasurementRegistrationInformationNGS>} with the measurement information
    * as {@link MeasurementRegistrationInformationNGS}.
    * @since 1.11.0
    */
-  Flux<MeasurementCreationResponseNGS> create(Flux<MeasurementCreationRequestNGS> requestStream);
+  Flux<MeasurementRegistrationResponse> create(Flux<MeasurementRegistrationRequest> requestStream);
 
 
   /**
@@ -1570,7 +1570,7 @@ public interface AsyncProjectService {
       ExperimentUpdateRequest, ExperimentalGroupCreationRequest, ExperimentalGroupDeletionRequest,
       ExperimentalGroupUpdateRequest, ExperimentalVariablesDeletionRequest,
       ExperimentalVariablesUpdateRequest, FundingInformationCreationRequest,
-      MeasurementCreationRequestNGS, ProjectResponsibleCreationRequest,
+      MeasurementRegistrationRequest, ProjectResponsibleCreationRequest,
       ProjectResponsibleDeletionRequest, ProjectUpdateRequest, ValidationRequest {
 
     /**
@@ -1833,6 +1833,17 @@ public interface AsyncProjectService {
   }
 
   /**
+   * Type interface for the registration information of measurements
+   *
+   * @since 1.11.0
+   */
+  sealed interface MeasurementRegistrationRequestBody permits MeasurementRegistrationInformationNGS,
+      MeasurementRegistrationInformationPxP {
+
+  }
+
+
+  /**
    * Information container to register an NGS measurement.
    *
    * @param organisationId        the ROR ID of the organization that performed the measurement
@@ -1855,7 +1866,7 @@ public interface AsyncProjectService {
       String sequencingReadType, String libraryKit, String flowCell,
       String sequencingRunProtocol, String samplePoolGroup,
       Map<String, MeasurementSpecificNGS> specificMetadata
-  ) implements ValidationRequestBody {
+  ) implements ValidationRequestBody, MeasurementRegistrationRequestBody {
 
     public MeasurementRegistrationInformationNGS {
       requireNonNull(organisationId);
@@ -1869,7 +1880,6 @@ public interface AsyncProjectService {
       requireNonNull(specificMetadata);
       specificMetadata = new HashMap<>(specificMetadata);
     }
-
 
 
     /**
@@ -1991,7 +2001,7 @@ public interface AsyncProjectService {
       String lcmsMethod,
       String labelingType,
       Map<String, MeasurementSpecificPxP> specificMetadata
-  ) implements ValidationRequestBody {
+  ) implements ValidationRequestBody, MeasurementRegistrationRequestBody {
 
     /**
      * Returns the {@link List} of sample identifiers this measurement refers to.

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
@@ -30,6 +30,7 @@ import life.qbic.projectmanagement.application.api.fair.ResearchProject;
 import life.qbic.projectmanagement.application.api.template.TemplateService;
 import life.qbic.projectmanagement.application.authorization.ReactiveSecurityContextUtils;
 import life.qbic.projectmanagement.application.experiment.ExperimentInformationService;
+import life.qbic.projectmanagement.application.measurement.MeasurementService;
 import life.qbic.projectmanagement.application.measurement.validation.MeasurementValidationService;
 import life.qbic.projectmanagement.application.ontology.OntologyClass;
 import life.qbic.projectmanagement.application.ontology.SpeciesLookupService;
@@ -81,6 +82,7 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
   private final ExperimentInformationService experimentInformationService;
   private final TerminologyService terminologyService;
   private final SpeciesLookupService taxaService;
+  private final MeasurementService measurementService;
 
   public AsyncProjectServiceImpl(
       @Autowired ProjectInformationService projectService,
@@ -92,7 +94,8 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
       @Autowired MeasurementValidationService measurementValidationService,
       @Autowired ExperimentInformationService experimentInformationService,
       @Autowired TerminologyService termService,
-      @Autowired SpeciesLookupService taxaService) {
+      @Autowired SpeciesLookupService taxaService,
+      MeasurementService measurementService) {
     this.projectService = Objects.requireNonNull(projectService);
     this.sampleInfoService = Objects.requireNonNull(sampleInfoService);
     this.scheduler = Objects.requireNonNull(scheduler);
@@ -103,6 +106,7 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     this.experimentInformationService = Objects.requireNonNull(experimentInformationService);
     this.terminologyService = Objects.requireNonNull(termService);
     this.taxaService = Objects.requireNonNull(taxaService);
+    this.measurementService = measurementService;
   }
 
   private static Retry defaultRetryStrategy() {
@@ -196,7 +200,8 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
   }
 
   private ExperimentInformationService.ExperimentalGroup convertFromAPI(ExperimentalGroup group) {
-    return new ExperimentInformationService.ExperimentalGroup(group.id(), group.groupId(), group.name(),
+    return new ExperimentInformationService.ExperimentalGroup(group.id(), group.groupId(),
+        group.name(),
         group.levels().stream().map(AsyncProjectServiceImpl::convertFromApi).toList(),
         group.sampleSize());
   }
@@ -204,15 +209,18 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
   @Override
   public Mono<ExperimentalGroupDeletionResponse> delete(ExperimentalGroupDeletionRequest request) {
     var call = Mono.fromCallable(() -> {
-      if (sampleInfoService.hasSamples(ProjectId.parse(request.projectId()), request.experimentId())) {
+      if (sampleInfoService.hasSamples(ProjectId.parse(request.projectId()),
+          request.experimentId())) {
         throw new RequestFailedException(
             "Cannot delete experimental group, samples are registered for experiment "
                 + request.experimentId());
       }
-      experimentInformationService.deleteExperimentalGroupByGroupNumber(request.projectId(), request.experimentId(),
+      experimentInformationService.deleteExperimentalGroupByGroupNumber(request.projectId(),
+          request.experimentId(),
           request.experimentalGroupNumber());
 
-      return new ExperimentalGroupDeletionResponse(request.experimentId(), request.experimentalGroupNumber(),
+      return new ExperimentalGroupDeletionResponse(request.experimentId(),
+          request.experimentalGroupNumber(),
           request.requestId());
     });
     return applySecurityContext(call)
@@ -224,11 +232,32 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
   }
 
   @Override
+  public Flux<MeasurementCreationResponseNGS> create(
+      Flux<MeasurementCreationRequestNGS> requestStream) {
+    return requestStream.flatMap(this::registerMeasurementNGS);
+  }
+
+  private Mono<MeasurementCreationResponseNGS> registerMeasurementNGS(
+      MeasurementCreationRequestNGS measurement) {
+    return applySecurityContext(Mono.fromCallable(() -> {
+          measurementService.registerMeasurementNGS(ProjectId.parse(measurement.projectId()),
+              measurement.measurement());
+          return new MeasurementCreationResponseNGS(measurement.requestId(), measurement.measurement());
+        }
+    ))
+        .subscribeOn(VirtualThreadScheduler.getScheduler())
+        .contextWrite(reactiveSecurity(SecurityContextHolder.getContext()))
+        .retryWhen(defaultRetryStrategy())
+        .doOnError(e -> log.error("Error registering measurement", e))
+        .onErrorMap(AsyncProjectServiceImpl::mapToAPIException);
+  }
+
+  @Override
   public Flux<ExperimentalGroup> getExperimentalGroups(String projectId, String experimentId) {
     var call = Flux.fromStream(() ->
-      experimentInformationService.fetchGroups(projectId, ExperimentId.parse(experimentId))
-          .stream()
-          .map(AsyncProjectServiceImpl::convertToApi));
+        experimentInformationService.fetchGroups(projectId, ExperimentId.parse(experimentId))
+            .stream()
+            .map(AsyncProjectServiceImpl::convertToApi));
     return applySecurityContextMany(call)
         .subscribeOn(VirtualThreadScheduler.getScheduler())
         .contextWrite(reactiveSecurity(SecurityContextHolder.getContext()))
@@ -237,9 +266,12 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
         .onErrorMap(AsyncProjectServiceImpl::mapToAPIException);
   }
 
-  private static ExperimentalGroup convertToApi(ExperimentInformationService.ExperimentalGroup group) {
-    return new ExperimentalGroup(group.id(), group.groupNumber(), group.name(), group.replicateCount(),
-        group.levels().stream().map(AsyncProjectServiceImpl::convertToApi).collect(Collectors.toSet()));
+  private static ExperimentalGroup convertToApi(
+      ExperimentInformationService.ExperimentalGroup group) {
+    return new ExperimentalGroup(group.id(), group.groupNumber(), group.name(),
+        group.replicateCount(),
+        group.levels().stream().map(AsyncProjectServiceImpl::convertToApi)
+            .collect(Collectors.toSet()));
   }
 
   private static VariableLevel convertToApi(ExperimentInformationService.VariableLevel level) {
@@ -546,10 +578,12 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     return switch (request.requestBody()) {
       // Sample Registration
       case SampleRegistrationInformation req ->
-          validateSampleMetadata(req, request.requestId(), request.projectId(), request.experimentId());
+          validateSampleMetadata(req, request.requestId(), request.projectId(),
+              request.experimentId());
       // Sample Update
       case SampleUpdateInformation req ->
-          validateSampleMetadataUpdate(req, request.requestId(), request.projectId(), request.experimentId());
+          validateSampleMetadataUpdate(req, request.requestId(), request.projectId(),
+              request.experimentId());
       // Measurement Registration - NGS
       case MeasurementRegistrationInformationNGS req ->
           validateMeasurementMetadataNGS(req, request.requestId(), request.projectId());
@@ -631,17 +665,20 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
       String requestId, String projectId, String experimentId) {
     var securityContext = SecurityContextHolder.getContext();
     return validateMetadata(ReactiveSecurityContextUtils::applySecurityContext,
-        () -> sampleValidationService.validateExistingSample(update, ProjectId.parse(projectId), experimentId)
+        () -> sampleValidationService.validateExistingSample(update, ProjectId.parse(projectId),
+                experimentId)
             .validationResult(),
         result -> new ValidationResponse(requestId, result))
         .contextWrite(reactiveSecurity(securityContext));
   }
 
   private Mono<ValidationResponse> validateSampleMetadata(
-      SampleRegistrationInformation registration, String requestId, String projectId, String experimentId) {
+      SampleRegistrationInformation registration, String requestId, String projectId,
+      String experimentId) {
     var securityContext = SecurityContextHolder.getContext();
     return validateMetadata(ReactiveSecurityContextUtils::applySecurityContext,
-        () -> sampleValidationService.validateNewSample(registration, ProjectId.parse(projectId), experimentId)
+        () -> sampleValidationService.validateNewSample(registration, ProjectId.parse(projectId),
+                experimentId)
             .validationResult(),
         result -> new ValidationResponse(requestId, result))
         .contextWrite(reactiveSecurity(securityContext));
@@ -756,16 +793,18 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
   @Override
   public Flux<ExperimentalVariable> getExperimentalVariables(String projectId,
       String experimentId) {
-    var call = Flux.fromStream(() -> experimentInformationService.getVariablesOfExperiment(projectId,
-            ExperimentId.parse(experimentId))
-        .stream()
-        .map(this::convertToApi));
+    var call = Flux.fromStream(
+        () -> experimentInformationService.getVariablesOfExperiment(projectId,
+                ExperimentId.parse(experimentId))
+            .stream()
+            .map(this::convertToApi));
 
     return applySecurityContextMany(call)
         .subscribeOn(VirtualThreadScheduler.getScheduler())
         .contextWrite(reactiveSecurity(SecurityContextHolder.getContext()))
         .doOnError(e -> log.error("Could not load experimental variables", e))
-        .onErrorMap(org.springframework.security.access.AccessDeniedException.class, e -> new AccessDeniedException(ACCESS_DENIED))
+        .onErrorMap(org.springframework.security.access.AccessDeniedException.class,
+            e -> new AccessDeniedException(ACCESS_DENIED))
         .onErrorMap(ProjectNotFoundException.class,
             e -> new RequestFailedException("Project was not found"))
         .retryWhen(defaultRetryStrategy());
@@ -786,8 +825,9 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     var call = Mono.fromCallable(() -> {
       experimentInformationService.addVariableToExperiment(request.projectId(),
           request.experimentId(), request.experimentalVariables());
-      return new ExperimentalVariablesCreationResponse(request.projectId(), request.experimentalVariables(),
-        request.experimentId());
+      return new ExperimentalVariablesCreationResponse(request.projectId(),
+          request.experimentalVariables(),
+          request.experimentId());
     });
     return applySecurityContext(call)
         .subscribeOn(VirtualThreadScheduler.getScheduler())

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
@@ -106,7 +106,7 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     this.experimentInformationService = Objects.requireNonNull(experimentInformationService);
     this.terminologyService = Objects.requireNonNull(termService);
     this.taxaService = Objects.requireNonNull(taxaService);
-    this.measurementService = measurementService;
+    this.measurementService = Objects.requireNonNull(measurementService);
   }
 
   private static Retry defaultRetryStrategy() {
@@ -257,8 +257,8 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     ))
         .subscribeOn(VirtualThreadScheduler.getScheduler())
         .contextWrite(reactiveSecurity(SecurityContextHolder.getContext()))
-        .retryWhen(defaultRetryStrategy())
         .doOnError(e -> log.error("Error registering measurement", e))
+        .retryWhen(defaultRetryStrategy())
         .onErrorMap(AsyncProjectServiceImpl::mapToAPIException);
   }
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
@@ -479,7 +479,8 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
   @Override
   public Flux<Sample> getSamplesForBatch(String projectId, String batchId)
       throws RequestFailedException {
-    throw new RuntimeException("not implemented");
+    // TODO implement
+    throw new RuntimeException("Not yet implemented");
   }
 
   @Override

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -189,16 +189,9 @@ public class MeasurementService {
 
   private void performRegistrationNGS(MeasurementRegistrationInformationNGS measurement,
       String project) {
-    var measurementWithSampleIdPair = process(measurement, project);
-    measurementDomainService.addNGSAll(measurementWithSampleIdPair);
-  }
-
-  private Map<NGSMeasurement, Collection<SampleIdCodeEntry>> process(
-      MeasurementRegistrationInformationNGS measurement, String project) {
-
     var sampleIdCodeEntries = buildSampleIdCodeEntries(measurement);
     var measurementDomain = toDomain(measurement, project, sampleIdCodeEntries);
-    return Map.of(measurementDomain, sampleIdCodeEntries);
+    measurementDomainService.addNGSAll(Map.of(measurementDomain, sampleIdCodeEntries));
   }
 
   private List<SampleIdCodeEntry> buildSampleIdCodeEntries(

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/api/AsyncProjectServiceImplTest.java
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/api/AsyncProjectServiceImplTest.java
@@ -14,6 +14,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.ProjectUp
 import life.qbic.projectmanagement.application.api.fair.DigitalObjectFactory;
 import life.qbic.projectmanagement.application.api.template.TemplateService;
 import life.qbic.projectmanagement.application.experiment.ExperimentInformationService;
+import life.qbic.projectmanagement.application.measurement.MeasurementService;
 import life.qbic.projectmanagement.application.measurement.validation.MeasurementValidationService;
 import life.qbic.projectmanagement.application.ontology.SpeciesLookupService;
 import life.qbic.projectmanagement.application.ontology.TerminologyService;
@@ -41,6 +42,7 @@ class AsyncProjectServiceImplTest {
       ExperimentInformationService.class);
   TerminologyService terminologyService = mock(TerminologyService.class);
   SpeciesLookupService taxaService = mock(SpeciesLookupService.class);
+  MeasurementService measurementService = mock(MeasurementService.class);
 
   @BeforeEach
   void setUp() {
@@ -67,7 +69,9 @@ class AsyncProjectServiceImplTest {
         measurementValidationService,
         experimentInformationServiceMock,
         terminologyService,
-        taxaService
+        taxaService,
+        measurementService
+
     );
 
     String projectId = UUID.randomUUID().toString();
@@ -107,7 +111,8 @@ class AsyncProjectServiceImplTest {
         measurementValidationService,
         experimentInformationServiceMock,
         terminologyService,
-        taxaService
+        taxaService,
+        measurementService
     );
 
     String projectId = UUID.randomUUID().toString();

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/dialog/AppDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/dialog/AppDialog.java
@@ -100,7 +100,10 @@ public class AppDialog extends Dialog implements BeforeLeaveObserver {
         "By aborting the editing process and closing the dialog, you will loose all information entered."));
     life.qbic.datamanager.views.general.dialog.DialogFooter.with(confirmDialog, "Continue editing",
         "Discard changes");
-    confirmDialog.registerConfirmAction(onConfirmAction);
+    confirmDialog.registerConfirmAction(() -> {
+      confirmDialog.close();
+      onConfirmAction.execute();
+    });
     confirmDialog.registerCancelAction(confirmDialog::close);
     return confirmDialog;
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/dialog/DialogBody.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/dialog/DialogBody.java
@@ -29,10 +29,32 @@ public class DialogBody {
     dialog.setBody(component);
   }
 
+  /**
+   * Creates a new {@link DialogBody} instance and registers the {@link UserInput} by calling the
+   * {@link AppDialog#registerUserInput(UserInput)} without the client required to do so manually.
+   *
+   * @param simpleDialog the {@link AppDialog} the body shall be created for
+   * @param component    the component to be rendered in the body part of the dialog
+   * @param userInput    the {@link UserInput} for input validation
+   * @return a {@link DialogBody} for a given {@link AppDialog}
+   * @since 1.7.0
+   */
   public static DialogBody with(AppDialog simpleDialog, Component component, UserInput userInput) {
     return new DialogBody(simpleDialog, component, userInput);
   }
 
+  /**
+   * Creates a new {@link DialogBody} instance for a given {@link AppDialog}.
+   * <p>
+   * <i>NOTE: since there is no {@link UserInput} is provided, the client needs to register it
+   * explicitly via {@link AppDialog#registerUserInput(UserInput)} if automatic input validation
+   * is desired.</i>
+   *
+   * @param simpleDialog the {@link AppDialog} the body shall be created for
+   * @param component    the component to be rendered in the body part of the dialog
+   * @return a {@link DialogBody} for a given {@link AppDialog}
+   * @since 1.7.0
+   */
   public static DialogBody withoutUserInput(AppDialog simpleDialog, Component component) {
     return new DialogBody(simpleDialog, component);
   }

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -544,9 +544,8 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
     dialog.open();
   }
 
-  private void submitRequest(String projectId,
-      List<MeasurementRegistrationInformationNGS> requestList) {
-    var requests = requestList.stream()
+  private void submitPreparedRequest(String projectId, List<MeasurementRegistrationInformationNGS> registrationRequests) {
+    var requests = registrationRequests.stream()
         .map(measurement -> new MeasurementCreationRequestNGS(projectId, measurement)).toList();
 
     AtomicInteger counter = new AtomicInteger(1);
@@ -560,8 +559,8 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
             "Processing %d of %d measurement registrations.".formatted(counter.getAndIncrement(),
                 requests.size())))
         .doOnComplete(() -> {
-            closeToast(registrationToast);
-            displayRegistrationSuccessful();
+          closeToast(registrationToast);
+          displayRegistrationSuccessful();
         })
         .doOnError(throwable -> {
           log.error("Measurement registration failed", throwable);
@@ -569,6 +568,17 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
           closeToast(registrationToast);
         })
         .subscribe();
+  }
+
+  private void submitRequest(String projectId,
+      List<MeasurementRegistrationInformationNGS> requestList) {
+    var preparedRequests = mergeByPool(requestList);
+    submitPreparedRequest(projectId, preparedRequests);
+  }
+
+  private static List<MeasurementRegistrationInformationNGS> mergeByPool(List<MeasurementRegistrationInformationNGS> requests) {
+    // TODO implement
+    throw new RuntimeException("Not yet implemented");
   }
 
   private void displayRegistrationSuccessful() {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -518,13 +518,20 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
 
   private void openRegistrationDialog() {
     AppDialog dialog = AppDialog.large();
-    dialog.registerCancelAction(() -> dialog.close());
     DialogHeader.with(dialog, "Register your measurement metadata");
     DialogFooter.with(dialog, "Cancel", "Register");
 
     var registrationUseCase = new MeasurementUpload(asyncService, context, ConverterRegistry.converterFor(
         MeasurementRegistrationInformationNGS.class), messageSourceNotificationFactory);
     DialogBody.with(dialog, registrationUseCase, registrationUseCase);
+
+    dialog.registerCancelAction(() -> dialog.close());
+    dialog.registerConfirmAction(() -> {
+      var requestContent = registrationUseCase.getValidationRequestContent();
+      for (var entry : requestContent) {
+        log.info(String.valueOf(entry instanceof MeasurementRegistrationInformationNGS));
+      }
+    });
 
     add(dialog);
     dialog.open();

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import life.qbic.application.commons.ApplicationException;
 import life.qbic.application.commons.ApplicationException.ErrorCode;
 import life.qbic.application.commons.FileNameFormatter;
@@ -61,6 +62,7 @@ import life.qbic.logging.api.Logger;
 import life.qbic.logging.service.LoggerFactory;
 import life.qbic.projectmanagement.application.ProjectInformationService;
 import life.qbic.projectmanagement.application.api.AsyncProjectService;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementCreationRequestNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationNGS;
 import life.qbic.projectmanagement.application.experiment.ExperimentInformationService;
 import life.qbic.projectmanagement.application.measurement.MeasurementService;
@@ -76,6 +78,7 @@ import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
 
 
 /**
@@ -214,7 +217,7 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
     Button registerMeasurementButton = new Button("Register Measurements");
     registerMeasurementButton.addClassName("primary");
     registerMeasurementButton.addClickListener(
-        event -> openRegisterMeasurementDialog());
+        event -> openRegistrationDialog());
 
     Button editButton = new Button("Edit");
     editButton.addClickListener(event -> openEditMeasurementDialog());
@@ -521,20 +524,74 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
     DialogHeader.with(dialog, "Register your measurement metadata");
     DialogFooter.with(dialog, "Cancel", "Register");
 
-    var registrationUseCase = new MeasurementUpload(asyncService, context, ConverterRegistry.converterFor(
-        MeasurementRegistrationInformationNGS.class), messageSourceNotificationFactory);
+    var registrationUseCase = new MeasurementUpload(asyncService, context,
+        ConverterRegistry.converterFor(
+            MeasurementRegistrationInformationNGS.class), messageSourceNotificationFactory);
     DialogBody.with(dialog, registrationUseCase, registrationUseCase);
 
+    var registrationRequestsNGS = new ArrayList<MeasurementRegistrationInformationNGS>();
     dialog.registerCancelAction(() -> dialog.close());
     dialog.registerConfirmAction(() -> {
       var requestContent = registrationUseCase.getValidationRequestContent();
       for (var entry : requestContent) {
-        log.info(String.valueOf(entry instanceof MeasurementRegistrationInformationNGS));
+        registrationRequestsNGS.add((MeasurementRegistrationInformationNGS) entry);
       }
+      dialog.close();
+      submitRequest(context.projectId().orElseThrow().value(), registrationRequestsNGS);
     });
 
     add(dialog);
     dialog.open();
+  }
+
+  private void submitRequest(String projectId,
+      List<MeasurementRegistrationInformationNGS> requestList) {
+    var requests = requestList.stream()
+        .map(measurement -> new MeasurementCreationRequestNGS(projectId, measurement)).toList();
+
+    AtomicInteger counter = new AtomicInteger(1);
+    var registrationToast = messageFactory.pendingTaskToast("measurement.registration.in-progress",
+        new Object[]{}, getLocale());
+    registrationToast.open();
+    asyncService.create(Flux.fromIterable(requests))
+        .doFirst(() -> log.debug(
+            "Starting registration of %d measurement requests.".formatted(requests.size())))
+        .doOnEach(signal -> log.debug(
+            "Processing %d of %d measurement registrations.".formatted(counter.getAndIncrement(),
+                requests.size())))
+        .doOnComplete(() -> {
+            closeToast(registrationToast);
+            displayRegistrationSuccessful();
+        })
+        .doOnError(throwable -> {
+          log.error("Measurement registration failed", throwable);
+          displayRegistrationFailure();
+          closeToast(registrationToast);
+        })
+        .subscribe();
+  }
+
+  private void displayRegistrationSuccessful() {
+    getUI().ifPresent(ui -> ui.access(() -> {
+      Toast toast = messageFactory.toast("measurement.registration.successful", new Object[]{}, getLocale());
+      toast.open();
+    }));
+  }
+
+  private void displayToast(Toast toast) {
+    getUI().ifPresent(ui -> ui.access(() -> toast.open()));
+  }
+
+  private void closeToast(Toast toast) {
+    getUI().ifPresent(ui -> ui.access(() -> toast.close()));
+  }
+
+  private void displayRegistrationFailure() {
+    getUI().ifPresent(ui -> ui.access(() -> {
+      var toast = messageFactory.toast("measurement.registration.failed", new Object[]{},
+          getLocale());
+      toast.open();
+    }));
   }
 
   private void routeToSampleCreation(ComponentEvent<?> componentEvent) {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -65,7 +65,7 @@ import life.qbic.logging.api.Logger;
 import life.qbic.logging.service.LoggerFactory;
 import life.qbic.projectmanagement.application.ProjectInformationService;
 import life.qbic.projectmanagement.application.api.AsyncProjectService;
-import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementCreationRequestNGS;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationRequest;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationNGS;
 import life.qbic.projectmanagement.application.experiment.ExperimentInformationService;
 import life.qbic.projectmanagement.application.measurement.MeasurementService;
@@ -76,7 +76,6 @@ import life.qbic.projectmanagement.domain.model.experiment.Experiment;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.measurement.MeasurementId;
 import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
-import life.qbic.projectmanagement.domain.model.measurement.NGSSpecificMeasurementMetadata;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
@@ -551,7 +550,7 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
   private void submitPreparedRequest(String projectId,
       List<MeasurementRegistrationInformationNGS> registrationRequests) {
     var requests = registrationRequests.stream()
-        .map(measurement -> new MeasurementCreationRequestNGS(projectId, measurement)).toList();
+        .map(measurement -> new MeasurementRegistrationRequest(projectId, measurement)).toList();
 
     AtomicInteger counter = new AtomicInteger(1);
     var registrationToast = messageFactory.pendingTaskToast("measurement.registration.in-progress",

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -588,10 +588,6 @@ public class MeasurementMain extends Main implements BeforeEnterObserver, Before
     }));
   }
 
-  private void displayToast(Toast toast) {
-    getUI().ifPresent(ui -> ui.access(() -> toast.open()));
-  }
-
   private void closeToast(Toast toast) {
     getUI().ifPresent(ui -> ui.access(() -> toast.close()));
   }

--- a/user-interface/src/main/resources/messages/toast-notifications.properties
+++ b/user-interface/src/main/resources/messages/toast-notifications.properties
@@ -56,7 +56,16 @@ measurement.upload.failed.message.type=html
 measurement.upload.failed.message.text=Apologies, something went wrong during the upload. Please contact <a href="mailto:support@qbic.zendesk.com">QBiC support</a>.
 measurement.upload.failed.level=error
 measurement.upload.failed.unsupported-file-type.message.type=html
-measurement.upload.failed.unsupported-file-type.message.text="File type is currently not supported.
+measurement.upload.failed.unsupported-file-type.message.text=File type is currently not supported.
+measurement.registration.in-progress.message.type=html
+measurement.registration.in-progress.message.text=Registering measurements
+measurement.registration.in-progress.level=success
+measurement.registration.failed.message.type=html
+measurement.registration.failed.message.text=Apologies, the registration failed. Please contact <a href="mailto:support@qbic.zendesk.com">QBiC support</a>.
+measurement.registration.failed.level=error
+measurement.registration.successful.message.type=html
+measurement.registration.successful.message.text=Measurement registration successful
+measurement.registration.successful.level=success
 sample-batch.deleted.success.message.type=html
 sample-batch.deleted.success.message.text=Deleted sample batch <strong>{0}</strong>.
 sample-batch.deleted.success.level=success


### PR DESCRIPTION
Takes the validation request input after the user confirmed the measurement action and
performs the actual metadata registration for NGS.

The service API has been adjusted to the existing structure request form. 