### PR TITLE
Fix display of orcid account on Chrome browser

### DIFF
--- a/user-interface/frontend/themes/datamanager/components/all.css
+++ b/user-interface/frontend/themes/datamanager/components/all.css
@@ -764,7 +764,7 @@ Older stuff -
   width: 100%;
 }
 
-.dynamic-growing-flex-item {
+.flex-grow-1 {
   flex-grow: 1;
 }
 

--- a/user-interface/src/main/java/life/qbic/datamanager/views/account/AccountContentBox.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/account/AccountContentBox.java
@@ -42,7 +42,7 @@ public class AccountContentBox extends Div {
     publicRecord.add(new Anchor(record.toString(), "View public record", AnchorTarget.BLANK));
 
     var spacer = new Div();
-    spacer.addClassNames("dynamic-growing-flex-item");
+    spacer.addClassNames("flex-grow-1");
 
     add(iconContainer, accountInfo, spacer, publicRecord);
   }


### PR DESCRIPTION
Firefox and chrome interpret 100% inside a flex layout differently. Chrome tries to assign the `spacer` a width of 100% by shrinking the public record component. Leading to a screwed display. By telling the browsers that the spacer should expand instead of that the spacer should fill the full width, both firefox and chrome display the component correctly.

Before this PR:
<img width="867" height="217" alt="image" src="https://github.com/user-attachments/assets/19ee0ac3-d21e-4389-8e6a-ffc331464202" />

After this PR:
<img width="867" height="217" alt="image" src="https://github.com/user-attachments/assets/027c93e4-04b4-4a8d-89fa-7d49521de5c5" />
