### PR TITLE
feat(raw-data): Display file sizes in human-readable units within the Raw Data View

### DIFF
--- a/application-commons/src/main/java/life/qbic/application/commons/FileSizeFormatter.java
+++ b/application-commons/src/main/java/life/qbic/application/commons/FileSizeFormatter.java
@@ -1,0 +1,46 @@
+package life.qbic.application.commons;
+
+import java.util.Locale;
+
+/**
+ * Utility class for formatting file sizes in human-readable format.
+ * <p>
+ * Provides methods to convert byte values to human-readable strings
+ * using decimal (SI) units where 1 KB = 1000 B, 1 MB = 1000 KB,
+ * and 1 GB = 1000 MB.
+ */
+public class FileSizeFormatter {
+
+  private static final long KILOBYTE = 1_000L;
+  private static final long MEGABYTE = 1_000_000L;
+  private static final long GIGABYTE = 1_000_000_000L;
+
+  private FileSizeFormatter() {
+    // Utility class - no instantiation
+  }
+
+  /**
+   * Formats a byte value into a human-readable string.
+   * <p>
+   * The value is scaled to the most appropriate decimal unit (B, KB, MB, or GB)
+   * and rounded to 2 decimal places.
+   *
+   * @param bytes the size in bytes
+   * @return a formatted string with the appropriate unit (e.g., "3.00 GB", "512.75 MB")
+   */
+  public static String formatBytes(long bytes) {
+    if (bytes < 0) {
+      return "0 B";
+    }
+    if (bytes < KILOBYTE) {
+      return bytes + " B";
+    }
+    if (bytes < MEGABYTE) {
+      return String.format(Locale.US, "%.2f KB", bytes / (double) KILOBYTE);
+    }
+    if (bytes < GIGABYTE) {
+      return String.format(Locale.US, "%.2f MB", bytes / (double) MEGABYTE);
+    }
+    return String.format(Locale.US, "%.2f GB", bytes / (double) GIGABYTE);
+  }
+}

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataDetailsComponent.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataDetailsComponent.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import life.qbic.application.commons.FileNameFormatter;
+import life.qbic.application.commons.FileSizeFormatter;
 import life.qbic.application.commons.time.DateTimeFormat;
 import life.qbic.datamanager.files.export.download.DownloadStreamProvider;
 import life.qbic.datamanager.files.export.rawdata.RawDataUrlFile;
@@ -401,7 +402,7 @@ public class RawDataDetailsComponent extends PageArea implements Serializable {
           BasicSampleInformation::sampleName).toList());
       rawDataItem.addEntry("Number of Files",
           String.valueOf(rawData.dataset().numberOfFiles()));
-      rawDataItem.addEntry("File Size", String.valueOf(rawData.dataset().totalSizeBytes()));
+      rawDataItem.addEntry("File Size", FileSizeFormatter.formatBytes(rawData.dataset().totalSizeBytes()));
       rawDataItem.addListEntry("File Suffixes", rawData.dataset().fileTypes());
       return rawDataItem;
     });
@@ -414,7 +415,7 @@ public class RawDataDetailsComponent extends PageArea implements Serializable {
           BasicSampleInformation::sampleName).toList());
       rawDataItem.addEntry("Number of Files",
           String.valueOf(rawData.dataset().numberOfFiles()));
-      rawDataItem.addEntry("File Size", String.valueOf(rawData.dataset().totalSizeBytes()));
+      rawDataItem.addEntry("File Size", FileSizeFormatter.formatBytes(rawData.dataset().totalSizeBytes()));
       rawDataItem.addListEntry("File Suffixes", rawData.dataset().fileTypes());
       return rawDataItem;
     });


### PR DESCRIPTION
## Summary

Display file sizes in the Raw Data View in human-readable format (B, KB, MB, GB) instead of raw byte values.

## Changes

- **New utility class**: FileSizeFormatter.java in application-commons
  - Converts bytes to human-readable format (e.g., 3221225472 -> 3.00 GB)
  - Rounds to 2 decimal places
  - Uses appropriate unit based on file size

- **Updated UI**: RawDataDetailsComponent.java
  - Applied formatter in renderRawDataNgs() and renderRawDataPxp() methods

## Acceptance Criteria

- [x] File sizes shown in human-readable format (B, KB, MB, or GB)
- [x] Values rounded to 2 decimal places
- [x] Lower bounds never begins with 0 (except Bytes range)
- [x] Upper bounds never surpasses 1000 (except GB range)

## Files Modified

| File | Change |
|------|--------|
| application-commons/src/main/java/life/qbic/application/commons/FileSizeFormatter.java | New |
| datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/rawdata/RawDataDetailsComponent.java | Modified |

## Links

Addresses #1405