### PR TITLE
Remove unused columns from object

### DIFF
--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/Experiment.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/experiment/Experiment.java
@@ -43,12 +43,6 @@ public class Experiment {
   private String name;
   @Embedded
   private ExperimentalDesign experimentalDesign;
-  @Column(name = "speciesIconName", nullable = true, columnDefinition = "varchar(31) default 'default'")
-  private String speciesIconName;
-  @Column(name = "specimenIconName", nullable = true, columnDefinition = "varchar(31) default 'default'")
-  private String specimenIconName;
-  @Column(name = "analyteIconName", nullable = true, columnDefinition = "varchar(31) default 'default'")
-  private String analyteIconName;
 
   @Version
   private int version;


### PR DESCRIPTION
Prevents object mapping exceptions for null values. Remove deprecated and unused columns from the object mapping as to prevent conflicts during runtime.
Leave the value to the databases default value.

```
Caused by: org.hibernate.exception.ConstraintViolationException: could not execute statement [Column 'analyteIconName' cannot be null] [insert into experiments_datamanager (analyteIconName,experimentName,speciesIconName,specimenIconName,version,id) values (?,?,?,?,?,?)]
```
