### PR TITLE
Activate deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,17 +210,11 @@
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
         <version>3.1.1</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.1.2</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Previously the deployment has been skipped in the parent pom.xml, which was inherited by all children.