### PR TITLE
Fixes sample registration and update issues

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/template/provider/openxml/factory/SampleUpdateFactory.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/template/provider/openxml/factory/SampleUpdateFactory.java
@@ -6,6 +6,7 @@ import static life.qbic.projectmanagement.infrastructure.template.provider.openx
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 import life.qbic.application.commons.ApplicationException;
@@ -65,7 +66,7 @@ class SampleUpdateFactory implements WorkbookFactory {
     for (Sample sample : samples) {
       Row row = getOrCreateRow(sheet, rowIndex);
       var experimentalGroup = experimentalGroups.stream()
-          .filter(group -> group.id() == sample.experimentalGroupId())
+          .filter(group -> Objects.equals(group.id(), sample.experimentalGroupId()))
           .findFirst().orElseThrow();
       fillRowWithSampleMetadata(row, sample, experimentalGroup.condition(),
           cellStyles.defaultCellStyle(),

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
@@ -1878,6 +1878,10 @@ public interface AsyncProjectService {
       requireNonNull(projectId);
       requireNonNull(requestId);
     }
+
+    public ValidationRequest(String projectId, SampleRegistrationInformation registration) {
+      this(projectId, registration, UUID.randomUUID().toString());
+    }
   }
 
   /**

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/RegisterSampleBatchDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/RegisterSampleBatchDialog.java
@@ -155,7 +155,7 @@ public class RegisterSampleBatchDialog extends WizardDialogWindow {
 
   private static ValidationRequest convertToRequest(SampleRegistrationInformation registration,
       String projectId) {
-    return new ValidationRequest(projectId, registration, null);
+    return new ValidationRequest(projectId, registration);
   }
 
   private void setValidatedSampleMetadata(List<SampleRegistrationInformation> registrations) {


### PR DESCRIPTION
Sample registration was not possible due to a NullPointerException. A validation request required a request id which was always null. Further sample update was not possible due to a wrong comparison of Long values. 
This PR fixes both issues.