### PR TITLE
Fix sizing in width and height classes

### DIFF
--- a/user-interface/frontend/themes/datamanager/components/all.css
+++ b/user-interface/frontend/themes/datamanager/components/all.css
@@ -1061,6 +1061,13 @@ Icons
   text-wrap: nowrap;
 }
 
+.width-50-pct,
+.width-full,
+.height-50-pct,
+.height-full {
+  box-sizing: border-box;
+}
+
 .width-full {
   width: 100%;
 }

--- a/user-interface/frontend/themes/datamanager/components/grid-templates.css
+++ b/user-interface/frontend/themes/datamanager/components/grid-templates.css
@@ -20,7 +20,7 @@
 
 .main.raw-data {
   grid-template-columns: minmax(min-content, 80%) minmax(min-content, 20%);
-  grid-template-rows: minmax(min-content, 10%) 90%;
+  grid-template-rows: minmax(min-content, 10%) minmax(90%, 100%);
   grid-template-areas:
     ". rawdatadownloadinformation"
     "rawdatadetails rawdatadownloadinformation";

--- a/user-interface/frontend/themes/datamanager/components/main.css
+++ b/user-interface/frontend/themes/datamanager/components/main.css
@@ -287,6 +287,7 @@
 
 .main.raw-data .raw-data-details-component {
   grid-area: rawdatadetails;
+  box-sizing: border-box;
 }
 
 .main.raw-data .raw-data-main-content {
@@ -302,13 +303,6 @@
   color: var(--lumo-secondary-text-color);
   font-size: var(--lumo-font-size-xxl);
   margin-bottom: 0.5rem;
-}
-
-.main.raw-data .raw-data-main-content .buttonAndField {
-  display: inline-flex;
-  justify-content: space-between;
-  /*Moves this bar to end of container*/
-  margin-top: auto;
 }
 
 .main.user-registration {

--- a/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataMain.java
+++ b/user-interface/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataMain.java
@@ -2,12 +2,8 @@ package life.qbic.datamanager.views.projects.project.rawdata;
 
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.icon.VaadinIcon;
-import com.vaadin.flow.component.textfield.TextField;
-import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Route;
@@ -28,7 +24,6 @@ import life.qbic.datamanager.views.notifications.MessageSourceNotificationFactor
 import life.qbic.datamanager.views.projects.project.experiments.ExperimentMainLayout;
 import life.qbic.logging.api.Logger;
 import life.qbic.logging.service.LoggerFactory;
-import life.qbic.projectmanagement.application.ProjectInformationService;
 import life.qbic.projectmanagement.application.api.AsyncProjectService;
 import life.qbic.projectmanagement.application.dataset.RemoteRawDataService;
 import life.qbic.projectmanagement.application.experiment.ExperimentInformationService;
@@ -100,6 +95,7 @@ public class RawDataMain extends Main implements BeforeEnterObserver {
     noRawDataRegisteredDisclaimer.addClassName("no-raw-data-registered-disclaimer");
     downloadComponent = new DownloadComponent();
     rawdataDetailsComponentContainer = new Div();
+    rawdataDetailsComponentContainer.addClassNames("display-contents");
 
     initContent();
     add(registerMeasurementsDisclaimer);


### PR DESCRIPTION
Changes the height and width css classes to respect borders, margins and padding. Switches for percentage based classes to the border-box instead of the content-box. (https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/box-sizing)