### PR TITLE
Story tracking structure: stable IDs, workflow, and features.md rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,16 @@ The governance model for this project follows a strict top-down traceability cha
 
 ```
 PRD (docs/prd.md)
-  └── Features  (.github/ISSUE_TEMPLATE/feature.yml)
-        └── Stories  (.github/ISSUE_TEMPLATE/story.yml)
+  └── Features  (docs/features.md + .github/ISSUE_TEMPLATE/feature.yml)
+        └── Stories  (docs/features.md + .github/ISSUE_TEMPLATE/story.yml)
               └── Tasks  (.github/ISSUE_TEMPLATE/task.yml)
                     └── Implementation (code, PRs)
 ```
+
+Stories are tracked in two places: `docs/features.md` (the stakeholder-facing, stable record) and
+GitHub issues (the implementation tracking record). When a story moves from draft (discussion in
+SharePoint Word doc) to approved (ready for implementation), it receives a stable Story ID and is
+documented in both locations simultaneously. See **§11.1 Story Lifecycle** for the full workflow.
 
 - **PRD** defines product vision, user personas, and business objectives.
 - **Features** group related Stories under a named, user-visible capability. A Feature references one or more requirement IDs and describes the high-level scope.
@@ -89,6 +94,33 @@ Where:
 -   A Feature must reference at least one requirement ID (`R-<NN>` or `NFR-<NN>`).
 -   Constraints (`C-<NN>`) must not be used as the sole reference in a Feature — they may appear in Feature notes but Features must cite at least one `R` or `NFR` ID.
 -   One Feature may group multiple Stories across different domains, provided the Stories share a coherent user-visible purpose.
+
+---
+
+### Story ID Schema
+
+Stories are identified using a short, human-readable slug derived from their parent Feature:
+
+    FEAT-<SLUG>-<NN>
+
+Where:
+
+-   **SLUG** --- a concise, abbreviated identifier derived from the parent Feature slug (e.g., `IP-MEAS` for `FEAT-IMMUNOPEPTIDOMICS-MEASUREMENT`). Abbreviations must be short enough for readability but descriptive enough to be self-explanatory within the Feature context.
+-   **NN** --- sequential number, zero-padded to exactly two digits (e.g., `01`, `02`, `10`).
+
+#### Examples
+
+    FEAT-IP-MEAS-01
+    FEAT-IP-MEAS-05
+    FEAT-SAMPLE-03
+
+#### Rules
+
+-   Story IDs are assigned when a story moves from draft (discussion/refinement) to approved (ready for implementation).
+-   Story IDs must be stable and must never be renumbered.
+-   Tasks reference stories by their stable ID, not by GitHub issue number.
+-   GitHub issues for stories are updated to carry the stable story ID in the title and body.
+-   Abbreviated slugs must be unique within their parent Feature, but do not need to be globally unique across Features.
 
 ---
 
@@ -200,6 +232,27 @@ Rules:
 
 -   Tasks must not redefine acceptance criteria.
 -   Tasks must not expand requirement scope.
+-   Tasks reference stories by their stable ID (e.g., `FEAT-IP-MEAS-01`), not by GitHub issue number.
+
+---
+
+#### Story Lifecycle
+
+Stories move through a lifecycle from draft to implementation. This flow keeps the GitHub issue history clean and ensures stakeholders have a stable, reviewable document.
+
+1. **Draft (Discussion)** — The story is captured in a SharePoint Word document or similar internal medium where discussion, refinement, and iteration happen. No stable ID is assigned. The story is not yet tracked in `docs/features.md`.
+2. **Approved (Ready for Implementation)** — The story is finalised, a stable `FEAT-<SLUG>-<NN>` ID is assigned, and it is:
+   - Written into `docs/features.md` with full narrative and acceptance criteria
+   - A GitHub issue is created (if it does not already exist) or an existing issue is updated with the stable ID in the title and body
+   - The status in `docs/features.md` is updated from 🔴 (Open) to 🟡 (In Progress) when implementation begins, and 🟢 (Done) when complete
+3. **Implementation** — Tasks are created in GitHub referencing the stable story ID (not the GitHub issue number). Implementation traces: Task → Story (stable ID) → Feature → Requirement → PRD.
+
+**Rules:**
+
+- A story must never be implemented without a stable ID in `docs/features.md`.
+- When a story was created on GitHub before this flow existed (e.g., old issue numbers), update the existing issue with the stable ID rather than creating a new one.
+- Tasks reference stories by their stable ID in the "Parent Story" field, not by GitHub issue number.
+- The GitHub issue remains the source of truth for implementation tracking (comments, sub-issues, assignees), but `docs/features.md` is the source of truth for story content (narrative, acceptance criteria).
 
 ---
 
@@ -207,8 +260,9 @@ Rules:
 
 - A Feature must be created before any Story references it. Create the Feature first.
 - A Story must always reference a parent Feature. Never create a Story without a parent Feature issue.
-- A Task must always be preceded by a Story. Create the Story first, then create the Task referencing it.
-- Never create a Task without a parent Story issue.
+- A Story must receive a stable `FEAT-<SLUG>-<NN>` ID before any Task is created for it.
+- A Task must always be preceded by a Story. Create the Story first (draft → approved → stable ID), then create the Task referencing the stable story ID.
+- Never create a Task without a parent Story issue. Tasks must reference the story by its stable ID.
 - If no parent Feature exists for a piece of work (e.g., when acting on a direct implementation request), create the Feature first, then the Story, then the Task.
 - A single Story may have multiple Tasks; a Task must not span multiple Stories.
 
@@ -621,6 +675,14 @@ When working on this codebase, an AI agent should:
 - A Feature slug (`FEAT-<SLUG>`) must be unique and must not be changed once Stories reference it.
 - If you are unsure whether a new Feature is needed or an existing Feature should be extended, pause and ask a human reviewer.
 
+### Creating Stories
+
+- Stories start as drafts (discussion/refinement in SharePoint Word or similar internal medium). They are NOT tracked in `docs/features.md` or GitHub while in draft.
+- When a story is finalised and approved for implementation: assign a stable `FEAT-<SLUG>-<NN>` ID, write it into `docs/features.md` with full narrative and acceptance criteria, and create or update the corresponding GitHub issue with the stable ID in the title and body.
+- For stories that were created on GitHub before this workflow existed, update the existing issue with the stable ID rather than creating a new one.
+- Tasks reference the story by its stable ID (e.g., `FEAT-IP-MEAS-01`), not by GitHub issue number.
+- If you are unsure whether a new Story is needed or an existing Feature should be extended, pause and ask a human reviewer.
+
 ### Making domain changes
 
 - New domain concepts go in `domain/model/` of the relevant bounded context.
@@ -679,6 +741,7 @@ An agent should pause and request human review/approval before:
 |---|---|
 | `docs/requirements.md` | Authoritative requirement registry — all R/NFR/C requirements documented here; must be updated before new capabilities are implemented |
 | `docs/requirements-guide.md` | Authoring conventions for creating, editing, and retiring requirements |
+| `docs/features.md` | Stakeholder-facing features and user stories tracker — stable story records with narrative, acceptance criteria, and status; stories move here from draft once approved |
 | `README.md` | Setup, configuration reference, how to run |
 | `ExceptionHandling.md` | Exception handling conventions (read before touching error handling) |
 | `service_api.md` | Service API design patterns (Mono/Flux, request/response shapes) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,7 +15,28 @@ view of the implementation roadmap.
 | 🟢 | Done |
 | ⚫ | Closed / Cancelled |
 
----
+## Story ID Schema
+
+Stories are identified using a short, human-readable slug derived from their parent Feature:
+
+    FEAT-<SLUG>-<NN>
+
+Where:
+
+- **SLUG** — a concise, abbreviated identifier derived from the parent Feature slug (e.g., `IP-MEAS` for `FEAT-IMMUNOPEPTIDOMICS-MEASUREMENT`)
+- **NN** — sequential number, zero-padded to two digits (e.g., `01`, `02`, `05`)
+
+### Example
+
+    FEAT-IP-MEAS-01
+    FEAT-IP-MEAS-05
+
+### Rules
+
+- Story IDs are assigned when a story moves from draft (refinement) to approved (ready for implementation).
+- Story IDs must be stable and must never be renumbered.
+- Tasks reference stories by their stable ID, not by GitHub issue number.
+- GitHub issues for stories are updated to carry the stable story ID in the title and body.
 
 ## Active Features
 
@@ -29,27 +50,179 @@ view of the implementation roadmap.
 | **GitHub Feature** | [#1412](https://github.com/qbicsoftware/data-manager-app/issues/1412) |
 | **Status** | 🟡 In Progress |
 
-#### Stories
+---
 
-| # | Title | Requirement IDs | Status | GitHub |
-|---|---|---|---|---|
-| #1428 | Register Immunopeptidomics Measurements via Excel Template | `MEASUREMENT-R-01` | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1428) |
-| #1429 | Edit Immunopeptidomics Measurements via Pre-filled Excel Template | `MEASUREMENT-R-02` | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1429) |
-| #1430 | Delete Immunopeptidomics Measurements | `MEASUREMENT-R-03` | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1430) |
-| #1431 | View Immunopeptidomics Measurements in Measurement View | `MEASUREMENT-R-04` | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1431) |
-| #1432 | View and Access Immunopeptidomics Raw Datasets | `DATA-R-01`, `DATA-R-02`, `DATA-R-03` | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1432) |
+### Stories
 
-#### Tasks
+#### FEAT-IP-MEAS-01 — Register Immunopeptidomics Measurements via Excel Template
 
-| # | Title | Parent Story | Status | GitHub |
-|---|---|---|---|---|
-| #1413 | Registration of Immunopeptidomics Measurements | #1428 | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1413) |
-| #1414 | Editing of Immunopeptidomics Measurements | #1429 | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1414) |
-| #1415 | Deletion of Immunopeptidomics Measurements | #1430 | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1415) |
-| #1417 | Show the Immunopeptidomics Measurements in the Measurement View | #1431 | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1417) |
-| #1416 | Show Immunopeptidomic datasets within the raw data view | #1432 | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1416) |
-| #1434 | Integration Test — End-to-End Verification | #1432 | 🔴 Open | [Link](https://github.com/qbicsoftware/data-manager-app/issues/1434) |
+| Field | Value |
+|---|---|
+| **Requirement IDs** | `MEASUREMENT-R-01` |
+| **Status** | 🟢 Done |
+| **GitHub** | [#1428](https://github.com/qbicsoftware/data-manager-app/issues/1428) |
+
+**User Story**
+
+> As a data provider, I want to register immunopeptidomics measurements via a domain-specific Excel template, so that I can capture domain-specific metadata (MHC antibody, enrichment method, LC column, etc.) for my experiment.
+
+**Acceptance Criteria**
+
+- Given a user is on the measurement registration page, When they select the immunopeptidomics domain, Then a downloadable registration template with the correct columns and Property Information sheet is provided.
+- Given a user uploads a filled immunopeptidomics registration template with all mandatory fields valid, When the system validates the sheet, Then all measurements are registered successfully with unique `IP-` prefixed measurement codes.
+- Given a user uploads a sheet with a missing mandatory field (e.g., blank `MHC Antibody`), When the system validates the sheet, Then an error identifying the column and row is returned and no records are created.
+- Given a user uploads a sheet with an invalid `Organisation URL` or `Prep Date` format, When validation runs, Then a domain-appropriate error is returned and no records are created.
+- Given a user uploads a sheet with a non-existent or cross-experiment `QBiC Sample Id`, When validation runs, Then a missing/unknown-id error is returned and no records are created.
+- Given a user uploads a sheet with all optional fields blank and all mandatory fields valid, When the system processes the sheet, Then measurements are created successfully.
+
+**Notes & Context**
+
+- The registration template columns must match the immunopeptidomics partner facility specification.
+- OpenBIS must be extended with a dedicated object type for immunopeptidomics measurements.
+
+**Tasks**
+
+| # | Title | Status | GitHub |
+|---|---|---|---|
+| — | Registration of Immunopeptidomics Measurements | 🟢 Done | [#1413](https://github.com/qbicsoftware/data-manager-app/issues/1413) |
+| — | Integration Test — Register Immunopeptidomics Measurements | 🟢 Done | [#1437](https://github.com/qbicsoftware/data-manager-app/issues/1437) |
 
 ---
 
-*Last updated: 2026-05-06*
+#### FEAT-IP-MEAS-02 — Edit Immunopeptidomics Measurements via Pre-filled Excel Template
+
+| Field | Value |
+|---|---|
+| **Requirement IDs** | `MEASUREMENT-R-02` |
+| **Status** | 🟢 Done |
+| **GitHub** | [#1429](https://github.com/qbicsoftware/data-manager-app/issues/1429) |
+
+**User Story**
+
+> As a data provider, I want to edit existing immunopeptidomics measurements via a pre-filled Excel template, so that I can update metadata (e.g., comments, instrument changes) without re-registering measurements.
+
+**Acceptance Criteria**
+
+1. **Pre-filled edit template**
+   Given a user has selected existing immunopeptidomics measurements to edit, when they choose to download the edit template, then a pre-filled Excel file is produced containing the current metadata values for those measurements, with properties logically grouped in the same familiar structure as the registration template.
+2. **Persist valid modifications**
+   Given a user has modified modifiable fields in the downloaded template and re-uploads it, when the system processes the file, then the corresponding measurement records are updated with the new values.
+3. **Ignore read-only changes**
+   Given a user has modified read-only fields in the downloaded template and re-uploads it, when the system processes the file, then those changes are silently ignored without causing errors, and any valid modifications to modifiable fields are still applied.
+4. **Require measurement identifier**
+   Given a user uploads an edit template containing rows without a measurement identifier, when the system validates the file, then the upload is rejected with a clear error indicating that the identifier is required.
+5. **Scope edits to the experiment**
+   Given a user uploads an edit template containing measurement identifiers that do not belong to the current experiment, when the system validates the file, then the upload is rejected with a clear error.
+6. **Validate mandatory modifiable fields**
+   Given a user clears a mandatory modifiable field in the template and re-uploads it, when the system validates the file, then the upload is rejected with clear guidance indicating which required information is missing.
+7. **Template reference accuracy**
+   Given a user downloads the edit template, when they review the included property information, then it accurately reflects the measurement specification, including property categories, provisioning guidance, and allowed values.
+
+**Notes & Context**
+
+- Editable and read-only fields are defined in the measurement specification; non-editable fields are ignored on re-upload.
+
+**Tasks**
+
+| # | Title | Status | GitHub |
+|---|---|---|---|
+| — | Editing of Immunopeptidomics Measurements | 🟢 Done | [#1414](https://github.com/qbicsoftware/data-manager-app/issues/1414) |
+
+---
+
+#### FEAT-IP-MEAS-03 — Delete Immunopeptidomics Measurements
+
+| Field | Value |
+|---|---|
+| **Requirement IDs** | `MEASUREMENT-R-03` |
+| **Status** | 🟢 Done |
+| **GitHub** | [#1430](https://github.com/qbicsoftware/data-manager-app/issues/1430) |
+
+**User Story**
+
+> As a project member with management rights, I want to delete immunopeptidomics measurements, so that I can remove erroneously registered entries to increase metadata quality of the project.
+
+**Acceptance Criteria**
+
+- Given a user with management rights selects immunopeptidomics measurements for deletion, When they confirm deletion, Then measurements with no attached dataset are deleted successfully.
+- Given a user with management rights deletes an immunopeptidomics measurement with an attached dataset, the deletion must fail and the user shall be informed to delete the raw datasets first.
+- Given a user with view-only rights views the measurement page, they shall not be able to delete measurements.
+- The user shall see a confirmation notification about the amount of successfully deleted measurements.
+
+**Notes & Context**
+
+- Dataset deletion is out of scope; users must remove datasets via the raw data view first.
+
+**Tasks**
+
+| # | Title | Status | GitHub |
+|---|---|---|---|
+| — | Deletion of Immunopeptidomics Measurements | 🟢 Done | [#1415](https://github.com/qbicsoftware/data-manager-app/issues/1415) |
+
+---
+
+#### FEAT-IP-MEAS-04 — View Immunopeptidomics Measurements in Measurement View
+
+| Field | Value |
+|---|---|
+| **Requirement IDs** | `MEASUREMENT-R-04` |
+| **Status** | 🟢 Done |
+| **GitHub** | [#1431](https://github.com/qbicsoftware/data-manager-app/issues/1431) |
+
+**User Story**
+
+> As a project member, I want to see registered immunopeptidomics measurements in the measurement view, so that I can track which measurements exist for my experiment and review their metadata.
+
+**Acceptance Criteria**
+
+- Given a user navigates to the measurement view, When the page loads, Then a dedicated immunopeptidomics tab is visible alongside NGS and proteomics tabs.
+- Given the immunopeptidomics tab is active, When measurements exist, Then they are displayed with domain-specific columns: QBiC Sample Id, Sample Name, Measurement Name, Organisation URL, Facility, Sample Mass (mg), Sample Volume, Cycle/Fraction Name, MHC Antibody, MHC Typing Method, Enrichment Method, Instrument, Prep Date, MS Run Date, LCMS Method, LC Column, Data Acquisition, Mass range (m/z), Retention time range (min), Charge range, Ion mobility range (1/k0), Registration Date, Comment.
+- Given the immunopeptidomics tab is active, When the page loads, Then the current count of immunopeptidomics measurements is shown.
+- Given a user enters a search term in the filter box, When they type, Then the displayed measurements are filtered to show rows where any visible property contains the search term.
+- Given no immunopeptidomics measurements exist for the experiment, When the page loads, Then the tab shows an empty state or zero count.
+
+**Notes & Context**
+
+- The measurement view must keep immunopeptidomics data visually distinct from NGS and proteomics data.
+- The grid component pattern should mirror the existing flexible grid used for proteomics and genomics.
+
+**Tasks**
+
+| # | Title | Status | GitHub |
+|---|---|---|---|
+| — | Show the Immunopeptidomics Measurements in the Measurement View | 🟢 Done | [#1417](https://github.com/qbicsoftware/data-manager-app/issues/1417) |
+
+---
+
+#### FEAT-IP-MEAS-05 — View and Access Immunopeptidomics Raw Datasets
+
+| Field | Value |
+|---|---|
+| **Requirement IDs** | `DATA-R-01`, `DATA-R-02`, `DATA-R-03` |
+| **Status** | 🟢 Done |
+| **GitHub** | [#1432](https://github.com/qbicsoftware/data-manager-app/issues/1432) |
+
+**User Story**
+
+> As a user with project access, I want to see available immunopeptidomics raw datasets for measured samples and instructions how to access them for detailed investigation and processing.
+
+**Acceptance Criteria**
+
+- Given a user with project access rights accesses the available raw datasets for measured samples, the user is able to see contextual metadata and properties about each raw dataset.
+- Given a user with project access rights accesses the available raw datasets for measured samples, the user is able to filter datasets with generic text input.
+- Given a user with project access rights accesses the available raw datasets for measured samples, the user is able to see the total number of available raw datasets.
+- Given no raw datasets for the selected experiment exist, the user is informed about how to register datasets and that there are no raw datasets registered yet.
+
+**Notes & Context**
+
+- Raw data upload/download backend implementations live in separate repositories (`data-scanner`, `data-download-server`). The Data Manager only consumes the scanned metadata and provides download URLs.
+
+**Tasks**
+
+| # | Title | Status | GitHub |
+|---|---|---|---|
+| — | Show Immunopeptidomic datasets within the raw data view | 🟢 Done | [#1416](https://github.com/qbicsoftware/data-manager-app/issues/1416) |
+
+---
+
+*Last updated: 2026-06-15*


### PR DESCRIPTION
## Summary

Establishes a stable story tracking structure for the data manager project. Introduces Story IDs, a documented story lifecycle workflow, and migrates existing immunopeptidomics stories into `docs/features.md` as the stakeholder-facing source of truth.

## Changes

### `docs/features.md` — rewritten
- Story ID schema documented: `FEAT-<SLUG>-<NN>`
- All 5 immunopeptidomics stories migrated with full narrative, acceptance criteria, stable IDs, and status
- Task section removed — tasks remain GitHub-only (implementation-level)

### `AGENTS.md` — updated
- Governance hierarchy now reflects `docs/features.md` as the story source of truth
- New **Story ID Schema** section (§0) with rules and examples
- New **Story Lifecycle** section (§0) documenting the draft → approved → implement flow
- Updated task rules to reference stories by stable ID
- New "Creating Stories" section (§11) for agent delegation guidance
- Key Files Quick Reference now includes `docs/features.md`

### GitHub issues — all 10 issues updated (already applied)

**Story issues (#1428–#1432):**
| Issue | Stable ID |
|---|---|
| #1428 | `FEAT-IP-MEAS-01` |
| #1429 | `FEAT-IP-MEAS-02` |
| #1430 | `FEAT-IP-MEAS-03` |
| #1431 | `FEAT-IP-MEAS-04` |
| #1432 | `FEAT-IP-MEAS-05` |

**Task issues (#1413–#1417):** Parent Story field updated to reference stories by stable ID (e.g. `FEAT-IP-MEAS-01 (#1428)`).

**IT tasks (#1437–#1441):** Comments added marking them as superseded/skipped for this feature.

## Story ID Schema

```
FEAT-<SLUG>-<NN>
```

- **SLUG**: abbreviated identifier derived from parent Feature (e.g., `IP-MEAS` for `FEAT-IMMUNOPEPTIDOMICS-MEASUREMENT`)
- **NN**: sequential number, zero-padded (e.g., `01`, `02`)

## Story Lifecycle

1. **Draft** — discussion/refinement in SharePoint Word doc (no stable ID, not in `features.md`)
2. **Approved** — stable ID assigned, story written into `docs/features.md`, GitHub issue updated
3. **Implementation** — Tasks reference the story by stable ID, not by GitHub issue number

## What to review

- `docs/features.md` — story content, acceptance criteria, IDs, status
- `AGENTS.md` — new Story ID Schema, Story Lifecycle, and Creating Stories sections