### PR TITLE
Correctly reload the measurements

### DIFF
--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -80,7 +80,6 @@ import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
-import life.qbic.projectmanagement.infrastructure.template.provider.openxml.WorkbookFactory;
 import life.qbic.projectmanagement.infrastructure.template.provider.openxml.factory.NGSWorkbooks;
 import life.qbic.projectmanagement.infrastructure.template.provider.openxml.factory.ProteomicsWorkbooks;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -705,6 +704,7 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
   private void reloadMeasurements() {
     getUI().ifPresent(ui -> ui.access(() -> {
         measurementDetailsComponent.setContext(context);
+      setMeasurementInformation();
     }));
   }
 


### PR DESCRIPTION
Given no measurements exists, after the first registration of measurements, the list of measurements was not reloaded and shown. This PR correctly sets the visibility after the first registration of measurements.