### PR TITLE
Fix condition comparison and fail for duplicate conditions

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/Condition.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/Condition.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -104,8 +105,8 @@ public class Condition {
     }
 
     Condition condition = (Condition) o;
-
-    return this.variableLevels.equals(condition.variableLevels);
+    //we do not care about the order when comparing
+    return new HashSet<>(variableLevels).equals(new HashSet<>(condition.variableLevels));
   }
 
   @Override


### PR DESCRIPTION
Due to an incorrect comparison of conditions, the check for experimental groups with duplicate condition was not correct.

This PR corrects the comparison of conditions and ignores the order of variable levels when comparing conditions as two conditions with the same values of the same variables are considered equal.