### PR TITLE
Fix sample metadata download

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/template/provider/openxml/factory/SampleInformationFactory.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/template/provider/openxml/factory/SampleInformationFactory.java
@@ -3,6 +3,7 @@ package life.qbic.projectmanagement.infrastructure.template.provider.openxml.fac
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 import life.qbic.application.commons.ApplicationException;
@@ -62,7 +63,7 @@ class SampleInformationFactory implements WorkbookFactory {
     for (Sample sample : samples) {
       Row row = XLSXTemplateHelper.getOrCreateRow(sheet, rowIndex);
       var experimentalGroup = experimentalGroups.stream()
-          .filter(group -> group.id() == sample.experimentalGroupId())
+          .filter(group -> Objects.equals(group.id(), sample.experimentalGroupId()))
           .findFirst().orElseThrow();
       fillRowWithSampleMetadata(row, sample, experimentalGroup.condition(),
           cellStyles.defaultCellStyle(),


### PR DESCRIPTION
Fixes incorrect comparison of Long values in the sample metadata download.
Previous to this PR, no sample metadata excel file could be obtained due to incorrect comparison of Long values. (Long values > 127 break with `==` comparison)