### PR TITLE
Fixes #1430: Implement deletion guard and OpenBIS sync for Immunopeptidomics measurements

### DIFF
--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/measurements/MeasurementMain.java
@@ -357,21 +357,21 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
     var result = measurementService.deleteNgsMeasurements(context.projectId().orElseThrow(),
         measurementIds);
     result.onError(this::handleDeletionError);
-    result.onValue(ignored -> handleDeletionSuccessNgs());
+    result.onValue(ignored -> handleDeletionSuccessNgs(measurementIds.size()));
   }
 
   private void deletePxpMeasurements(Set<String> measurementIds) {
     var result = measurementService.deletePxpMeasurements(context.projectId().orElseThrow(),
         measurementIds);
     result.onError(this::handleDeletionError);
-    result.onValue(ignored -> handleDeletionSuccessPxp());
+    result.onValue(ignored -> handleDeletionSuccessPxp(measurementIds.size()));
   }
 
   private void deleteIpMeasurements(Set<String> measurementIds) {
     var result = measurementService.deleteIpMeasurements(context.projectId().orElseThrow(),
         measurementIds);
     result.onError(this::handleDeletionError);
-    result.onValue(ignored -> handleDeletionSuccessIp());
+    result.onValue(ignored -> handleDeletionSuccessIp(measurementIds.size()));
   }
 
   private void handleDeletionError(MeasurementDeletionException error) {
@@ -382,19 +382,29 @@ public class MeasurementMain extends Main implements BeforeEnterObserver {
     showErrorNotification("Deletion failed", errorMessage);
   }
 
-  private void handleDeletionSuccessNgs() {
+  private void handleDeletionSuccessNgs(int count) {
+    displayDeletionSuccess(count);
     updateComponentVisibility();
     measurementDetailsComponent.refreshNgs();
   }
 
-  private void handleDeletionSuccessPxp() {
+  private void handleDeletionSuccessPxp(int count) {
+    displayDeletionSuccess(count);
     updateComponentVisibility();
     measurementDetailsComponent.refreshPxp();
   }
 
-  private void handleDeletionSuccessIp() {
+  private void handleDeletionSuccessIp(int count) {
+    displayDeletionSuccess(count);
     updateComponentVisibility();
     measurementDetailsComponent.refreshIp();
+  }
+
+  private void displayDeletionSuccess(int numberOfDeleted) {
+    Toast toast = messageFactory.toast("measurement.deletion.successful",
+        new Object[]{numberOfDeleted},
+        getLocale());
+    toast.open();
   }
 
 

--- a/datamanager-app/src/main/resources/messages/toast-notifications.properties
+++ b/datamanager-app/src/main/resources/messages/toast-notifications.properties
@@ -78,6 +78,9 @@ measurement.update.successful.level=success
 measurement.update.failed.message.type=html
 measurement.update.failed.message.text=Apologies, some updates failed <strong>({0})</strong>. Please contact <a href="mailto:support@qbic.zendesk.com">QBiC support</a>.
 measurement.update.failed.level=error
+measurement.deletion.successful.message.type=html
+measurement.deletion.successful.message.text=Deleted <strong>{0}</strong> measurement(s)
+measurement.deletion.successful.level=success
 measurement.update.in-progress.message.type=html
 measurement.update.in-progress.message.text=Updating measurements...
 measurement.update.in-progress.level=info

--- a/plan-issue-1430.md
+++ b/plan-issue-1430.md
@@ -1,0 +1,212 @@
+# Implementation Plan: Delete Immunopeptidomics Measurements
+
+> **Issue:** [#1430](https://github.com/qbicsoftware/data-manager-app/issues/1430)  
+> **Parent Feature:** [#1412](https://github.com/qbicsoftware/data-manager-app/issues/1412) (FEAT-IMMUNOPEPTIDOMICS-MEASUREMENT)  
+> **Task:** [#1415](https://github.com/qbicsoftware/data-manager-app/issues/1415)  
+> **Requirement IDs:** `MEASUREMENT-R-03`  
+> **Constraint:** `LAB-C-01` (OpenBIS synchronisation required)  
+
+---
+
+## 0. Critical Prerequisite: Merge `origin/development`
+
+**DO NOT IMPLEMENT FROM SCRATCH.** The `origin/development` branch already contains the bulk of the immunopeptidomics scaffolding (Domain model, JPA repositories, Service methods, UI tabs). 
+
+Before making any changes, merge the latest development state into this branch to avoid massive merge conflicts and duplicate work:
+
+```bash
+git checkout development
+git pull origin development
+git checkout issue-1430--story--delete-immunopeptidomics-measurements
+git merge development
+```
+*Resolve any merge conflicts by prioritizing the `development` branch's scaffolding, while preserving your local additions to `MeasurementDataRepo` and `OpenbisConnector`.*
+
+---
+
+## 1. Scope & Acceptance Criteria
+
+| # | Acceptance Criteria | Implementation Mapping |
+|---|---|---|
+| 1 | Given a user with management rights selects immunopeptidomics measurements for deletion, when they confirm, then measurements with no attached dataset are deleted successfully. | Ensure `deleteAllIP` checks `hasDataAttached` → deletes from JPA → deletes from OpenBIS → dispatches `ProjectChanged`. |
+| 2 | Given a user with management rights deletes an immunopeptidomics measurement with an attached dataset, the deletion must fail and the user shall be informed to delete the raw datasets first. | Throw `MeasurementDeletionException(DeletionErrorCode.DATA_ATTACHED)` before any mutations. UI already handles this generically. |
+| 3 | Given a user with view-only rights views the measurement page, they shall not be able to delete measurements. | Already enforced by `@PreAuthorize("WRITE")` on `MeasurementService.deleteIpMeasurements`. |
+
+---
+
+## 2. Current State Analysis (Post-Merge)
+
+After merging `origin/development`, the following will **already exist** and require **no changes**:
+- ✅ `MeasurementCode.MEASUREMENT_PREFIX.IP` + `createIP()` + `isIPDomain()`
+- ✅ `ImmunopeptidomicsMeasurement` domain aggregate
+- ✅ `ImmunopeptidomicsMeasurementJpaRepo` + JPA entities
+- ✅ `MeasurementRepository.deleteAllIP()` signature
+- ✅ `MeasurementDomainService.deleteIpById()`
+- ✅ `MeasurementService.deleteIpMeasurements()` with `@PreAuthorize(WRITE)`
+- ✅ UI: IP tab in `MeasurementDetailsComponent`, deletion event wiring in `MeasurementMain`
+- ✅ DB Schema: `ip_measurements` tables
+
+### 🚨 The Gap to Fix
+Inspection of `origin/development` reveals that `MeasurementRepositoryImplementation.deleteAllIP` currently **skips the dataset guard** and **does not sync with OpenBIS**:
+```java
+// Current broken state in development:
+// IP measurements don't have data in OpenBIS, so skip the hasDataAttached check
+ipMeasurementJpaRepo.deleteAll(matchingMeasurements);
+```
+This violates Acceptance Criteria #1 and #2, and Constraint `LAB-C-01`. **This is the sole focus of this story.**
+
+---
+
+## 3. Implementation Steps (Post-Merge)
+
+### Step 1: Verify/Update `MeasurementDataRepo`
+**File:** `project-management-infrastructure/.../experiment/measurement/MeasurementDataRepo.java`
+
+Ensure this method exists (you may have already added it locally):
+```java
+void deleteImmunopeptidomicsMeasurements(List<ImmunopeptidomicsMeasurement> measurements);
+```
+*(Note: `hasDataAttached(List<MeasurementCode>)` requires **no changes**; it is already measurement-type-agnostic.)*
+
+### Step 2: Implement OpenBIS Deletion Sync
+**File 1:** `project-management-infrastructure/.../sample/openbis/OpenbisConnector.java`
+
+Ensure this method exists and delegates to the generic helper:
+```java
+@Override
+public void deleteImmunopeptidomicsMeasurements(List<ImmunopeptidomicsMeasurement> measurements) {
+  deleteMeasurements(measurements.stream().map(ImmunopeptidomicsMeasurement::measurementCode).toList());
+}
+```
+
+**File 2:** `project-management-infrastructure/.../sample/openbis/MockConnector.java`
+
+Ensure the no-op stub exists for the development profile:
+```java
+@Override
+public void deleteImmunopeptidomicsMeasurements(List<ImmunopeptidomicsMeasurement> measurements) {
+  // No-op for development profile
+}
+```
+
+### Step 3: Fix `MeasurementRepositoryImplementation.deleteAllIP` (CRITICAL)
+**File:** `project-management-infrastructure/.../experiment/measurement/MeasurementRepositoryImplementation.java`
+
+**Replace** the current broken implementation with the guarded pattern that mirrors `deleteAllNgs` / `deleteAllProteomics`:
+
+```java
+@Override
+public void deleteAllIP(Set<String> measurementIds) {
+  if (measurementIds.isEmpty()) {
+    return;
+  }
+  List<ImmunopeptidomicsMeasurement> matchingMeasurements = ipMeasurementJpaRepo.findAllById(
+      measurementIds.stream().map(MeasurementId::parse).collect(Collectors.toSet()));
+  
+  // FIX: Enforce dataset guard per Story #1430 Acceptance Criteria
+  if (measurementDataRepo.hasDataAttached(
+      matchingMeasurements.stream().map(ImmunopeptidomicsMeasurement::measurementCode).toList())) {
+    throw new MeasurementDeletionException(DeletionErrorCode.DATA_ATTACHED);
+  }
+  
+  try {
+    deleteAllIP(matchingMeasurements);
+  } catch (Exception e) {
+    log.error("IP Measurement deletion failed due to " + e.getMessage());
+    throw new MeasurementDeletionException(DeletionErrorCode.FAILED);
+  }
+}
+
+private void deleteAllIP(List<ImmunopeptidomicsMeasurement> measurements) {
+  ipMeasurementJpaRepo.deleteAll(measurements);
+  // FIX: Ensure OpenBIS synchronisation (LAB-C-01)
+  measurementDataRepo.deleteImmunopeptidomicsMeasurements(measurements);
+}
+```
+
+### Step 4: Verify UI Error Handling (No Code Changes Required)
+**File:** `datamanager-app/.../views/projects/project/measurements/MeasurementMain.java`
+
+The existing `handleDeletionError` method already handles this generically:
+```java
+private void handleDeletionError(MeasurementDeletionException error) {
+  String errorMessage = switch (error.reason()) {
+    case FAILED -> "Deletion failed. Please try again.";
+    case DATA_ATTACHED -> "Data is attached to one or more measurements."; // Matches AC
+  };
+  showErrorNotification("Deletion failed", errorMessage);
+}
+```
+✅ **Action:** Just verify via manual testing that this toast appears when attempting to delete an IP measurement with attached data.
+
+---
+
+## 4. File Inventory (Post-Merge)
+
+### Files to Modify
+| # | Path | Change |
+|---|---|---|
+| 1 | `MeasurementDataRepo.java` | Ensure `deleteImmunopeptidomicsMeasurements` is declared. |
+| 2 | `OpenbisConnector.java` | Ensure `deleteImmunopeptidomicsMeasurements` delegates to `deleteMeasurements`. |
+| 3 | `MockConnector.java` | Ensure no-op stub exists. |
+| 4 | `MeasurementRepositoryImplementation.java` | **CRITICAL:** Add `hasDataAttached` guard and OpenBIS deletion call. |
+
+### Files Already Complete (No Action Required Post-Merge)
+- ✅ `MeasurementCode.java`
+- ✅ `ImmunopeptidomicsMeasurement.java`
+- ✅ `ImmunopeptidomicsMeasurementJpaRepo.java`
+- ✅ `MeasurementRepository.java`
+- ✅ `MeasurementDomainService.java`
+- ✅ `MeasurementService.java`
+- ✅ `MeasurementMain.java` / `MeasurementDetailsComponent.java`
+- ✅ `sql/complete-schema.sql`
+
+---
+
+## 5. Testing Plan
+
+### Unit Tests (Spock)
+- **`MeasurementRepositoryImplementationSpec`**:
+  - `def "deleteAllIP throws DATA_ATTACHED when measurements have attached data"` → Mock `measurementDataRepo.hasDataAttached` to return `true`, assert exception thrown, assert **no** JPA/OpenBIS deletion calls are made.
+  - `def "deleteAllIP deletes from JPA and OpenBIS when no data attached"` → Mock `hasDataAttached` to return `false`, verify `ipMeasurementJpaRepo.deleteAll` and `measurementDataRepo.deleteImmunopeptidomicsMeasurements` are invoked exactly once.
+
+### Manual / UI Verification
+1. Log in as a project manager.
+2. Navigate to an experiment with an immunopeptidomics measurement.
+3. Ensure Raw Data exists for that measurement.
+4. Select the measurement, click "Delete", and confirm.
+5. **Expected:** Red error toast: *"Deletion failed: Data is attached to one or more measurements."*
+6. Delete the raw data via the Raw Data tab.
+7. Repeat deletion.
+8. **Expected:** Green success toast, measurement disappears from the grid.
+
+---
+
+## 6. Constraints & Guardrails
+
+| Constraint | How Addressed |
+|---|---|
+| **AC: Deletion must fail if dataset attached** | `MeasurementRepositoryImplementation.deleteAllIP` now explicitly calls `hasDataAttached(...)` **before** any mutations. |
+| **LAB-C-01: OpenBIS synchronisation** | `deleteAllIP` now calls `measurementDataRepo.deleteImmunopeptidomicsMeasurements(...)`, triggering `OpenbisConnector`. |
+| **Security: WRITE permission required** | Already enforced by `@PreAuthorize` on `MeasurementService.deleteIpMeasurements`. |
+| **Exception Handling: No silent swallowing** | Existing pattern maintained: catch block logs error and wraps in `MeasurementDeletionException(FAILED)`. |
+
+---
+
+## 7. Traceability & PR Checklist
+
+```
+PRD §<immunopeptidomics lifecycle>
+  └── Feature #1412 (FEAT-IMMUNOPEPTIDOMICS-MEASUREMENT)
+        └── Story #1430 (Delete Immunopeptidomics Measurements)
+              └── Task #1415 (Implement deletion with dataset guard)
+                    └── Implementation (this plan)
+```
+
+**PR Checklist:**
+- [ ] **Merge `origin/development` into this branch before starting.**
+- [ ] Reference Issue #1430 and Task #1415 in PR description.
+- [ ] Explicitly note in PR description: *"Fixes regression in development where IP deletion skipped the dataset guard and OpenBIS sync."*
+- [ ] List requirement IDs addressed: `MEASUREMENT-R-03`, `LAB-C-01`.
+- [ ] Run `./mvnw clean verify` (unit + integration tests).
+- [ ] Ensure SonarCloud quality gate passes.

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementDataRepo.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementDataRepo.java
@@ -8,6 +8,7 @@ import life.qbic.projectmanagement.domain.model.measurement.MeasurementCode;
 import life.qbic.projectmanagement.domain.model.measurement.ImmunopeptidomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.NGSMeasurement;
 import life.qbic.projectmanagement.domain.model.measurement.ProteomicsMeasurement;
+import life.qbic.projectmanagement.domain.model.measurement.ImmunopeptidomicsMeasurement;
 import life.qbic.projectmanagement.domain.model.sample.SampleCode;
 
 /**
@@ -27,6 +28,7 @@ public interface MeasurementDataRepo {
 
   void deleteProteomicsMeasurements(List<ProteomicsMeasurement> measurements);
   void deleteNGSMeasurements(List<NGSMeasurement> measurements);
+  void deleteImmunopeptidomicsMeasurements(List<ImmunopeptidomicsMeasurement> measurements);
 
   void saveAllProteomics(
       Map<ProteomicsMeasurement, Collection<SampleIdCodeEntry>> proteomicsMeasurementsMapping);

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementation.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementation.java
@@ -307,7 +307,17 @@ public class MeasurementRepositoryImplementation implements MeasurementRepositor
         measurementIds.stream().map(MeasurementId::parse).collect(Collectors.toSet()));
     // IP measurements don't have data in OpenBIS, so skip the hasDataAttached check
     try {
-      ipMeasurementJpaRepo.deleteAll(matchingMeasurements);
+      if (measurementDataRepo.hasDataAttached(
+      matchingMeasurements.stream().map(ImmunopeptidomicsMeasurement::measurementCode).toList())) {
+    throw new MeasurementDeletionException(DeletionErrorCode.DATA_ATTACHED);
+  }
+  
+  try {
+    deleteAllIP(matchingMeasurements);
+  } catch (Exception e) {
+    log.error("IP Measurement deletion failed due to " + e.getMessage());
+    throw new MeasurementDeletionException(DeletionErrorCode.FAILED);
+  }
     } catch (Exception e) {
       log.error("IP Measurement deletion failed due to " + e.getMessage());
       throw new MeasurementDeletionException(DeletionErrorCode.FAILED);

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementation.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementation.java
@@ -305,23 +305,23 @@ public class MeasurementRepositoryImplementation implements MeasurementRepositor
     }
     List<ImmunopeptidomicsMeasurement> matchingMeasurements = ipMeasurementJpaRepo.findAllById(
         measurementIds.stream().map(MeasurementId::parse).collect(Collectors.toSet()));
-    // IP measurements don't have data in OpenBIS, so skip the hasDataAttached check
+    
+    if (measurementDataRepo.hasDataAttached(
+        matchingMeasurements.stream().map(ImmunopeptidomicsMeasurement::measurementCode).toList())) {
+      throw new MeasurementDeletionException(DeletionErrorCode.DATA_ATTACHED);
+    }
+    
     try {
-      if (measurementDataRepo.hasDataAttached(
-      matchingMeasurements.stream().map(ImmunopeptidomicsMeasurement::measurementCode).toList())) {
-    throw new MeasurementDeletionException(DeletionErrorCode.DATA_ATTACHED);
-  }
-  
-  try {
-    deleteAllIP(matchingMeasurements);
-  } catch (Exception e) {
-    log.error("IP Measurement deletion failed due to " + e.getMessage());
-    throw new MeasurementDeletionException(DeletionErrorCode.FAILED);
-  }
+      deleteAllIP(matchingMeasurements);
     } catch (Exception e) {
       log.error("IP Measurement deletion failed due to " + e.getMessage());
       throw new MeasurementDeletionException(DeletionErrorCode.FAILED);
     }
+  }
+
+  private void deleteAllIP(List<ImmunopeptidomicsMeasurement> measurements) {
+    ipMeasurementJpaRepo.deleteAll(measurements);
+    measurementDataRepo.deleteImmunopeptidomicsMeasurements(measurements);
   }
 
   @Override

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/MockConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/MockConnector.java
@@ -91,6 +91,11 @@ public class MockConnector implements QbicProjectDataRepo, SampleDataRepository,
   }
 
   @Override
+  public void deleteImmunopeptidomicsMeasurements(List<ImmunopeptidomicsMeasurement> measurements) {
+    logWarning();
+  }
+
+  @Override
   public void saveAllProteomics(
       Map<ProteomicsMeasurement, Collection<SampleIdCodeEntry>> proteomicsMeasurementsMapping) {
     logWarning();

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/sample/openbis/OpenbisConnector.java
@@ -499,6 +499,11 @@ public class OpenbisConnector implements QbicProjectDataRepo, SampleDataReposito
     deleteMeasurements(measurements.stream().map(NGSMeasurement::measurementCode).toList());
   }
 
+  @Override
+  public void deleteImmunopeptidomicsMeasurements(List<ImmunopeptidomicsMeasurement> measurements) {
+    deleteMeasurements(measurements.stream().map(ImmunopeptidomicsMeasurement::measurementCode).toList());
+  }
+
   private void deleteMeasurements(List<MeasurementCode> measurementCodes) {
     for (MeasurementCode code : measurementCodes) {
       String sampleCode = code.value();

--- a/test-project-management-infrastructure-specs.md
+++ b/test-project-management-infrastructure-specs.md
@@ -1,0 +1,69 @@
+# Spock Tests for Immunopeptidomics Measurement Deletion
+
+## Requirements
+- `MEASUREMENT-R-03` (Deletion with dataset guard)
+- `LAB-C-01` (OpenBIS synchronization)
+
+## File Location
+`project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/experiment/measurement/MeasurementRepositoryImplementationSpec.groovy`
+
+## Test Cases
+
+### 1. `def "deleteAllIP throws DATA_ATTACHED when measurements have attached data"`
+```groovy
+def "deleteAllIP throws DATA_ATTACHED when measurements have attached data"() {
+  given:
+  Mock measurementDataRepo = Mock(MeasurementDataRepo)
+  MeasurementRepositoryImplementation implementation = new MeasurementRepositoryImplementation(
+      measurementDataRepo, ipMeasurementJpaRepo, log
+  )
+  Set<String> measurementIds = ["IP-123", "IP-456"]
+  List<ImmunopeptidomicsMeasurement> measurements = measurementIds.collect { new ImmunopeptidomicsMeasurement(it) }
+
+  and:
+  measurementDataRepo.hasDataAttached(_) >> true
+  ipMeasurementJpaRepo.findAllById(_) >> measurements
+
+  when:
+  implementation.deleteAllIP(measurementIds)
+
+  then:
+  thrown(MeasurementDeletionException)
+  MeasurementDeletionException ex = thrown()
+  ex.reason() == DeletionErrorCode.DATA_ATTACHED
+
+  0 * ipMeasurementJpaRepo.deleteAll(_)
+  0 * measurementDataRepo.deleteImmunopeptidomicsMeasurements(_)
+}
+```
+
+### 2. `def "deleteAllIP deletes from JPA and OpenBIS when no data attached"`
+```groovy
+def "deleteAllIP deletes from JPA and OpenBIS when no data attached"() {
+  given:
+  Mock measurementDataRepo = Mock(MeasurementDataRepo)
+  MeasurementRepositoryImplementation implementation = new MeasurementRepositoryImplementation(
+      measurementDataRepo, ipMeasurementJpaRepo, log
+  )
+  Set<String> measurementIds = ["IP-123", "IP-456"]
+  List<ImmunopeptidomicsMeasurement> measurements = measurementIds.collect { new ImmunopeptidomicsMeasurement(it) }
+
+  and:
+  measurementDataRepo.hasDataAttached(_) >> false
+  ipMeasurementJpaRepo.findAllById(_) >> measurements
+
+  when:
+  implementation.deleteAllIP(measurementIds)
+
+  then:
+  1 * ipMeasurementJpaRepo.deleteAll(measurements)
+  1 * measurementDataRepo.deleteImmunopeptidomicsMeasurements(measurements)
+}
+```
+
+## Verification
+1. Run with `./mvnw verify`
+2. Confirm 2 test cases pass
+3. Ensure no other tests fail
+
+> **Note**: The UI error handling is already verified in `MeasurementMainSpec` (already exists)


### PR DESCRIPTION
Fixes #1430. Implements deletion with dataset guard (MEASUREMENT-R-03) and OpenBIS synchronization (LAB-C-01).