### PR TITLE
Check for missing measurement ID on update validation

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -265,6 +265,7 @@ public class MeasurementService {
   }
 
   private void performUpdateNGS(MeasurementUpdateInformationNGS measurement, String projectId) {
+    Objects.requireNonNull(measurement);
     var sampleCodeEntries = buildSampleIdCodeEntries(measurement.measuredSamples());
     var measurementDomain = toDomainUpdate(measurement, sampleCodeEntries);
     measurementDomainService.updateNGSAll(List.of(measurementDomain));
@@ -273,6 +274,7 @@ public class MeasurementService {
   @NonNull
   private NGSMeasurement toDomainUpdate(MeasurementUpdateInformationNGS measurement,
       List<SampleIdCodeEntry> sampleCodeEntries) {
+    Objects.requireNonNull(measurement);
     if (measurementIdMissing(measurement)) {
       throw new MeasurementUpdateException(ErrorCode.MISSING_MEASUREMENT_ID);
     }
@@ -309,23 +311,22 @@ public class MeasurementService {
   }
 
   private boolean measurementUnknown(MeasurementUpdateInformationNGS measurement) {
+    Objects.requireNonNull(measurement);
     return measurementRepository.findNGSMeasurement(measurement.measurementId()).isEmpty();
   }
 
-  private boolean measurementUnknown(MeasurementUpdateInformationPxP measurement) {
-    return measurementRepository.findProteomicsMeasurement(measurement.measurementId()).isEmpty();
-  }
-
   private boolean measurementIdMissing(MeasurementUpdateInformationNGS measurement) {
+    Objects.requireNonNull(measurement);
     return measurementIdMissing(measurement.measurementId());
   }
 
   private boolean measurementIdMissing(MeasurementUpdateInformationPxP measurement) {
+    Objects.requireNonNull(measurement);
     return measurementIdMissing(measurement.measurementId());
   }
 
   private static boolean measurementIdMissing(String measurementId) {
-    return measurementId.isEmpty();
+    return measurementId == null || measurementId.isEmpty();
   }
 
   @NonNull

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementNGSValidator.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementNGSValidator.java
@@ -366,10 +366,10 @@ public class MeasurementNGSValidator implements
         MeasurementUpdateInformationNGS metadata) {
       var validation = ValidationResult.successful();
       if (metadata.measurementId().isEmpty()) {
-        validation.combine(ValidationResult.withFailures(
+        validation = validation.combine(ValidationResult.withFailures(
             List.of("Measurement id: missing measurement id for update")));
       } else {
-        validation.combine(ValidationResult.successful());
+        validation = validation.combine(ValidationResult.successful());
       }
       if (metadata.organisationId().isBlank()) {
         validation = validation.combine(

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementProteomicsValidator.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementProteomicsValidator.java
@@ -409,7 +409,7 @@ public class MeasurementProteomicsValidator implements
         MeasurementUpdateInformationPxP metadata) {
       var validation = ValidationResult.successful();
       if (metadata.measurementId().isEmpty()) {
-        validation.combine(ValidationResult.withFailures(
+        validation = validation.combine(ValidationResult.withFailures(
             List.of("Measurement id: missing measurement id for update")));
       } else {
         validation.combine(ValidationResult.successful());


### PR DESCRIPTION
Fixes false positive validation during measurement update, in case the measurement ID is missing.

Previously users were able to upload measurement update sheets with missing measurement IDs, and the validation would pass.