### PR TITLE
Use pessimistic lock to address bursts

### DIFF
--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
@@ -3,8 +3,6 @@ package life.qbic.projectmanagement.infrastructure.project;
 import static java.util.Objects.requireNonNull;
 import static life.qbic.logging.service.LoggerFactory.logger;
 
-import jakarta.persistence.LockModeType;
-import java.time.Instant;
 import java.util.Optional;
 import life.qbic.logging.api.Logger;
 import life.qbic.projectmanagement.application.AuthenticationToUserIdTranslationService;
@@ -15,8 +13,6 @@ import life.qbic.projectmanagement.domain.model.project.ProjectCode;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
 import life.qbic.projectmanagement.domain.repository.ProjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/ProjectRepositoryImpl.java
@@ -3,6 +3,7 @@ package life.qbic.projectmanagement.infrastructure.project;
 import static java.util.Objects.requireNonNull;
 import static life.qbic.logging.service.LoggerFactory.logger;
 
+import jakarta.persistence.LockModeType;
 import java.time.Instant;
 import java.util.Optional;
 import life.qbic.logging.api.Logger;
@@ -14,6 +15,8 @@ import life.qbic.projectmanagement.domain.model.project.ProjectCode;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
 import life.qbic.projectmanagement.domain.repository.ProjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -96,6 +99,11 @@ public class ProjectRepositoryImpl implements ProjectRepository {
   @Override
   public Optional<Project> find(ProjectId projectId) {
     return projectRepo.findById(projectId);
+  }
+
+  @Override
+  public Optional<Project> findByIdForUpdate(ProjectId projectId) {
+    return projectRepo.findByIdForUpdate(projectId);
   }
 
   /**

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/QbicProjectRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/project/QbicProjectRepo.java
@@ -1,9 +1,16 @@
 package life.qbic.projectmanagement.infrastructure.project;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import java.util.Optional;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectCode;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 /**
  * <b>QBiC project repository interface</b>
@@ -20,4 +27,8 @@ public interface QbicProjectRepo extends CrudRepository<Project, ProjectId> {
 
   boolean existsProjectByProjectCode(ProjectCode projectCode);
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select p from Project p where p.projectId = :id")
+  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "15000")) // ms
+  Optional<Project> findByIdForUpdate(@Param("id") ProjectId id);
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
@@ -27,6 +27,7 @@ import life.qbic.projectmanagement.domain.model.project.ProjectTitle;
 import life.qbic.projectmanagement.domain.repository.ProjectRepository;
 import org.hibernate.dialect.lock.OptimisticEntityLockException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -217,8 +218,11 @@ public class ProjectInformationService {
       try {
         tryToUpdateModifiedDate(project, modifiedOn);
         return;
-      } catch (OptimisticEntityLockException e) {
+      } catch (ObjectOptimisticLockingFailureException e) {
         log.debug("Optimistic lock exception occurred while updating modified date for project " + projectID);
+      } catch (Exception e) {
+        log.error("Error while updating modified date for project " + projectID, e);
+        throw e;
       }
       try {
         Thread.sleep(calcBase2Duration(attempt));
@@ -235,7 +239,7 @@ public class ProjectInformationService {
   Will only update the last modified date in case the passed instant is newer then the
   the already stored one in the project.
    */
-  private void tryToUpdateModifiedDate(Project project, Instant modifiedOn) throws OptimisticEntityLockException {
+  private void tryToUpdateModifiedDate(Project project, Instant modifiedOn) throws ObjectOptimisticLockingFailureException {
     if (project.getLastModified() == null) {
       project.setLastModified(modifiedOn);
     }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
@@ -213,9 +213,11 @@ public class ProjectInformationService {
     // To address this, the update is tried until it will eventually not throw the locking exception anymore.
     // This approach naively assumes, that the locked resource will be released eventually again by the other process.
     var attempt = 1;
-    var project = projectRepository.find(projectID).orElseThrow(() -> new ProjectNotFoundException("Project with not found: %s".formatted(projectID)));
-    while(true) {
+    var maxAttempts = 5;
+    Project project;
+    while(attempt <= maxAttempts) {
       try {
+        project = projectRepository.findByIdForUpdate(projectID).orElseThrow(() -> new ProjectNotFoundException("Project with not found: %s".formatted(projectID)));
         tryToUpdateModifiedDate(project, modifiedOn);
         return;
       } catch (ObjectOptimisticLockingFailureException e) {
@@ -229,6 +231,7 @@ public class ProjectInformationService {
       } catch (InterruptedException e) {
         log.error("Interrupted while updating modified date for project " + projectID);
         // We try one last time
+        project = projectRepository.find(projectID).orElseThrow(() -> new ProjectNotFoundException("Project with not found: %s".formatted(projectID)));
         tryToUpdateModifiedDate(project, modifiedOn);
         Thread.currentThread().interrupt();
       }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/ProjectInformationService.java
@@ -231,7 +231,7 @@ public class ProjectInformationService {
       } catch (InterruptedException e) {
         log.error("Interrupted while updating modified date for project " + projectID);
         // We try one last time
-        project = projectRepository.find(projectID).orElseThrow(() -> new ProjectNotFoundException("Project with not found: %s".formatted(projectID)));
+        project = projectRepository.find(projectID).orElseThrow(() -> new ProjectNotFoundException("Project not found: %s".formatted(projectID)));
         tryToUpdateModifiedDate(project, modifiedOn);
         Thread.currentThread().interrupt();
       }

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/repository/ProjectRepository.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/repository/ProjectRepository.java
@@ -16,7 +16,8 @@ import life.qbic.projectmanagement.domain.model.project.ProjectId;
 public interface ProjectRepository {
 
   /**
-   * Adds a {@link Project} entity permanently and sets access rights according to the logged in user.
+   * Adds a {@link Project} entity permanently and sets access rights according to the logged in
+   * user.
    *
    * @param project the project to store
    * @since 1.0.0
@@ -33,6 +34,7 @@ public interface ProjectRepository {
 
   /**
    * Saves a project to the repository
+   *
    * @param project the project to save
    * @since 1.11.1
    */
@@ -48,6 +50,15 @@ public interface ProjectRepository {
   boolean existsProjectByProjectCode(ProjectCode projectCode);
 
   Optional<Project> find(ProjectId projectId);
+
+  /**
+   * Will create a pessimistic lock on the project row for the given id.
+   *
+   * @param projectId the project to find the id for
+   * @return the project if found
+   * @since 1.11.0
+   */
+  Optional<Project> findByIdForUpdate(ProjectId projectId);
 
   /**
    * Is thrown if a project that should be created already exists, as denoted by the project id


### PR DESCRIPTION
Will ignore job flooding from concurrent project update requests.