### PR TITLE
Add Client ID for ROR repository

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/AppConfig.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/AppConfig.java
@@ -107,8 +107,8 @@ public class AppConfig {
   }
 
   @Bean
-  public OrganisationRepository organisationRepository() {
-    return new CachedOrganisationRepository();
+  public OrganisationRepository organisationRepository(@Value("") String clientId) {
+    return new CachedOrganisationRepository(clientId);
   }
 
 

--- a/user-interface/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/user-interface/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -184,6 +184,11 @@
       "name": "qbic.external-service.person-search.orcid.issuer",
       "type": "java.lang.String",
       "description": "The URL of the orcid issuer. Most probably https://orcid.org"
+    },
+    {
+      "name": "qbic.external-service.organisation-search.ror.client-id",
+      "type": "java.lang.String",
+      "description": "The client id for the ROR API to allow for a rate limit of 2000 requests/5 minutes. See https://ror.readme.io/docs/client-id for more detail."
     }
   ]
 }

--- a/user-interface/src/main/resources/application.properties
+++ b/user-interface/src/main/resources/application.properties
@@ -124,6 +124,9 @@ qbic.external-service.person-search.orcid.extended-search-uri=${qbic.external-se
 qbic.external-service.person-search.orcid.scope=/read-public
 qbic.external-service.person-search.orcid.grant-type=client_credentials
 qbic.external-service.person-search.orcid.issuer=${ORCID_SEARCH_ISSUER_URL:https://orcid.org}
+###############################################################################
+################### ROR ID ####################################################
+qbic.external-service.organisation-search.ror.client-id=${ROR_CLIENT_ID}
 
 ###############################################################################
 ################### ActiveMQ Artemis ##########################################


### PR DESCRIPTION
Due to a change coming december, the ROR repository requires the addition of a client id to the http request. This PR introduces these changes. It does not adapt the data manager to being able to use the `v2` api of the ROR repository. For more information see https://ror.readme.io/docs/client-id.