### PR TITLE
Use info style for showing measurement registration

### DIFF
--- a/user-interface/src/main/resources/messages/toast-notifications.properties
+++ b/user-interface/src/main/resources/messages/toast-notifications.properties
@@ -59,7 +59,7 @@ measurement.upload.failed.unsupported-file-type.message.type=html
 measurement.upload.failed.unsupported-file-type.message.text=File type is currently not supported.
 measurement.registration.in-progress.message.type=html
 measurement.registration.in-progress.message.text=Registering measurements
-measurement.registration.in-progress.level=success
+measurement.registration.in-progress.level=info
 measurement.registration.failed.message.type=html
 measurement.registration.failed.message.text=Apologies, some registrations failed <strong>({0})</strong>. Please contact <a href="mailto:support@qbic.zendesk.com">QBiC support</a>.
 measurement.registration.failed.level=error


### PR DESCRIPTION
The previous style was "success", but "info" is the correct style for pending tasks.