### PR TITLE
Specify Schema version to v1 in ror API

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/CachedOrganisationRepository.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/CachedOrganisationRepository.java
@@ -38,7 +38,7 @@ public class CachedOrganisationRepository implements OrganisationRepository {
 
   private static final Logger log = logger(CachedOrganisationRepository.class);
   private static final int DEFAULT_CACHE_SIZE = 50;
-  private static final String ROR_API_URL = "https://api.ror.org/organizations/%s";
+  private static final String ROR_API_URL = "https://api.ror.org/v1/organizations/%s";
   private static final String ROR_ID_PATTERN = "0[a-z|0-9]{6}[0-9]{2}$";
   private final Map<String, String> iriToOrganisation = new HashMap<>();
   private final int configuredCacheSize;


### PR DESCRIPTION
**What was changed**
[Last week](https://github.com/ror-community/ror-api/releases/tag/1.15.0) the ror API default URL was changed to return the v2 schema instead of the v1 schema. 
This leads to [test failures](https://github.com/qbicsoftware/data-manager-app/actions/runs/16812073098/job/47619626819) since the v2 API returns a list of names instead of a singular name as before. 

Details about the schema differences can be found in the ror [readme](https://ror.readme.io/docs/schema-v2)

**How to fix**
Specified that v1 should be used until we decide if we want to incorporate the v2 in our system. (Would need an overhaul of the objectmapper extracting the information from the returned json).
