### PR TITLE
Add logging for unspecific upload errors

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/general/upload/UploadWithDisplay.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/general/upload/UploadWithDisplay.java
@@ -92,7 +92,8 @@ public class UploadWithDisplay extends Div {
     upload.setI18n(uploadI18N);
 
     upload.addSucceededListener(it -> fireEvent(new SucceededEvent(this, it.isFromClient())));
-    upload.addFailedListener(it -> fireEvent(new FailedEvent(this, it.isFromClient())));
+    upload.addFailedListener(
+        it -> fireEvent(new UnspecificFailedEvent(this, it.isFromClient(), it.getReason())));
     upload.addFileRejectedListener(fileRejected -> {
       errorArea.setVisible(true);
       errorArea.setText(fileRejected.getErrorMessage());
@@ -118,8 +119,9 @@ public class UploadWithDisplay extends Div {
     return addListener(SucceededEvent.class, listener);
   }
 
-  public Registration addFailureListener(ComponentEventListener<FailedEvent> listener) {
-    return addListener(FailedEvent.class, listener);
+  public Registration addUnspecificFailureListener(
+      ComponentEventListener<UnspecificFailedEvent> listener) {
+    return addListener(UnspecificFailedEvent.class, listener);
   }
 
   public Registration addRemovedListener(ComponentEventListener<UploadRemovedEvent> listener) {
@@ -236,7 +238,9 @@ public class UploadWithDisplay extends Div {
     }
   }
 
-  public static class FailedEvent extends ComponentEvent<UploadWithDisplay> {
+  public static class UnspecificFailedEvent extends ComponentEvent<UploadWithDisplay> {
+
+    private final Exception cause;
 
     /**
      * Creates a new event using the given source and indicator whether the event originated from
@@ -246,8 +250,13 @@ public class UploadWithDisplay extends Div {
      * @param fromClient <code>true</code> if the event originated from the client
      *                   side, <code>false</code> otherwise
      */
-    public FailedEvent(UploadWithDisplay source, boolean fromClient) {
+    public UnspecificFailedEvent(UploadWithDisplay source, boolean fromClient, Exception cause) {
       super(source, fromClient);
+      this.cause = cause;
+    }
+
+    public Exception getCause() {
+      return cause;
     }
   }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/RegisterSampleBatchDialog.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/samples/registration/batch/RegisterSampleBatchDialog.java
@@ -61,7 +61,7 @@ public class RegisterSampleBatchDialog extends WizardDialogWindow {
   private final Div failedView;
   private final Div succeededView;
   private final UploadWithDisplay uploadWithDisplay;
-  private transient final MessageSourceNotificationFactory messageFactory;
+  private final transient MessageSourceNotificationFactory messageFactory;
   private final DownloadComponent downloadComponent;
   private final transient AsyncProjectService service;
 
@@ -100,8 +100,12 @@ public class RegisterSampleBatchDialog extends WizardDialogWindow {
     uploadWithDisplay = new UploadWithDisplay(MAX_FILE_SIZE, new FileType[]{
         new FileType(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     });
-    uploadWithDisplay.addFailureListener(
-        uploadFailed -> {/* display of the error is handled by the uploadWithDisplay component. So nothing to do here.*/});
+    uploadWithDisplay.addUnspecificFailureListener(
+        uploadFailed ->
+            /* display of the error is handled by the uploadWithDisplay component. However we do need to log with the context*/
+            log.error(
+                "Upload failed for project(" + projectId + ") experiment(" + experimentId + ")",
+                uploadFailed.getCause()));
     uploadWithDisplay.addSuccessListener(
         uploadSucceeded -> onUploadSucceeded(experimentId, projectId,
             uploadSucceeded));
@@ -121,12 +125,10 @@ public class RegisterSampleBatchDialog extends WizardDialogWindow {
   }
 
   private void handleError(Throwable throwable) {
-    switch (throwable) {
-      case AccessDeniedException ignored:
-        handleAccessDeniedError();
-        return;
-      default:
-        handleUnexpectedError(throwable);
+    if (Objects.requireNonNull(throwable) instanceof AccessDeniedException) {
+      handleAccessDeniedError();
+    } else {
+      handleUnexpectedError(throwable);
     }
   }
 
@@ -283,15 +285,14 @@ public class RegisterSampleBatchDialog extends WizardDialogWindow {
       String projectId, String projectCode) {
     Button downloadTemplate = new Button("Download metadata template");
     downloadTemplate.addClassName("download-metadata-button");
-    downloadTemplate.addClickListener(buttonClickEvent -> {
-      service.sampleRegistrationTemplate(projectId, experimentId,
-          OPEN_XML).doOnSuccess(resource ->
-          triggerDownload(resource,
-              FileNameFormatter.formatWithTimestampedSimple(LocalDate.now(), projectCode,
-                  "sample metadata template",
-                  "xlsx")
-          )).doOnError(this::handleError).subscribe();
-    });
+    downloadTemplate.addClickListener(
+        buttonClickEvent -> service.sampleRegistrationTemplate(projectId, experimentId,
+            OPEN_XML).doOnSuccess(resource ->
+            triggerDownload(resource,
+                FileNameFormatter.formatWithTimestampedSimple(LocalDate.now(), projectCode,
+                    "sample metadata template",
+                    "xlsx")
+            )).doOnError(this::handleError).subscribe());
     Div text = new Div();
     text.addClassName("download-metadata-text");
     text.setText(


### PR DESCRIPTION
Previously unspecific errors during file upload were only shown to the user but not logged on the server. To improve system stability and maintenance it is important to log the cause of the issues to address the underlying problem.