### PR TITLE
feat: edit immunopeptidomics measurements via pre-filled Excel template

### DIFF
--- a/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/ConverterRegistry.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/ConverterRegistry.java
@@ -7,6 +7,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.Measureme
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationIP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationPxP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.SampleRegistrationInformation;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.SampleUpdateInformation;
 import org.apache.commons.collections.map.HashedMap;
@@ -52,6 +53,8 @@ public class ConverterRegistry {
         MeasurementUpdateMetadataConverterNGS::new);
     registry.put(MeasurementUpdateInformationPxP.class,
         MeasurementUpdateMetadataConverterPxP::new);
+    registry.put(MeasurementUpdateInformationIP.class,
+        MeasurementUpdateMetadataConverterIP::new);
     // Add more mappings ...
   }
 

--- a/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/MeasurementRegistrationMetadataConverterIP.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/MeasurementRegistrationMetadataConverterIP.java
@@ -89,6 +89,7 @@ public class MeasurementRegistrationMetadataConverterIP implements
       var metadatum = new MeasurementRegistrationInformationIP(
           organisationId,
           instrument,
+          "", // instrumentName - not present in registration template, default empty
           facility,
           "", // pool group - empty for now, can be added if needed
           Map.of(sampleId, specificMetadata),

--- a/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/MeasurementUpdateMetadataConverterIP.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/MeasurementUpdateMetadataConverterIP.java
@@ -1,0 +1,108 @@
+package life.qbic.datamanager.files.parsing.converters;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import life.qbic.datamanager.files.parsing.ParsingResult;
+import life.qbic.datamanager.files.structure.measurement.IPMeasurementEditColumn;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementSpecificIP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
+
+/**
+ * Measurement Update Metadata Converter IP
+ * <p>
+ * Converter that converts a {@link ParsingResult} into a list of
+ * {@link MeasurementUpdateInformationIP}.
+ *
+ * @since 1.11.0
+ */
+public class MeasurementUpdateMetadataConverterIP implements
+    MetadataConverterV2<MeasurementUpdateInformationIP> {
+
+  @Override
+  public List<MeasurementUpdateInformationIP> convert(ParsingResult parsingResult) {
+    var convertedElements = new ArrayList<MeasurementUpdateInformationIP>();
+
+    for (int i = 0; i < parsingResult.rows().size(); i++) {
+      var measurementId = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.MEASUREMENT_ID.headerName(), "");
+      var sampleId = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.SAMPLE_ID.headerName(), "");
+      var organisationId = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.ORGANISATION_URL.headerName(), "");
+      var instrument = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.INSTRUMENT.headerName(), "");
+      var facility = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.FACILITY.headerName(), "");
+      var samplePoolGroup = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.SAMPLE_NAME.headerName(), "");
+      var measurementName = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.MEASUREMENT_NAME.headerName(), "");
+
+      // Sample-specific metadata
+      var sampleMass = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.SAMPLE_MASS.headerName(), "");
+      var sampleVolume = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.SAMPLE_VOLUME.headerName(), "");
+      var cycleFractionName = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.CYCLE_FRACTION_NAME.headerName(), "");
+      var mhcAntibody = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.MHC_ANTIBODY.headerName(), "");
+      var mhcTypingMethod = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.MHC_TYPING_METHOD.headerName(), "");
+      var enrichmentMethod = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.ENRICHMENT_METHOD.headerName(), "");
+      var prepDate = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.PREP_DATE.headerName(), "");
+      var msRunDate = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.MS_RUN_DATE.headerName(), "");
+      var lcmsMethod = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.LCMS_METHOD.headerName(), "");
+      var lcColumn = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.LC_COLUMN.headerName(), "");
+      var dataAcquisition = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.DATA_ACQUISITION.headerName(), "");
+      var massRange = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.MASS_RANGE.headerName(), "");
+      var retentionTimeRange = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.RETENTION_TIME_RANGE.headerName(), "");
+      var chargeRange = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.CHARGE_RANGE.headerName(), "");
+      var ionMobilityRange = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.ION_MOBILITY_RANGE.headerName(), "");
+      var comment = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.COMMENT.headerName(), "");
+
+      var specificMetadata = new MeasurementSpecificIP(
+          sampleMass,
+          sampleVolume,
+          cycleFractionName,
+          mhcAntibody,
+          mhcTypingMethod,
+          enrichmentMethod,
+          prepDate,
+          msRunDate,
+          lcmsMethod,
+          lcColumn,
+          dataAcquisition,
+          massRange,
+          retentionTimeRange,
+          chargeRange,
+          ionMobilityRange,
+          comment
+      );
+
+      var metaDatum = new MeasurementUpdateInformationIP(
+          measurementId,
+          organisationId,
+          instrument,
+          facility,
+          samplePoolGroup,
+          Map.of(sampleId, specificMetadata),
+          measurementName
+      );
+      convertedElements.add(metaDatum);
+    }
+    return convertedElements;
+  }
+}

--- a/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/MeasurementUpdateMetadataConverterIP.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/files/parsing/converters/MeasurementUpdateMetadataConverterIP.java
@@ -32,6 +32,8 @@ public class MeasurementUpdateMetadataConverterIP implements
           IPMeasurementEditColumn.ORGANISATION_URL.headerName(), "");
       var instrument = parsingResult.getValueOrDefault(i,
           IPMeasurementEditColumn.INSTRUMENT.headerName(), "");
+      var instrumentName = parsingResult.getValueOrDefault(i,
+          IPMeasurementEditColumn.INSTRUMENT_NAME.headerName(), "");
       var facility = parsingResult.getValueOrDefault(i,
           IPMeasurementEditColumn.FACILITY.headerName(), "");
       var samplePoolGroup = parsingResult.getValueOrDefault(i,
@@ -96,6 +98,7 @@ public class MeasurementUpdateMetadataConverterIP implements
           measurementId,
           organisationId,
           instrument,
+          instrumentName,
           facility,
           samplePoolGroup,
           Map.of(sampleId, specificMetadata),

--- a/datamanager-app/src/main/java/life/qbic/datamanager/files/structure/measurement/IPMeasurementEditColumn.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/files/structure/measurement/IPMeasurementEditColumn.java
@@ -1,0 +1,145 @@
+package life.qbic.datamanager.files.structure.measurement;
+
+import java.util.Arrays;
+import java.util.Optional;
+import life.qbic.datamanager.files.structure.Column;
+import life.qbic.datamanager.files.structure.ExampleProvider;
+import life.qbic.datamanager.files.structure.ExampleProvider.Helper;
+
+/**
+ * <b>IP Measurement Edit Columns</b>
+ *
+ * <p>Enumeration of the columns shown in the file used for immunopeptidomics measurement edit
+ * in the context of measurement file based upload. Provides the name of the header column, the
+ * column index and if the column should be set to readOnly in the generated sheet
+ * </p>
+ */
+public enum IPMeasurementEditColumn implements Column {
+
+  MEASUREMENT_ID("Measurement ID", 0, true, true),
+  SAMPLE_ID("QBiC Sample Id", 1, true, true),
+  SAMPLE_NAME("Sample Name", 2, true, false),
+  MEASUREMENT_NAME("Measurement Name", 3, false, false),
+  CYCLE_FRACTION_NAME("Cycle/Fraction Name", 4, false, false),
+  SAMPLE_MASS("Sample Mass (mg)", 5, false, true),
+  SAMPLE_VOLUME("Sample Volume (decimal)", 6, false, true),
+  PREP_DATE("Prep Date", 7, false, false),
+  ENRICHMENT_METHOD("Enrichment method", 8, false, true),
+  MHC_ANTIBODY("MHC Antibody", 9, false, true),
+  MHC_TYPING_METHOD("MHC Typing Method", 10, false, false),
+  FACILITY("Facility", 11, false, true),
+  ORGANISATION_URL("Organisation URL", 12, false, true),
+  ORGANISATION_NAME("Organisation Name", 13, true, false),
+  MS_RUN_DATE("MS Run Date", 14, false, false),
+  DATA_ACQUISITION("Data Acquisition", 15, false, true),
+  INSTRUMENT("Instrument", 16, false, true),
+  INSTRUMENT_NAME("Instrument Name", 17, true, false),
+  LCMS_METHOD("LCMS Method", 18, false, true),
+  LC_COLUMN("LC Column", 19, false, true),
+  CHARGE_RANGE("Charge range", 20, false, true),
+  ION_MOBILITY_RANGE("Ion mobility range (1/k0)", 21, false, false),
+  MASS_RANGE("Mass range (m/z)", 22, false, true),
+  RETENTION_TIME_RANGE("Retention time range (min)", 23, false, true),
+  COMMENT("Comment", 24, false, false);
+
+  private final String headerName;
+  private final int columnIndex;
+  private final boolean readOnly;
+  private final boolean mandatory;
+  private static final ExampleProvider exampleProvider = (Column column) -> {
+    if (column instanceof IPMeasurementEditColumn ipMeasurementEditColumn) {
+      return switch (ipMeasurementEditColumn) {
+        case MEASUREMENT_ID -> new Helper("QBiC Measurement ID",
+            "A unique identifier of the measurement that will be linked to each sample.");
+        case SAMPLE_ID -> new Helper("QBiC sample IDs, e.g. Q2001, Q2002",
+            "The sample(s) that will be linked to the measurement.");
+        case SAMPLE_NAME -> new Helper("Free text, e.g. MySample 01",
+            "A visual aid to simplify sample navigation for the person managing the metadata. Will be ignored after upload.");
+        case MEASUREMENT_NAME -> new Helper("Free text, e.g. your local identifier for the measurement", "Name given for the measurement.");
+        case CYCLE_FRACTION_NAME -> new Helper("Free text, e.g. Fraction01, AB",
+            "Sometimes a sample is fractionated and all fractions are measured. With this property you can indicate which fraction it is.");
+        case SAMPLE_MASS -> new Helper("Decimal number, e.g. 1.5",
+            "Mass that was harvested from the biological probe (mg)");
+        case SAMPLE_VOLUME -> new Helper("Decimal number, e.g. 100.5",
+            "Volume after enrichment that was injected into the mass spectrometer (microliter)");
+        case PREP_DATE -> new Helper("YYYY-MM-DD",
+            "Includes the date of the sample preparation (YYYYMMDD)");
+        case ENRICHMENT_METHOD -> new Helper("Free text",
+            "Method to enrich HLA peptides in sample volume ( e.g. immunoaffinity purification, immunoaffinity purification (iodoacetamide), mild acid elution, detergent lysis )");
+        case MHC_ANTIBODY -> new Helper("Free text",
+            "The MHC Antibody that was used for the measurement");
+        case MHC_TYPING_METHOD -> new Helper("Free text",
+            "Method used to obtain the donors HLA typing (e.g. DNA seq-based with Optitype, RNA-seq-based with HLA-LA, Immunopeptidomics-based with immunotype)");
+        case FACILITY -> new Helper("Free text, e.g. Quantitative Biology Center",
+            "Ideally the facilities name within the organisation (groupname, etc.)");
+        case ORGANISATION_URL -> new Helper("ROR URL, e.g. https://ror.org/03a1kwz48",
+            "A unique identifier of the organisation where the measurement has been conducted. We expect a full ROR id as URL (e.g. https://ror.org/03a1kwz48)");
+        case ORGANISATION_NAME -> new Helper("Free text, e.g. University of Tübingen",
+            "The name of the organisation where the measurement has been conducted.");
+        case MS_RUN_DATE -> new Helper("YYYY-MM-DD",
+            "Includes the date of the sample measurement on the MS (YYYYMMDD)");
+        case DATA_ACQUISITION -> new Helper("Free text, e.g. DDA, DIA, PRM",
+            "Mass spectrometer acquisition mode (e.g. DDA, DIA, PRM etc.)");
+        case INSTRUMENT -> new Helper("CURIE (ontology), e.g. EFO:0008637",
+            "The instrument model that has been used for the measurement, which needs to be an ontology CURIE that will be resolved to an existing persistent ID.");
+        case INSTRUMENT_NAME -> new Helper("Free text, e.g. Illumina HiSeq",
+            "The name of the instrument model that has been used for the measurement.");
+        case LCMS_METHOD -> new Helper("Free text, e.g. CIDOT, HCDOT, MSV035",
+            "Laboratory specific methods that have been used for LCMS measurements (e.g., CIDOT, HCDOT, MSV035..).");
+        case LC_COLUMN -> new Helper("Free text, e.g. C18",
+            "The type of column that has been used.");
+        case CHARGE_RANGE -> new Helper("Free text, e.g. 2-4",
+            "Charge window where the mass spectrometer method was designed to analyze precursors. Units are either m/z or Dalton");
+        case ION_MOBILITY_RANGE -> new Helper("Free text, e.g. 0.6-1.6",
+            "Ion mobility window where the mass spectrometer method was designed to analyze precursors. Units are 1/k0 or CCS.");
+        case MASS_RANGE -> new Helper("Free text, e.g. 300-1800",
+            "Mass window where the mass spectrometer method was designed to analyze precursors. Units are either m/z or Dalton");
+        case RETENTION_TIME_RANGE -> new Helper("Integer, e.g. 120",
+            "Time of chromatogram gradient (min)");
+        case COMMENT -> new Helper("Free text",
+            "Any other comments that can be noted (issue at the machines, during isolation or if the sample is excluded from the rest of the analysis)");
+      };
+    } else {
+      throw new IllegalArgumentException(
+          "Column not of class " + IPMeasurementEditColumn.class.getName() + " but is "
+              + column.getClass().getName());
+    }
+  };
+
+  IPMeasurementEditColumn(String headerName, int columnIndex, boolean readOnly,
+      boolean mandatory) {
+    this.headerName = headerName;
+    this.columnIndex = columnIndex;
+    this.readOnly = readOnly;
+    this.mandatory = mandatory;
+  }
+
+  @Override
+  public String headerName() {
+    return headerName;
+  }
+
+  @Override
+  public int index() {
+    return columnIndex;
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return readOnly;
+  }
+
+  @Override
+  public boolean isMandatory() {
+    return mandatory;
+  }
+
+  @Override
+  public Optional<Helper> getFillHelp() {
+    return Optional.ofNullable(exampleProvider.getHelper(this));
+  }
+
+  static int maxColumnIndex() {
+    return Arrays.stream(values()).mapToInt(IPMeasurementEditColumn::index).max().orElse(0);
+  }
+}

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementDetailsComponent.java
@@ -595,21 +595,7 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
           }
           fireEvent(new IpMeasurementExportRequested(selectedMeasurementIds, this, true));
         });
-    var deleteIpButton = new Button("Delete");
-    deleteIpButton.addClickListener(clicked -> {
-      Set<IpMeasurementLookup.MeasurementInfo> selectedMeasurements = filterGrid.selectedElements();
-      List<String> selectedMeasurementIds = selectedMeasurements
-          .stream()
-          .map(IpMeasurementLookup.MeasurementInfo::measurementId)
-          .distinct()
-          .toList();
-      if (selectedMeasurementIds.isEmpty()) {
-        displayMissingSelectionNote();
-        return;
-      }
-      fireEvent(new IpMeasurementDeletionRequested(selectedMeasurementIds, this, true));
-    });
-    filterGrid.setSecondaryActionGroup(deleteIpButton);
+    // Edit and Delete buttons are already set up in filterGridIp()
   }
 
   private FilterGrid<IpMeasurementLookup.MeasurementInfo, SearchTermFilter> filterGridIp(
@@ -643,6 +629,36 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
 
     filterGrid.itemDisplayLabel("measurement");
     filterGrid.searchFieldPlaceholder("Search Measurements");
+    var editIpButton = new Button("Edit");
+    editIpButton.addClickListener(clicked -> {
+      Set<IpMeasurementLookup.MeasurementInfo> selectedMeasurements = filterGrid.selectedElements();
+      List<String> selectedMeasurementIds = selectedMeasurements
+          .stream()
+          .map(IpMeasurementLookup.MeasurementInfo::measurementId)
+          .distinct()
+          .toList();
+      if (selectedMeasurementIds.isEmpty()) {
+        displayMissingSelectionNote();
+        return;
+      }
+      fireEvent(new IpMeasurementEditRequested(selectedMeasurementIds, this, true));
+    });
+
+    var deleteIpButton = new Button("Delete");
+    deleteIpButton.addClickListener(clicked -> {
+      Set<IpMeasurementLookup.MeasurementInfo> selectedMeasurements = filterGrid.selectedElements();
+      List<String> selectedMeasurementIds = selectedMeasurements
+          .stream()
+          .map(IpMeasurementLookup.MeasurementInfo::measurementId)
+          .distinct()
+          .toList();
+      if (selectedMeasurementIds.isEmpty()) {
+        displayMissingSelectionNote();
+        return;
+      }
+      fireEvent(new IpMeasurementDeletionRequested(selectedMeasurementIds, this, true));
+    });
+    filterGrid.setSecondaryActionGroup(deleteIpButton, editIpButton);
     return filterGrid;
   }
 
@@ -1225,6 +1241,35 @@ public class MeasurementDetailsComponent extends PageArea implements Serializabl
   public Registration addIpRegisterListener(
       ComponentEventListener<IpMeasurementRegistrationRequested> listener) {
     return addListener(IpMeasurementRegistrationRequested.class, listener);
+  }
+
+  public static class IpMeasurementEditRequested extends
+      ComponentEvent<MeasurementDetailsComponent> {
+
+    private final List<String> measurementIds;
+
+    /**
+     * Creates a new event using the given source and indicator whether the event originated from
+     * the client side or the server side.
+     *
+     * @param source     the source component
+     * @param fromClient <code>true</code> if the event originated from the client
+     *                   side, <code>false</code> otherwise
+     */
+    public IpMeasurementEditRequested(List<String> measurementIds,
+        MeasurementDetailsComponent source, boolean fromClient) {
+      super(source, fromClient);
+      this.measurementIds = measurementIds.stream().toList();
+    }
+
+    public List<String> measurementIds() {
+      return measurementIds;
+    }
+  }
+
+  public Registration addIpEditListener(
+      ComponentEventListener<IpMeasurementEditRequested> listener) {
+    return addListener(IpMeasurementEditRequested.class, listener);
   }
 
   public static class IpMeasurementDeletionRequested extends

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -55,6 +55,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.Measureme
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationRequestBody;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationPxP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateRequest;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateRequestBody;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.ValidationRequestBody;
@@ -196,6 +197,8 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
 
     measurementDetailsComponent.addIpRegisterListener(
         registrationRequest -> openRegistrationDialog());
+    measurementDetailsComponent.addIpEditListener(
+        editRequest -> ipEditDialog(editRequest.measurementIds()).open());
     measurementDetailsComponent.addIpExportListener(
         exportRequest -> downloadIPMetadata(exportRequest.measurementIds()));
     measurementDetailsComponent.addIpDeletionListener(
@@ -262,6 +265,35 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
     var upload = new MeasurementUpload(asyncService, context,
         ConverterRegistry.converterFor(
             MeasurementUpdateInformationPxP.class), messageFactory);
+    var uploadComponent = new MeasurementUpdateComponent(templateDownload, upload);
+    DialogBody.with(dialog, uploadComponent, uploadComponent);
+    dialog.registerCancelAction(dialog::close);
+    dialog.registerConfirmAction(() -> {
+      if (upload.validate().hasPassed()) {
+        var validationRequests = upload.getValidationRequestContent();
+        submitUpdateRequest(context.projectId().orElseThrow().value(),
+            createUpdateRequestPackage(validationRequests));
+        dialog.close();
+      }
+    });
+    return dialog;
+  }
+
+  private AppDialog ipEditDialog(List<String> selectedMeasurementIds) {
+    var dialog = AppDialog.medium();
+    DialogHeader.with(dialog, "Edit Measurements");
+    DialogFooter.with(dialog, "Cancel", "Update");
+    var templateDownload = new MeasurementTemplateComponent(
+        UPDATE_MEASUREMENT_DESCRIPTION,
+        "Download Metadata",
+        asyncService.measurementUpdateIP(context.projectId().orElseThrow().value(),
+            selectedMeasurementIds, OPEN_XML),
+        messageFactory,
+        projectContext::projectId);
+
+    var upload = new MeasurementUpload(asyncService, context,
+        ConverterRegistry.converterFor(
+            MeasurementUpdateInformationIP.class), messageFactory);
     var uploadComponent = new MeasurementUpdateComponent(templateDownload, upload);
     DialogBody.with(dialog, uploadComponent, uploadComponent);
     dialog.registerCancelAction(dialog::close);
@@ -547,6 +579,25 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
   private void submitUpdateRequest(String projectId, UpdateRequestPackage updateRequestPackage) {
     submitUpdateRequestNGS(projectId, updateRequestPackage.updateInformationNGS);
     submitUpdateRequestPxP(projectId, updateRequestPackage.updateInformationPxP);
+    submitUpdateRequestIP(projectId, updateRequestPackage.updateInformationIP);
+  }
+
+  private void submitUpdateRequestIP(String projectId,
+      List<MeasurementUpdateInformationIP> updateInformationIP) {
+    if (updateInformationIP.isEmpty()) {
+      return;
+    }
+    var preparedRequests = mergeByPoolUpdateIP(updateInformationIP);
+    submitPreparedUpdateRequest(projectId, preparedRequests);
+  }
+
+  private List<MeasurementUpdateInformationIP> mergeByPoolUpdateIP(
+      List<MeasurementUpdateInformationIP> updateInformationIP) {
+    var processor = ProcessorRegistry.processorFor(MeasurementUpdateInformationIP.class);
+    if (processor == null) {
+      throw new IllegalStateException("No processor for MeasurementUpdateInformationIP");
+    }
+    return processor.process(updateInformationIP);
   }
 
   private void submitUpdateRequestPxP(String projectId,
@@ -627,16 +678,18 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
       List<? extends ValidationRequestBody> validationRequests) {
     var requestsNGS = new ArrayList<MeasurementUpdateInformationNGS>();
     var requestsPxP = new ArrayList<MeasurementUpdateInformationPxP>();
+    var requestsIP = new ArrayList<MeasurementUpdateInformationIP>();
 
     for (var entry : validationRequests) {
       switch (entry) {
         case MeasurementUpdateInformationNGS info -> requestsNGS.add(info);
         case MeasurementUpdateInformationPxP info -> requestsPxP.add(info);
+        case MeasurementUpdateInformationIP info -> requestsIP.add(info);
         default -> throw new IllegalStateException(
             "Unexpected request body of type: " + entry.getClass().getName());
       }
     }
-    return new UpdateRequestPackage(requestsNGS, requestsPxP);
+    return new UpdateRequestPackage(requestsNGS, requestsPxP, requestsIP);
   }
 
   private RegistrationRequestPackage createRegistrationRequestPackage(
@@ -903,12 +956,13 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
   }
 
   record UpdateRequestPackage(List<MeasurementUpdateInformationNGS> updateInformationNGS,
-                              List<MeasurementUpdateInformationPxP> updateInformationPxP) {
+                              List<MeasurementUpdateInformationPxP> updateInformationPxP,
+                              List<MeasurementUpdateInformationIP> updateInformationIP) {
 
     public UpdateRequestPackage {
       updateInformationNGS = List.copyOf(Objects.requireNonNull(updateInformationNGS));
       updateInformationPxP = List.copyOf(Objects.requireNonNull(updateInformationPxP));
-
+      updateInformationIP = List.copyOf(Objects.requireNonNull(updateInformationIP));
     }
 
   }

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/MeasurementRegistrationProcessorIP.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/MeasurementRegistrationProcessorIP.java
@@ -50,6 +50,7 @@ class MeasurementRegistrationProcessorIP implements
       var pooledMeasurement = new MeasurementRegistrationInformationIP(
           commonMetadata.organisationId(),
           commonMetadata.instrumentCURIE(),
+          commonMetadata.instrumentName(),
           commonMetadata.facility(),
           commonMetadata.samplePoolGroup(),
           specificMetadata,

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/MeasurementUpdateProcessorIP.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/MeasurementUpdateProcessorIP.java
@@ -81,6 +81,7 @@ class MeasurementUpdateProcessorIP implements MeasurementProcessor<MeasurementUp
           commonMetadata.measurementId(),
           commonMetadata.organisationId(),
           commonMetadata.instrumentCURIE(),
+          commonMetadata.instrumentName(),
           commonMetadata.facility(),
           commonMetadata.samplePoolGroup(),
           specificMetadata,

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/MeasurementUpdateProcessorIP.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/MeasurementUpdateProcessorIP.java
@@ -1,0 +1,92 @@
+package life.qbic.datamanager.views.projects.project.measurements.processor;
+
+import static life.qbic.logging.service.LoggerFactory.logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import life.qbic.logging.api.Logger;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementSpecificIP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
+
+/**
+ * <b>Measurement Update Processor IP</b>
+ * <p>
+ * Processes {@link MeasurementUpdateInformationIP} and merges metadata entries that belong to the
+ * same measurement pool.
+ *
+ * @since 1.11.0
+ */
+class MeasurementUpdateProcessorIP implements MeasurementProcessor<MeasurementUpdateInformationIP> {
+
+  private static final Logger log = logger(MeasurementUpdateProcessorIP.class);
+
+  @Override
+  public List<MeasurementUpdateInformationIP> process(
+      List<MeasurementUpdateInformationIP> requests) {
+    // 1. In the update use case we need to group measurements first by measurement ID, since multiple
+    // measurements for the same sample ID can exist
+    var measurementsById = new HashMap<String, List<MeasurementUpdateInformationIP>>();
+    for (MeasurementUpdateInformationIP measurement : requests) {
+      measurementsById.computeIfAbsent(measurement.measurementId(), k -> new ArrayList<>())
+          .add(measurement);
+    }
+    var finalMeasurements = new ArrayList<MeasurementUpdateInformationIP>();
+    // 2. Now we need to iterate through the measurements for every unique measurement ID
+    // and process pooled measurements
+    for (var entry : measurementsById.entrySet()) {
+      var measurements = entry.getValue();
+
+      var processedMeasurements = processPools(measurements);
+      finalMeasurements.addAll(processedMeasurements);
+    }
+    return finalMeasurements;
+  }
+
+
+  private static List<MeasurementUpdateInformationIP> processPools(
+      List<MeasurementUpdateInformationIP> measurements) {
+    var finalMeasurements = new ArrayList<MeasurementUpdateInformationIP>();
+
+    // Lookup table for aggregated measurements by pool name
+    var measurementsBySamplePool = new HashMap<String, List<MeasurementUpdateInformationIP>>();
+
+    for (var measurement : measurements) {
+      if (measurement.samplePoolGroup() == null || measurement.samplePoolGroup().isBlank()) {
+        // no need to further process
+        finalMeasurements.add(measurement);
+      } else {
+        // store measurement for pool name
+        measurementsBySamplePool.computeIfAbsent(measurement.samplePoolGroup(),
+            k -> new ArrayList<>()).add(measurement);
+      }
+    }
+
+    // We need to merge sample-specific metadata of the pooled measurements
+    for (var pooledEntry : measurementsBySamplePool.entrySet()) {
+      // Every entry has the same pool name and by definition are only distinct in their specific metadata
+      Map<String, MeasurementSpecificIP> specificMetadata;
+      try {
+        specificMetadata = pooledEntry.getValue().stream()
+            .flatMap(m -> m.specificMetadata().entrySet().stream())
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+      } catch (IllegalStateException e) {
+        throw new ProcessingException("Preparation of specific measurement data failed.", e);
+      }
+      var commonMetadata = pooledEntry.getValue().getFirst();
+      var pooledMeasurement = new MeasurementUpdateInformationIP(
+          commonMetadata.measurementId(),
+          commonMetadata.organisationId(),
+          commonMetadata.instrumentCURIE(),
+          commonMetadata.facility(),
+          commonMetadata.samplePoolGroup(),
+          specificMetadata,
+          commonMetadata.measurementName());
+      finalMeasurements.add(pooledMeasurement);
+    }
+    return finalMeasurements;
+  }
+}

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/ProcessorRegistry.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/processor/ProcessorRegistry.java
@@ -8,6 +8,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.Measureme
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationIP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationPxP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 
 /**
  * <b>Processor Registry</b>
@@ -35,6 +36,8 @@ public class ProcessorRegistry {
         MeasurementUpdateProcessorNGS::new);
     registry.put(MeasurementUpdateInformationPxP.class,
         MeasurementUpdateProcessorPxP::new);
+    registry.put(MeasurementUpdateInformationIP.class,
+        MeasurementUpdateProcessorIP::new);
     // Add more mappings ...
   }
 

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/registration/MeasurementUpload.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/registration/MeasurementUpload.java
@@ -48,6 +48,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.Measureme
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationPxP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationPxP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.ValidationRequest;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.ValidationRequestBody;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.ValidationResponse;
@@ -253,6 +254,10 @@ public class MeasurementUpload extends Div implements UserInput {
       case MeasurementUpdateInformationNGS ignored: {
         var processor = ProcessorRegistry.processorFor(MeasurementUpdateInformationNGS.class);
         return processor.process((List<MeasurementUpdateInformationNGS>) validationRequest);
+      }
+      case MeasurementUpdateInformationIP ignored: {
+        var processor = ProcessorRegistry.processorFor(MeasurementUpdateInformationIP.class);
+        return processor.process((List<MeasurementUpdateInformationIP>) validationRequest);
       }
       default:
         throw new IllegalStateException("Unknown validation request: " + validationRequest);

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/template/provider/openxml/TemplateProviderOpenXML.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/template/provider/openxml/TemplateProviderOpenXML.java
@@ -209,7 +209,7 @@ public class TemplateProviderOpenXML implements TemplateProvider {
           req.ionMobilityRange(),
           req.massRange(),
           req.retentionTimeRange(),
-          ""
+          req.comment()
       );
       entries.add(entry);
     }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
@@ -1351,7 +1351,7 @@ public interface AsyncProjectService {
   }
 
   sealed interface MeasurementUpdateRequestBody permits MeasurementUpdateInformationNGS,
-      MeasurementUpdateInformationPxP {
+      MeasurementUpdateInformationPxP, MeasurementUpdateInformationIP {
 
   }
 
@@ -1785,7 +1785,7 @@ public interface AsyncProjectService {
   sealed interface ValidationRequestBody permits MeasurementRegistrationInformationNGS,
       MeasurementRegistrationInformationPxP, MeasurementRegistrationInformationIP,
       MeasurementUpdateInformationNGS,
-      MeasurementUpdateInformationPxP, SampleRegistrationInformation, SampleUpdateInformation {
+      MeasurementUpdateInformationPxP, MeasurementUpdateInformationIP, SampleRegistrationInformation, SampleUpdateInformation {
 
   }
 
@@ -2411,6 +2411,45 @@ public interface AsyncProjectService {
       String comment
   ) {
 
+  }
+
+  /**
+   * Information container to update an immunopeptidomics measurement.
+   *
+   * @param measurementId   the identifier of the measurement
+   * @param organisationId  the ROR ID of the organization that performed the measurement
+   * @param instrumentCURIE the CURIE of the mass spectrometry device used for the measurement
+   * @param facility        the facility within the organization that actually performed the
+   *                        measurement
+   * @param samplePoolGroup the name of the sample pool
+   * @param specificMetadata specific metadata that differentiates pooled samples as a
+   *                         {@link Map}, with the sample ids as keys and the sample-specific
+   *                         measurement annotations as values. Will have only one entry if no
+   *                         pooling was done. {@link MeasurementSpecificIP}
+   * @param measurementName a given name for the measurement. For example a local ID or label
+   *                        that helps users to connect the created dataset with the registered
+   *                        metadata
+   * @since 1.11.0
+   */
+  record MeasurementUpdateInformationIP(
+      String measurementId,
+      String organisationId,
+      String instrumentCURIE,
+      String facility,
+      String samplePoolGroup,
+      Map<String, MeasurementSpecificIP> specificMetadata,
+      String measurementName
+  ) implements ValidationRequestBody, MeasurementUpdateRequestBody {
+
+    /**
+     * Returns the {@link List} of sample identifiers this measurement refers to.
+     *
+     * @return the {@link List} of sample identifiers
+     * @since 1.11.0
+     */
+    public List<String> measuredSamples() {
+      return List.copyOf(specificMetadata.keySet());
+    }
   }
 
   /**

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectService.java
@@ -2353,6 +2353,7 @@ public interface AsyncProjectService {
   record MeasurementRegistrationInformationIP(
       String organisationId,
       String instrumentCURIE,
+      String instrumentName,
       String facility,
       String samplePoolGroup,
       Map<String, MeasurementSpecificIP> specificMetadata,
@@ -2435,6 +2436,7 @@ public interface AsyncProjectService {
       String measurementId,
       String organisationId,
       String instrumentCURIE,
+      String instrumentName,
       String facility,
       String samplePoolGroup,
       Map<String, MeasurementSpecificIP> specificMetadata,

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/AsyncProjectServiceImpl.java
@@ -328,6 +328,10 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
         return updateMeasurementPxP(measurementUpdateRequest.projectId(),
             measurementUpdateRequest.requestId(), m);
       }
+      case MeasurementUpdateInformationIP m -> {
+        return updateMeasurementIP(measurementUpdateRequest.projectId(),
+            measurementUpdateRequest.requestId(), m);
+      }
     }
   }
 
@@ -349,6 +353,19 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     var errorMessage = "Error updating measurement";
     return applySecurityContext(Mono.fromCallable(() -> {
       measurementService.updateMeasurementNGS(projectId, measurement);
+      return new MeasurementUpdateResponse(requestId, measurement);
+    })).subscribeOn(scheduler)
+        .contextWrite(reactiveSecurity(SecurityContextHolder.getContext()))
+        .doOnError(e -> log.error(errorMessage, e))
+        .retryWhen(defaultRetryStrategy())
+        .onErrorMap(e1 -> mapToAPIException(e1, errorMessage));
+  }
+
+  private Mono<MeasurementUpdateResponse> updateMeasurementIP(String projectId, String requestId,
+      MeasurementUpdateInformationIP measurement) {
+    var errorMessage = "Error updating immunopeptidomics measurement";
+    return applySecurityContext(Mono.fromCallable(() -> {
+      measurementService.updateMeasurementIP(projectId, measurement);
       return new MeasurementUpdateResponse(requestId, measurement);
     })).subscribeOn(scheduler)
         .contextWrite(reactiveSecurity(SecurityContextHolder.getContext()))
@@ -951,6 +968,9 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
       // Measurement Registration - Immunopeptidomics
       case MeasurementRegistrationInformationIP req -> validateMeasurementMetadataIP(req,
           request.requestId(), request.experimentId(), request.projectId());
+      // Measurement Update - Immunopeptidomics
+      case MeasurementUpdateInformationIP req -> validateMeasurementMetadataIPUpdate(req,
+          request.requestId(), request.experimentId(), request.projectId());
     };
   }
 
@@ -1028,6 +1048,18 @@ public class AsyncProjectServiceImpl implements AsyncProjectService {
     var securityContext = SecurityContextHolder.getContext();
     return applySecurityContext(Mono.fromCallable(
             () -> measurementValidationService.validateNGS(update, experimentId,
+                ProjectId.parse(projectId)))
+        .map(validationResult -> new ValidationResponse(requestId, validationResult)))
+        .contextWrite(reactiveSecurity(securityContext))
+        .subscribeOn(scheduler);
+  }
+
+  private Mono<ValidationResponse> validateMeasurementMetadataIPUpdate(
+      MeasurementUpdateInformationIP update, String requestId, String experimentId,
+      String projectId) {
+    var securityContext = SecurityContextHolder.getContext();
+    return applySecurityContext(Mono.fromCallable(
+            () -> measurementValidationService.validateIP(update, experimentId,
                 ProjectId.parse(projectId)))
         .map(validationResult -> new ValidationResponse(requestId, validationResult)))
         .contextWrite(reactiveSecurity(securityContext))

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/template/TemplateProvider.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/template/TemplateProvider.java
@@ -340,7 +340,8 @@ public interface TemplateProvider {
       String prepDate,
       String msRunDate,
       Map<String, MeasurementSpecificIP> specificMetadata,
-      String measurementName
+      String measurementName,
+      String comment
   ) {
 
     public MeasurementInformationIP {
@@ -367,6 +368,7 @@ public interface TemplateProvider {
       requireNonNull(specificMetadata);
       specificMetadata = new HashMap<>(specificMetadata);
       requireNonNull(measurementName);
+      requireNonNull(comment);
     }
 
     /**

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/api/template/TemplateService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/api/template/TemplateService.java
@@ -376,7 +376,8 @@ public class TemplateService {
         measurement.msRunDate().map(java.time.LocalDate::toString).orElse(""),
         convertSpecificMetadataIP(measurement.specificMeasurementMetadata().stream().toList(),
             sampleNameById),
-        measurement.measurementName()
+        measurement.measurementName(),
+        measurement.comment().orElse("")
     );
   }
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookupService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementLookupService.java
@@ -48,6 +48,10 @@ public class MeasurementLookupService {
     return measurementRepository.findNGSMeasurement(measurementId);
   }
 
+  public Optional<ImmunopeptidomicsMeasurement> findIPMeasurement(String measurementCode) {
+    return measurementRepository.findIPMeasurement(measurementCode);
+  }
+
   public Optional<ImmunopeptidomicsMeasurement> findIPMeasurementById(String measurementId) {
     return measurementRepository.findIPMeasurementById(measurementId);
   }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -117,6 +117,10 @@ public class MeasurementService {
     return measurementLookupService.findProteomicsMeasurement(measurementCode);
   }
 
+  public Optional<ImmunopeptidomicsMeasurement> findIPMeasurement(String measurementCode) {
+    return measurementLookupService.findIPMeasurement(measurementCode);
+  }
+
   @PreAuthorize(
       "hasPermission(#projectId, 'life.qbic.projectmanagement.domain.model.project.Project', 'READ')")
   public Optional<ImmunopeptidomicsMeasurement> findIPMeasurementById(String projectId,

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -29,6 +29,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.Measureme
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementSpecificIP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationPxP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 import life.qbic.projectmanagement.application.ontology.TerminologyService;
 import life.qbic.projectmanagement.application.sample.SampleIdCodeEntry;
 import life.qbic.projectmanagement.application.sample.SampleInformationService;
@@ -312,6 +313,11 @@ public class MeasurementService {
     return measurementIdMissing(measurement.measurementId());
   }
 
+  private boolean measurementIdMissing(MeasurementUpdateInformationIP measurement) {
+    Objects.requireNonNull(measurement);
+    return measurementIdMissing(measurement.measurementId());
+  }
+
   private static boolean measurementIdMissing(String measurementId) {
     return measurementId == null || measurementId.isEmpty();
   }
@@ -354,6 +360,97 @@ public class MeasurementService {
     measurementDomain.updateMethod(method);
     measurementDomain.setMeasurementName(measurement.measurementName());
     return measurementDomain;
+  }
+
+  @NonNull
+  private ImmunopeptidomicsMeasurement toDomainUpdate(MeasurementUpdateInformationIP measurement,
+      List<SampleIdCodeEntry> sampleCodeEntries) {
+    Objects.requireNonNull(measurement);
+    if (measurementIdMissing(measurement)) {
+      throw new MeasurementUpdateException(ErrorCode.MISSING_MEASUREMENT_ID);
+    }
+    if (measurementUnknown(measurement)) {
+      throw new MeasurementUpdateException(ErrorCode.UNKNOWN_MEASUREMENT);
+    }
+
+    var measurementDomain = measurementRepository.findIPMeasurement(
+        measurement.measurementId()).orElseThrow();
+    measurementDomain.setSpecificMetadata(
+        convertSpecificMetadataIP(measurement.specificMetadata(), sampleCodeEntries));
+    var organisationQuery = organisationLookupService.organisation(
+        measurement.organisationId());
+    if (organisationQuery.isEmpty()) {
+      throw new MeasurementUpdateException(ErrorCode.UNKNOWN_ORGANISATION_ROR_ID);
+    }
+
+    var msDeviceQuery = resolveOntologyCURI(measurement.instrumentCURIE());
+    if (msDeviceQuery.isEmpty()) {
+      throw new MeasurementUpdateException(ErrorCode.UNKNOWN_ONTOLOGY_TERM);
+    }
+
+    // Extract specific metadata fields from the first entry for method-level metadata
+    var firstSpecific = measurement.specificMetadata().values().iterator().next();
+    var method = new IPMethodMetadata(
+        msDeviceQuery.get(),
+        "",
+        measurement.facility(),
+        parseDoubleOrNull(firstSpecific.sampleMass()),
+        parseDoubleOrNull(firstSpecific.sampleVolume()),
+        firstSpecific.cycleFractionName(),
+        firstSpecific.mhcAntibody(),
+        firstSpecific.mhcTypingMethod(),
+        firstSpecific.enrichmentMethod(),
+        parseLocalDateOrNull(firstSpecific.prepDate()),
+        parseLocalDateOrNull(firstSpecific.msRunDate()),
+        firstSpecific.lcmsMethod(),
+        firstSpecific.lcColumn(),
+        firstSpecific.dataAcquisition(),
+        firstSpecific.massRange(),
+        parseIntegerOrNull(firstSpecific.retentionTimeRange()),
+        firstSpecific.chargeRange(),
+        firstSpecific.ionMobilityRange(),
+        firstSpecific.comment()
+    );
+
+    measurementDomain.setOrganisation(organisationQuery.get());
+    measurementDomain.updateMethod(method);
+    measurementDomain.setMeasurementName(measurement.measurementName());
+    measurementDomain.setSamplePoolGroup(measurement.samplePoolGroup());
+    return measurementDomain;
+  }
+
+  private boolean measurementUnknown(MeasurementUpdateInformationIP measurement) {
+    Objects.requireNonNull(measurement);
+    return measurementRepository.findIPMeasurement(measurement.measurementId()).isEmpty();
+  }
+
+  private void performUpdateIP(MeasurementUpdateInformationIP measurement, String projectId) {
+    Objects.requireNonNull(measurement);
+    var sampleCodeEntries = buildSampleIdCodeEntries(measurement.measuredSamples());
+    var measurementDomain = toDomainUpdate(measurement, sampleCodeEntries);
+    measurementDomainService.updateIPAll(List.of(measurementDomain));
+  }
+
+  @PreAuthorize(
+      "hasPermission(#projectId, 'life.qbic.projectmanagement.domain.model.project.Project', 'WRITE')")
+  public MeasurementUpdateInformationIP updateMeasurementIP(String projectId,
+      MeasurementUpdateInformationIP measurement) throws MeasurementUpdateException {
+    // 1. Setup domain event cache and dispatcher to listen to domain events
+    List<DomainEvent> domainEventsCache = new ArrayList<>();
+    var localDomainEventDispatcher = LocalDomainEventDispatcher.instance();
+    localDomainEventDispatcher.reset();
+    localDomainEventDispatcher.subscribe(
+        new MeasurementUpdatedDomainEventSubscriber(domainEventsCache));
+
+    // 2. Perform actual update
+    performUpdateIP(measurement, projectId);
+
+    // 3. Dispatch domain events
+    domainEventsCache.forEach(
+        domainEvent -> DomainEventDispatcher.instance().dispatch(domainEvent));
+
+    // 4. Return measurement information
+    return measurement;
   }
 
   @PreAuthorize(

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -393,6 +393,9 @@ public class MeasurementService {
     }
 
     // Extract specific metadata fields from the first entry for method-level metadata
+    if (measurement.specificMetadata() == null || measurement.specificMetadata().isEmpty()) {
+      throw new MeasurementUpdateException(ErrorCode.FAILED);
+    }
     var firstSpecific = measurement.specificMetadata().values().iterator().next();
     var method = new IPMethodMetadata(
         msDeviceQuery.get(),

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/MeasurementService.java
@@ -399,7 +399,7 @@ public class MeasurementService {
     var firstSpecific = measurement.specificMetadata().values().iterator().next();
     var method = new IPMethodMetadata(
         msDeviceQuery.get(),
-        "",
+        measurement.instrumentName(),
         measurement.facility(),
         parseDoubleOrNull(firstSpecific.sampleMass()),
         parseDoubleOrNull(firstSpecific.sampleVolume()),
@@ -653,7 +653,7 @@ public class MeasurementService {
 
     var method = new IPMethodMetadata(
         instrumentQuery.get(),
-        "",
+        measurement.instrumentName(),
         measurement.facility(),
         parseDoubleOrNull(firstSpecific.sampleMass()),
         parseDoubleOrNull(firstSpecific.sampleVolume()),

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
@@ -117,6 +117,9 @@ public class MeasurementIPValidator {
     private static final String ROR_ID_REGEX = "^(https?://)?ror\\.org/[0-9a-zA-Z]{9}$";
 
     ValidationResult validateMeasurementCode(String measurementCode) {
+      if (measurementCode == null || measurementCode.isBlank()) {
+        return ValidationResult.successful(); // Skip, handled by validateMandatoryMetadataDataForUpdate
+      }
       var queryMeasurement = measurementService.findIPMeasurement(measurementCode);
       return queryMeasurement.map(measurement -> ValidationResult.successful()).orElse(
           ValidationResult.withFailures(
@@ -167,6 +170,9 @@ public class MeasurementIPValidator {
     }
 
     ValidationResult validateOrganisation(String organisationId) {
+      if (organisationId == null || organisationId.isBlank()) {
+        return ValidationResult.successful(); // Skip, handled by validateMandatoryMetadataDataForUpdate
+      }
       if (Pattern.compile(ROR_ID_REGEX).matcher(organisationId).find()) {
         return ValidationResult.successful();
       }
@@ -175,6 +181,9 @@ public class MeasurementIPValidator {
     }
 
     ValidationResult validateInstrument(String instrument) {
+      if (instrument == null || instrument.isBlank()) {
+        return ValidationResult.successful(); // Skip, handled by validateMandatoryMetadataDataForUpdate
+      }
       var result = terminologyService.findByCurie(instrument);
       if (result.isPresent()) {
         return ValidationResult.successful();
@@ -187,7 +196,7 @@ public class MeasurementIPValidator {
       var validation = ValidationResult.successful();
       if (metadata.measurementId() == null || metadata.measurementId().isEmpty()) {
         validation = validation.combine(ValidationResult.withFailures(
-            List.of("Measurement id: missing measurement id for update")));
+            List.of("Measurement ID: missing measurement ID for update")));
       } else {
         validation = validation.combine(ValidationResult.successful());
       }
@@ -292,6 +301,23 @@ public class MeasurementIPValidator {
         } else if (!Pattern.compile(RANGE_REGEX).matcher(specificMetadata.chargeRange()).matches()) {
           validation = validation.combine(
               ValidationResult.withFailures(List.of("Charge range must be a valid range (e.g. 1-2)")));
+        }
+        // Date validation
+        if (specificMetadata.prepDate() != null && !specificMetadata.prepDate().isBlank()) {
+          try {
+            LocalDate.parse(specificMetadata.prepDate(), DATE_FORMATTER);
+          } catch (DateTimeParseException e) {
+            validation = validation.combine(
+                ValidationResult.withFailures(List.of("Prep Date must be formatted as YYYY-MM-DD")));
+          }
+        }
+        if (specificMetadata.msRunDate() != null && !specificMetadata.msRunDate().isBlank()) {
+          try {
+            LocalDate.parse(specificMetadata.msRunDate(), DATE_FORMATTER);
+          } catch (DateTimeParseException e) {
+            validation = validation.combine(
+                ValidationResult.withFailures(List.of("MS Run Date must be formatted as YYYY-MM-DD")));
+          }
         }
       }
       return validation;

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
@@ -16,6 +16,7 @@ import life.qbic.logging.api.Logger;
 import life.qbic.projectmanagement.application.ProjectInformationService;
 import life.qbic.projectmanagement.application.ValidationResult;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationIP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 import life.qbic.projectmanagement.application.measurement.MeasurementService;
 import life.qbic.projectmanagement.application.ontology.TerminologyService;
 import life.qbic.projectmanagement.application.sample.SampleInformationService;
@@ -85,6 +86,217 @@ public class MeasurementIPValidator {
     result = result.combine(validateInstrument(registration));
     result = result.combine(validateMandatoryFields(registration));
     return result;
+  }
+
+  /**
+   * Validates an immunopeptidomics measurement update request.
+   *
+   * @param update     the measurement update information
+   * @param experimentId the experiment ID
+   * @param projectId   the project ID
+   * @return the validation result
+   * @since 1.11.0
+   */
+  public ValidationResult validateUpdate(MeasurementUpdateInformationIP update,
+      String experimentId, ProjectId projectId) {
+    var validationPolicy = new ValidationPolicy();
+    var result = ValidationResult.successful();
+    for (String sampleId : update.measuredSamples()) {
+      result = result.combine(validationPolicy.validationProjectRelation(sampleId, projectId))
+          .combine(validationPolicy.validationExperimentRelation(sampleId, experimentId, projectId));
+    }
+    return result
+        .combine(validationPolicy.validateMeasurementCode(update.measurementId()))
+        .combine(validationPolicy.validateMandatoryMetadataDataForUpdate(update))
+        .combine(validationPolicy.validateOrganisation(update.organisationId()))
+        .combine(validationPolicy.validateInstrument(update.instrumentCURIE()));
+  }
+
+  private class ValidationPolicy {
+
+    private static final String ROR_ID_REGEX = "^(https?://)?ror\\.org/[0-9a-zA-Z]{9}$";
+
+    ValidationResult validateMeasurementCode(String measurementCode) {
+      var queryMeasurement = measurementService.findIPMeasurementById(
+          null, measurementCode);
+      return queryMeasurement.map(measurement -> ValidationResult.successful()).orElse(
+          ValidationResult.withFailures(
+              List.of(
+                  "Measurement ID: Unknown measurement for id '%s'".formatted(measurementCode))));
+    }
+
+    ValidationResult validationProjectRelation(String sampleId, ProjectId projectId) {
+      if (sampleId.isBlank()) {
+        return ValidationResult.withFailures(
+            List.of("Missing Sample id: No sample identifier was provided."));
+      }
+      SampleCode sampleCode = SampleCode.create(sampleId);
+      var projectQuery = projectInformationService.find(projectId);
+      if (projectQuery.isEmpty()) {
+        log.error("No project information found for projectId: " + projectId);
+        throw new RuntimeException("This should not happen, please try again.");
+      }
+      var experimentIds = projectQuery.get().experiments();
+      var sampleQuery = sampleInformationService.findSampleId(sampleCode).flatMap(
+          sampleIdCodeEntry -> sampleInformationService.findSample(sampleIdCodeEntry.sampleId()));
+      if (sampleQuery.isEmpty()) {
+        return ValidationResult.withFailures(
+            List.of("No sample information found for sample id: %s".formatted(sampleCode.code())));
+      }
+      if (experimentIds.contains(sampleQuery.get().experimentId())) {
+        return ValidationResult.successful();
+      }
+      return ValidationResult.withFailures(
+          List.of("Sample id does not belong to this project: %s".formatted(sampleCode.code())));
+    }
+
+    ValidationResult validationExperimentRelation(String sampleId, String experimentId,
+        ProjectId projectId) {
+      if (sampleId.isBlank()) {
+        return ValidationResult.withFailures(
+            List.of("Missing Sample id: No sample identifier was provided."));
+      }
+      SampleCode sampleCode = SampleCode.create(sampleId);
+      boolean sampleContainedInExperiment = sampleInformationService.retrieveSamplesForExperiment(
+          projectId,
+          experimentId).stream().anyMatch(it -> it.sampleCode().equals(sampleCode));
+      if (sampleContainedInExperiment) {
+        return ValidationResult.successful();
+      }
+      return ValidationResult.withFailures(
+          List.of("Sample id does not belong to this experiment: %s".formatted(sampleCode.code())));
+    }
+
+    ValidationResult validateOrganisation(String organisationId) {
+      if (Pattern.compile(ROR_ID_REGEX).matcher(organisationId).find()) {
+        return ValidationResult.successful();
+      }
+      return ValidationResult.withFailures(
+          List.of("The organisation ID does not seem to be a ROR ID: \"%s\"".formatted(organisationId)));
+    }
+
+    ValidationResult validateInstrument(String instrument) {
+      var result = terminologyService.findByCurie(instrument);
+      if (result.isPresent()) {
+        return ValidationResult.successful();
+      }
+      return ValidationResult.withFailures(
+          List.of("Unknown instrument: " + instrument));
+    }
+
+    ValidationResult validateMandatoryMetadataDataForUpdate(MeasurementUpdateInformationIP metadata) {
+      var validation = ValidationResult.successful();
+      if (metadata.measurementId() == null || metadata.measurementId().isEmpty()) {
+        validation = validation.combine(ValidationResult.withFailures(
+            List.of("Measurement id: missing measurement id for update")));
+      } else {
+        validation = validation.combine(ValidationResult.successful());
+      }
+      if (metadata.organisationId() == null || metadata.organisationId().isBlank()) {
+        validation = validation.combine(
+            ValidationResult.withFailures(List.of("Organisation URL missing mandatory metadata")));
+      } else {
+        validation = validation.combine(ValidationResult.successful());
+      }
+      if (metadata.instrumentCURIE() == null || metadata.instrumentCURIE().isBlank()) {
+        validation = validation.combine(
+            ValidationResult.withFailures(List.of("Instrument missing mandatory metadata")));
+      } else {
+        validation = validation.combine(ValidationResult.successful());
+      }
+      if (metadata.facility() == null || metadata.facility().isBlank()) {
+        validation = validation.combine(
+            ValidationResult.withFailures(List.of("Facility missing mandatory metadata")));
+      } else {
+        validation = validation.combine(ValidationResult.successful());
+      }
+      for (var entry : metadata.specificMetadata().entrySet()) {
+        var specificMetadata = entry.getValue();
+        if (specificMetadata.sampleMass() == null || specificMetadata.sampleMass().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Sample Mass missing mandatory metadata")));
+        } else {
+          try {
+            var value = Double.parseDouble(specificMetadata.sampleMass());
+            if (value < 0) {
+              validation = validation.combine(
+                  ValidationResult.withFailures(List.of("Sample Mass must not be negative")));
+            }
+          } catch (NumberFormatException e) {
+            validation = validation.combine(
+                ValidationResult.withFailures(List.of("Sample Mass must be a valid number")));
+          }
+        }
+        if (specificMetadata.sampleVolume() == null || specificMetadata.sampleVolume().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Sample Volume missing mandatory metadata")));
+        } else {
+          try {
+            var value = Double.parseDouble(specificMetadata.sampleVolume());
+            if (value < 0) {
+              validation = validation.combine(
+                  ValidationResult.withFailures(List.of("Sample Volume must not be negative")));
+            }
+          } catch (NumberFormatException e) {
+            validation = validation.combine(
+                ValidationResult.withFailures(List.of("Sample Volume must be a valid number")));
+          }
+        }
+        if (specificMetadata.mhcAntibody() == null || specificMetadata.mhcAntibody().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("MHC Antibody missing mandatory metadata")));
+        }
+        if (specificMetadata.enrichmentMethod() == null || specificMetadata.enrichmentMethod().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Enrichment method missing mandatory metadata")));
+        }
+        if (specificMetadata.lcmsMethod() == null || specificMetadata.lcmsMethod().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("LCMS Method missing mandatory metadata")));
+        }
+        if (specificMetadata.lcColumn() == null || specificMetadata.lcColumn().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("LC Column missing mandatory metadata")));
+        }
+        if (specificMetadata.dataAcquisition() == null || specificMetadata.dataAcquisition().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Data Acquisition missing mandatory metadata")));
+        }
+        if (specificMetadata.massRange() == null || specificMetadata.massRange().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Mass range missing mandatory metadata")));
+        } else if (!Pattern.compile(RANGE_REGEX).matcher(specificMetadata.massRange()).matches()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Mass range must be a valid range (e.g. 1-2)")));
+        }
+        if (specificMetadata.retentionTimeRange() == null || specificMetadata.retentionTimeRange().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Retention time range missing mandatory metadata")));
+        } else {
+          try {
+            double d = Double.parseDouble(specificMetadata.retentionTimeRange());
+            if (d < 0) {
+              validation = validation.combine(
+                  ValidationResult.withFailures(List.of("Retention time range must not be negative")));
+            } else if (d != (int) d) {
+              validation = validation.combine(
+                  ValidationResult.withFailures(List.of("Retention time range must be a valid integer")));
+            }
+          } catch (NumberFormatException e) {
+            validation = validation.combine(
+                ValidationResult.withFailures(List.of("Retention time range must be a valid integer")));
+          }
+        }
+        if (specificMetadata.chargeRange() == null || specificMetadata.chargeRange().isBlank()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Charge range missing mandatory metadata")));
+        } else if (!Pattern.compile(RANGE_REGEX).matcher(specificMetadata.chargeRange()).matches()) {
+          validation = validation.combine(
+              ValidationResult.withFailures(List.of("Charge range must be a valid range (e.g. 1-2)")));
+        }
+      }
+      return validation;
+    }
   }
 
   private static final String RANGE_REGEX = "^\\d+(\\.\\d+)?\\s*\\-\\s*\\d+(\\.\\d+)?$";

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
@@ -106,7 +106,7 @@ public class MeasurementIPValidator {
           .combine(validationPolicy.validationExperimentRelation(sampleId, experimentId, projectId));
     }
     return result
-        .combine(validationPolicy.validateMeasurementCode(update.measurementId()))
+        .combine(validationPolicy.validateMeasurementCode(projectId, update.measurementId()))
         .combine(validationPolicy.validateMandatoryMetadataDataForUpdate(update))
         .combine(validationPolicy.validateOrganisation(update.organisationId()))
         .combine(validationPolicy.validateInstrument(update.instrumentCURIE()));
@@ -116,9 +116,9 @@ public class MeasurementIPValidator {
 
     private static final String ROR_ID_REGEX = "^(https?://)?ror\\.org/[0-9a-zA-Z]{9}$";
 
-    ValidationResult validateMeasurementCode(String measurementCode) {
+    ValidationResult validateMeasurementCode(ProjectId projectId, String measurementCode) {
       var queryMeasurement = measurementService.findIPMeasurementById(
-          null, measurementCode);
+          projectId.value(), measurementCode);
       return queryMeasurement.map(measurement -> ValidationResult.successful()).orElse(
           ValidationResult.withFailures(
               List.of(

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidator.java
@@ -106,7 +106,7 @@ public class MeasurementIPValidator {
           .combine(validationPolicy.validationExperimentRelation(sampleId, experimentId, projectId));
     }
     return result
-        .combine(validationPolicy.validateMeasurementCode(projectId, update.measurementId()))
+        .combine(validationPolicy.validateMeasurementCode(update.measurementId()))
         .combine(validationPolicy.validateMandatoryMetadataDataForUpdate(update))
         .combine(validationPolicy.validateOrganisation(update.organisationId()))
         .combine(validationPolicy.validateInstrument(update.instrumentCURIE()));
@@ -116,9 +116,8 @@ public class MeasurementIPValidator {
 
     private static final String ROR_ID_REGEX = "^(https?://)?ror\\.org/[0-9a-zA-Z]{9}$";
 
-    ValidationResult validateMeasurementCode(ProjectId projectId, String measurementCode) {
-      var queryMeasurement = measurementService.findIPMeasurementById(
-          projectId.value(), measurementCode);
+    ValidationResult validateMeasurementCode(String measurementCode) {
+      var queryMeasurement = measurementService.findIPMeasurement(measurementCode);
       return queryMeasurement.map(measurement -> ValidationResult.successful()).orElse(
           ValidationResult.withFailures(
               List.of(

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementValidationService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/measurement/validation/MeasurementValidationService.java
@@ -6,6 +6,7 @@ import life.qbic.projectmanagement.application.api.AsyncProjectService.Measureme
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationPxP;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationNGS;
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationPxP;
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -68,6 +69,12 @@ public class MeasurementValidationService {
   public ValidationResult validateIP(MeasurementRegistrationInformationIP registration,
       String experimentId, ProjectId projectId) {
     return measurementIpValidator.validateRegistration(registration, experimentId, projectId);
+  }
+
+  @PreAuthorize("hasPermission(#projectId, 'life.qbic.projectmanagement.domain.model.project.Project', 'WRITE')")
+  public ValidationResult validateIP(MeasurementUpdateInformationIP update, String experimentId,
+      ProjectId projectId) {
+    return measurementIpValidator.validateUpdate(update, experimentId, projectId);
   }
 
   public enum Domain {

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidatorSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidatorSpec.groovy
@@ -2,6 +2,7 @@ package life.qbic.projectmanagement.application.measurement.validation
 
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementRegistrationInformationIP
 import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementSpecificIP
+import life.qbic.projectmanagement.application.api.AsyncProjectService.MeasurementUpdateInformationIP
 import life.qbic.projectmanagement.application.ProjectInformationService
 import life.qbic.projectmanagement.application.measurement.MeasurementService
 import life.qbic.projectmanagement.application.ontology.OntologyClass
@@ -11,6 +12,7 @@ import life.qbic.projectmanagement.application.sample.SampleInformationService
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentId
 import life.qbic.projectmanagement.domain.model.project.Project
 import life.qbic.projectmanagement.domain.model.project.ProjectId
+import life.qbic.projectmanagement.domain.model.measurement.ImmunopeptidomicsMeasurement
 import life.qbic.projectmanagement.domain.model.sample.Sample
 import life.qbic.projectmanagement.domain.model.sample.SampleCode
 import life.qbic.projectmanagement.domain.model.sample.SampleId
@@ -95,7 +97,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -134,7 +138,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -192,7 +198,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -238,7 +246,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -284,7 +294,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -330,7 +342,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -387,7 +401,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -453,7 +469,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -518,7 +536,9 @@ class MeasurementIPValidatorSpec extends Specification {
                 experiments() >> [experimentId]
             })
         }
-        def measurementService = Mock(MeasurementService)
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
 
         def validator = new MeasurementIPValidator(
                 sampleInformationService, terminologyService, projectInformationService, measurementService
@@ -579,6 +599,336 @@ class MeasurementIPValidatorSpec extends Specification {
                 "2-4",
                 "0.6-1.6",
                 "Test comment"
+        )
+    }
+
+    // --- validateUpdate tests ---
+
+    def "Given a valid IP update, validateUpdate returns a successful result"() {
+        given:
+        def experimentId = ExperimentId.create()
+        def projectId = ProjectId.create()
+        def sampleMock = Mock(Sample)
+        sampleMock.experimentId() >> experimentId
+        def sampleInformationService = Mock(SampleInformationService) {
+            findSampleId(SampleCode.create("QTEST001AE")) >> Optional.of(
+                    new SampleIdCodeEntry(SampleId.create(), SampleCode.create("QTEST001AE"))
+            )
+            findSample(_) >> Optional.of(sampleMock)
+            retrieveSamplesForExperiment(projectId, experimentId.value()) >> {
+                def sample = Mock(Sample)
+                sample.sampleCode() >> SampleCode.create("QTEST001AE")
+                [sample]
+            }
+        }
+        def terminologyService = Mock(TerminologyService) {
+            findByCurie("EFO:0008637") >> Optional.of(validInstrument)
+        }
+        def projectMock = Mock(Project) {
+            experiments() >> [experimentId]
+        }
+        def projectInformationService = Mock(ProjectInformationService) {
+            find(projectId) >> Optional.of(projectMock)
+        }
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement("IP-001") >> Optional.of(Mock(ImmunopeptidomicsMeasurement))
+        }
+
+        def validator = new MeasurementIPValidator(
+                sampleInformationService, terminologyService, projectInformationService, measurementService
+        )
+
+        def update = createValidUpdate()
+
+        when:
+        def result = validator.validateUpdate(update, experimentId.value(), projectId)
+
+        then:
+        result.allPassed()
+        result.failures().isEmpty()
+    }
+
+    def "Given an IP update with blank measurement id, validateUpdate returns failure"() {
+        given:
+        def experimentId = ExperimentId.create()
+        def projectId = ProjectId.create()
+        def sampleMock = Mock(Sample)
+        sampleMock.experimentId() >> experimentId
+        def sampleInformationService = Mock(SampleInformationService) {
+            findSampleId(SampleCode.create("QTEST001AE")) >> Optional.of(
+                    new SampleIdCodeEntry(SampleId.create(), SampleCode.create("QTEST001AE"))
+            )
+            findSample(_) >> Optional.of(sampleMock)
+            retrieveSamplesForExperiment(projectId, experimentId.value()) >> {
+                def sample = Mock(Sample)
+                sample.sampleCode() >> SampleCode.create("QTEST001AE")
+                [sample]
+            }
+        }
+        def terminologyService = Mock(TerminologyService) {
+            findByCurie("EFO:0008637") >> Optional.of(validInstrument)
+        }
+        def projectMock = Mock(Project) {
+            experiments() >> [experimentId]
+        }
+        def projectInformationService = Mock(ProjectInformationService) {
+            find(projectId) >> Optional.of(projectMock)
+        }
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement(_) >> Optional.empty()
+        }
+
+        def validator = new MeasurementIPValidator(
+                sampleInformationService, terminologyService, projectInformationService, measurementService
+        )
+
+        def update = new MeasurementUpdateInformationIP(
+                "", // blank measurement id
+                "https://ror.org/03a1kwz48",
+                "EFO:0008637",
+                "QBiC",
+                "",
+                Map.of("QTEST001AE", createValidSpecific()),
+                "MS Run 1"
+        )
+
+        when:
+        def result = validator.validateUpdate(update, experimentId.value(), projectId)
+
+        then:
+        !result.allPassed()
+        result.failures().contains("Measurement id: missing measurement id for update")
+    }
+
+    def "Given an IP update with unknown measurement code, validateUpdate returns failure"() {
+        given:
+        def experimentId = ExperimentId.create()
+        def projectId = ProjectId.create()
+        def sampleMock = Mock(Sample)
+        sampleMock.experimentId() >> experimentId
+        def sampleInformationService = Mock(SampleInformationService) {
+            findSampleId(SampleCode.create("QTEST001AE")) >> Optional.of(
+                    new SampleIdCodeEntry(SampleId.create(), SampleCode.create("QTEST001AE"))
+            )
+            findSample(_) >> Optional.of(sampleMock)
+            retrieveSamplesForExperiment(projectId, experimentId.value()) >> {
+                def sample = Mock(Sample)
+                sample.sampleCode() >> SampleCode.create("QTEST001AE")
+                [sample]
+            }
+        }
+        def terminologyService = Mock(TerminologyService) {
+            findByCurie("EFO:0008637") >> Optional.of(validInstrument)
+        }
+        def projectMock = Mock(Project) {
+            experiments() >> [experimentId]
+        }
+        def projectInformationService = Mock(ProjectInformationService) {
+            find(projectId) >> Optional.of(projectMock)
+        }
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement("UNKNOWN") >> Optional.empty()
+        }
+
+        def validator = new MeasurementIPValidator(
+                sampleInformationService, terminologyService, projectInformationService, measurementService
+        )
+
+        def update = new MeasurementUpdateInformationIP(
+                "UNKNOWN",
+                "https://ror.org/03a1kwz48",
+                "EFO:0008637",
+                "QBiC",
+                "",
+                Map.of("QTEST001AE", createValidSpecific()),
+                "MS Run 1"
+        )
+
+        when:
+        def result = validator.validateUpdate(update, experimentId.value(), projectId)
+
+        then:
+        !result.allPassed()
+        result.failures().any { it.contains("Unknown measurement for id 'UNKNOWN'") }
+    }
+
+    def "Given an IP update with missing mandatory fields, validateUpdate returns failures"() {
+        given:
+        def experimentId = ExperimentId.create()
+        def projectId = ProjectId.create()
+        def sampleMock = Mock(Sample)
+        sampleMock.experimentId() >> experimentId
+        def sampleInformationService = Mock(SampleInformationService) {
+            findSampleId(SampleCode.create("QTEST001AE")) >> Optional.of(
+                    new SampleIdCodeEntry(SampleId.create(), SampleCode.create("QTEST001AE"))
+            )
+            findSample(_) >> Optional.of(sampleMock)
+            retrieveSamplesForExperiment(projectId, experimentId.value()) >> {
+                def sample = Mock(Sample)
+                sample.sampleCode() >> SampleCode.create("QTEST001AE")
+                [sample]
+            }
+        }
+        def terminologyService = Mock(TerminologyService) {
+            findByCurie("EFO:0008637") >> Optional.of(validInstrument)
+        }
+        def projectMock = Mock(Project) {
+            experiments() >> [experimentId]
+        }
+        def projectInformationService = Mock(ProjectInformationService) {
+            find(projectId) >> Optional.of(projectMock)
+        }
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement("IP-001") >> Optional.of(Mock(ImmunopeptidomicsMeasurement))
+        }
+
+        def validator = new MeasurementIPValidator(
+                sampleInformationService, terminologyService, projectInformationService, measurementService
+        )
+
+        def blankSpecific = new MeasurementSpecificIP(
+                "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""
+        )
+        def update = new MeasurementUpdateInformationIP(
+                "IP-001",
+                "https://ror.org/03a1kwz48",
+                "EFO:0008637",
+                "QBiC",
+                "",
+                Map.of("QTEST001AE", blankSpecific),
+                "MS Run 1"
+        )
+
+        when:
+        def result = validator.validateUpdate(update, experimentId.value(), projectId)
+
+        then:
+        !result.allPassed()
+        result.failures().contains("Sample Mass missing mandatory metadata")
+        result.failures().contains("Sample Volume missing mandatory metadata")
+        result.failures().contains("MHC Antibody missing mandatory metadata")
+        result.failures().contains("Enrichment method missing mandatory metadata")
+        result.failures().contains("LCMS Method missing mandatory metadata")
+        result.failures().contains("LC Column missing mandatory metadata")
+        result.failures().contains("Data Acquisition missing mandatory metadata")
+        result.failures().contains("Mass range missing mandatory metadata")
+        result.failures().contains("Retention time range missing mandatory metadata")
+        result.failures().contains("Charge range missing mandatory metadata")
+    }
+
+    def "Given an IP update with unknown instrument, validateUpdate returns instrument failure"() {
+        given:
+        def experimentId = ExperimentId.create()
+        def projectId = ProjectId.create()
+        def sampleMock = Mock(Sample)
+        sampleMock.experimentId() >> experimentId
+        def sampleInformationService = Mock(SampleInformationService) {
+            findSampleId(SampleCode.create("QTEST001AE")) >> Optional.of(
+                    new SampleIdCodeEntry(SampleId.create(), SampleCode.create("QTEST001AE"))
+            )
+            findSample(_) >> Optional.of(sampleMock)
+            retrieveSamplesForExperiment(projectId, experimentId.value()) >> {
+                def sample = Mock(Sample)
+                sample.sampleCode() >> SampleCode.create("QTEST001AE")
+                [sample]
+            }
+        }
+        def terminologyService = Mock(TerminologyService) {
+            findByCurie("UNKNOWN:12345") >> Optional.empty()
+        }
+        def projectMock = Mock(Project) {
+            experiments() >> [experimentId]
+        }
+        def projectInformationService = Mock(ProjectInformationService) {
+            find(projectId) >> Optional.of(projectMock)
+        }
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement("IP-001") >> Optional.of(Mock(ImmunopeptidomicsMeasurement))
+        }
+
+        def validator = new MeasurementIPValidator(
+                sampleInformationService, terminologyService, projectInformationService, measurementService
+        )
+
+        def update = new MeasurementUpdateInformationIP(
+                "IP-001",
+                "https://ror.org/03a1kwz48",
+                "UNKNOWN:12345",
+                "QBiC",
+                "",
+                Map.of("QTEST001AE", createValidSpecific()),
+                "MS Run 1"
+        )
+
+        when:
+        def result = validator.validateUpdate(update, experimentId.value(), projectId)
+
+        then:
+        !result.allPassed()
+        result.failures().contains("Unknown instrument: UNKNOWN:12345")
+    }
+
+    def "Given an IP update with invalid ROR organisation, validateUpdate returns ROR format failure"() {
+        given:
+        def experimentId = ExperimentId.create()
+        def projectId = ProjectId.create()
+        def sampleMock = Mock(Sample)
+        sampleMock.experimentId() >> experimentId
+        def sampleInformationService = Mock(SampleInformationService) {
+            findSampleId(SampleCode.create("QTEST001AE")) >> Optional.of(
+                    new SampleIdCodeEntry(SampleId.create(), SampleCode.create("QTEST001AE"))
+            )
+            findSample(_) >> Optional.of(sampleMock)
+            retrieveSamplesForExperiment(projectId, experimentId.value()) >> {
+                def sample = Mock(Sample)
+                sample.sampleCode() >> SampleCode.create("QTEST001AE")
+                [sample]
+            }
+        }
+        def terminologyService = Mock(TerminologyService) {
+            findByCurie("EFO:0008637") >> Optional.of(validInstrument)
+        }
+        def projectMock = Mock(Project) {
+            experiments() >> [experimentId]
+        }
+        def projectInformationService = Mock(ProjectInformationService) {
+            find(projectId) >> Optional.of(projectMock)
+        }
+        def measurementService = Mock(MeasurementService) {
+            findIPMeasurement("IP-001") >> Optional.of(Mock(ImmunopeptidomicsMeasurement))
+        }
+
+        def validator = new MeasurementIPValidator(
+                sampleInformationService, terminologyService, projectInformationService, measurementService
+        )
+
+        def update = new MeasurementUpdateInformationIP(
+                "IP-001",
+                "not-a-ror-id",
+                "EFO:0008637",
+                "QBiC",
+                "",
+                Map.of("QTEST001AE", createValidSpecific()),
+                "MS Run 1"
+        )
+
+        when:
+        def result = validator.validateUpdate(update, experimentId.value(), projectId)
+
+        then:
+        !result.allPassed()
+        result.failures().any { it.startsWith("The organisation ID does not seem to be a ROR ID") }
+    }
+
+    private static MeasurementUpdateInformationIP createValidUpdate() {
+        return new MeasurementUpdateInformationIP(
+                "IP-001",
+                "https://ror.org/03a1kwz48",
+                "EFO:0008637",
+                "QBiC",
+                "",
+                Map.of("QTEST001AE", createValidSpecific()),
+                "MS Run 1"
         )
     }
 }

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidatorSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/measurement/validation/MeasurementIPValidatorSpec.groovy
@@ -153,6 +153,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", blankSpecific),
@@ -209,6 +210,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "", // blank instrument
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -257,6 +259,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "UNKNOWN:12345",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -305,6 +308,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "", // blank organisation
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -353,6 +357,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "not-a-ror-id",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -371,6 +376,7 @@ class MeasurementIPValidatorSpec extends Specification {
         return new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -430,6 +436,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "QBiC Facility",
                 Map.of("QTEST001AE", specific),
@@ -498,6 +505,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "QBiC Facility",
                 Map.of("QTEST001AE", specific),
@@ -565,6 +573,7 @@ class MeasurementIPValidatorSpec extends Specification {
         def registration = new MeasurementRegistrationInformationIP(
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "QBiC Facility",
                 Map.of("QTEST001AE", specific),
@@ -686,6 +695,7 @@ class MeasurementIPValidatorSpec extends Specification {
                 "", // blank measurement id
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -697,7 +707,7 @@ class MeasurementIPValidatorSpec extends Specification {
 
         then:
         !result.allPassed()
-        result.failures().contains("Measurement id: missing measurement id for update")
+        result.failures().contains("Measurement ID: missing measurement ID for update")
     }
 
     def "Given an IP update with unknown measurement code, validateUpdate returns failure"() {
@@ -738,6 +748,7 @@ class MeasurementIPValidatorSpec extends Specification {
                 "UNKNOWN",
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -793,6 +804,7 @@ class MeasurementIPValidatorSpec extends Specification {
                 "IP-001",
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", blankSpecific),
@@ -854,6 +866,7 @@ class MeasurementIPValidatorSpec extends Specification {
                 "IP-001",
                 "https://ror.org/03a1kwz48",
                 "UNKNOWN:12345",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -906,6 +919,7 @@ class MeasurementIPValidatorSpec extends Specification {
                 "IP-001",
                 "not-a-ror-id",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),
@@ -925,6 +939,7 @@ class MeasurementIPValidatorSpec extends Specification {
                 "IP-001",
                 "https://ror.org/03a1kwz48",
                 "EFO:0008637",
+                "",
                 "QBiC",
                 "",
                 Map.of("QTEST001AE", createValidSpecific()),


### PR DESCRIPTION
## Summary

Implements immunopeptidomics measurement editing following the same parallel-stack pattern used by NGS and Proteomics edit flows.

## Changes

### Domain & Application Layer
- **AsyncProjectService**: Added  record with measurementId, organisationId, instrumentCURIE, facility, samplePoolGroup, specificMetadata, and measurementName. Extended  and  sealed interfaces.
- **MeasurementService**: Added , ,  for ImmunopeptidomicsMeasurement updates with validation (missing ID, unknown measurement, org/instrument lookup).
- **MeasurementIPValidator**: Added  with  inner class validating measurementId, organisation, instrument, and all mandatory IP fields.
- **MeasurementValidationService**: Added  overload for  updates.
- **AsyncProjectServiceImpl**: Wired IP update case in  and  switches.

### UI Layer
- **IPMeasurementEditColumn**: New column enum (25 columns: Measurement ID, QBiC Sample Id, Sample Name, etc.)
- **MeasurementUpdateMetadataConverterIP**: New converter parsing Excel rows into .
- **MeasurementUpdateProcessorIP**: New processor grouping by measurementId and merging pooled IP measurements.
- **ConverterRegistry / ProcessorRegistry**: Registered new IP update classes.
- **MeasurementUpload**: Added case for .
- **MeasurementDetailsComponent**: Added  event with , plus Edit button on IP grid.
- **MeasurementMain**: Added  wired to , extended  with IP support.

## Testing
All tests pass (160 project-management, 29 datamanager-app).

## Requirements
- MEASUREMENT-R-02

## Story
- #1429 (Edit Immunopeptidomics Measurements via Pre-filled Excel Template)
- Parent Feature: #1412
- Corresponding Task: #1414