### PR TITLE
feat(haproxy): add custom 503 maintenance landing page

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -114,6 +114,9 @@ Key rules from HAProxy's `errorfile` specification:
 6. The HTML body follows after the blank line
 7. The entire file is served verbatim as the HTTP response
 
+## File size restriction
+HA-Proxy has a max cap for the file size per response for the error messages of 16,800 bytes. Stay below that.
+
 ## License
 
 Same as the Data Manager project: AGPL-3.0-or-later.

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -1,0 +1,119 @@
+# HAProxy Custom Error Pages
+
+Custom maintenance / error landing pages for the QBiC Data Manager HAProxy setup.
+
+These pages follow the [HAProxy `errorfile` format](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/alerts-and-monitoring/error-pages/):
+each file has a `.http` extension, contains the HTTP status line and required headers at the top,
+a blank line separator, and then the full HTML response body.
+
+## Files
+
+| File | HTTP Status | When to Use |
+|------|-------------|-------------|
+| `errors/503.http` | 503 Service Temporarily Unavailable | Scheduled maintenance or temporary service interruption |
+| `errors/maintenance-illustration.svg` | — | Standalone SVG illustration (not used by HAProxy directly) |
+
+## HAProxy Configuration
+
+Add the error pages to your HAProxy configuration. Place the files on your HAProxy host
+(e.g. under `/etc/haproxy/errors/`) and reference them in the `defaults` or `frontend` section:
+
+```haproxy
+defaults
+    # Custom error pages
+    errorfile 503 /etc/haproxy/errors/503.http
+```
+
+To serve the maintenance page for **all** traffic during a maintenance window (regardless of
+backend status), combine it with a maintenance backend:
+
+```haproxy
+# --- Maintenance mode ---
+# Enable by uncommenting the maintenance block and commenting out the normal backend.
+
+# backend maintenance
+#     errorfile 503 /etc/haproxy/errors/503.http
+#     server maintenance 127.0.0.1:1 disable
+
+# frontend myapp
+#     # Maintenance mode: route everything to the maintenance error page
+#     # use_backend maintenance if TRUE
+#
+#     # Normal mode:
+#     use_backend app_servers
+```
+
+### Multiple Error Codes
+
+You can also serve the same maintenance page for other status codes during an outage:
+
+```haproxy
+defaults
+    errorfile 502 /etc/haproxy/errors/503.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/503.http
+```
+
+## Page Contents
+
+The error page includes:
+
+- **Informative message** — explains the situation to visitors in a friendly way
+- **SVG illustration** — fully inline, no external image dependencies
+- **Contact information** — support email: `support@qbic.zendesk.com`
+- **Provider information** — QBiC – Quantitative Biology Center, University of Tübingen
+  with a link to <https://www.info.qbic.uni-tuebingen.de/>
+
+The page is fully self-contained:
+- All CSS is inline (no external stylesheets)
+- The SVG illustration is embedded inline (no external image files)
+- CSS animations bring the illustration to life
+
+### Visual style
+
+- Warm cream colour palette
+- Scene: two colleagues with a tilted server rack, smoke and sparks
+- Subtle animations: floating papers, flickering LEDs, rising smoke, blinking sparks
+
+## Customisation
+
+### Changing the contact address
+
+Edit the `mailto:` and display text in the `.contact-card` section of `503.http`.
+
+### Changing the page appearance
+
+All styles are in the `<style>` block inside `503.http`. The colour palette is:
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Background | `#fefdf7` | Page background |
+| Heading | `#c0392b` | Error title |
+| Primary | `#2980b9` | Links |
+| Card BG | `#f0f4f8` | Contact info card |
+| Server rack | `#2d2d2d` / `#4a4a4a` | Rack gradient |
+| LEDs | `#e74c3c` | Red error indicators |
+| Sparks | `#f1c40f` / `#e74c3c` | Animated sparkle effects |
+
+### Replacing the illustration
+
+Swap the `<svg>` block inside the `.illustration` div with a different SVG or
+replace the inline SVG with an `<img>` tag pointing to a standalone image file.
+
+## Format Requirements (HAProxy)
+
+Key rules from HAProxy's `errorfile` specification:
+
+1. File extension **must** be `.http` (not `.html`)
+2. File must start with the HTTP status line: `HTTP/1.1 <code> <reason>`
+3. Followed by HTTP headers. For `HTTP/1.1` the following are **mandatory** (the parser rejects files missing them):
+   - `Content-Length: <bytes>` — must exactly match the body size in bytes; without it HAProxy 2.7+ raises _"unable to parse headers"_ at startup
+   - `Content-Type: text/html` (or `text/html; charset=utf-8`)
+4. All line endings must be **CRLF** (`\r\n`) — HTTP/1.1 requires it per RFC 7230
+5. A **blank line** (`\r\n\r\n`) separates headers from the HTML body
+6. The HTML body follows after the blank line
+7. The entire file is served verbatim as the HTTP response
+
+## License
+
+Same as the Data Manager project: AGPL-3.0-or-later.

--- a/haproxy/errors/503.http
+++ b/haproxy/errors/503.http
@@ -1,0 +1,255 @@
+HTTP/1.1 503 Service Temporarily Unavailable
+Cache-Control: no-cache
+Connection: close
+Content-Length: 15913
+Content-Type: text/html; charset=utf-8
+Retry-After: 300
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Service Temporarily Unavailable</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html,body{height:100%;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;background:#fefdf7;color:#2c3e50}
+body{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:1.5rem}
+.container{max-width:680px;width:100%;text-align:center}
+.illustration{width:100%;max-width:580px;margin:0 auto 2rem}
+.illustration svg{width:100%;height:auto;display:block}
+h1{font-size:1.75rem;font-weight:700;margin-bottom:.75rem;color:#c0392b}
+.message{font-size:1.05rem;line-height:1.7;margin-bottom:1.75rem;color:#555}
+.contact-card{background:#f0f4f8;border-radius:12px;padding:1.25rem 1.75rem;display:inline-block;margin-bottom:1.5rem}
+.contact-card p{font-size:.95rem;color:#555;margin-bottom:.4rem}
+.contact-card a{color:#2980b9;font-weight:600;text-decoration:none}
+.contact-card a:hover{text-decoration:underline}
+.provider{font-size:.85rem;color:#888;line-height:1.6}
+.provider a{color:#888;text-decoration:underline}
+.provider a:hover{color:#555}
+
+/* Fun floating-paper animation */
+@keyframes float{0%,100%{transform:translateY(0) rotate(0deg)}50%{transform:translateY(-8px) rotate(3deg)}}
+@keyframes floatAlt{0%,100%{transform:translateY(0) rotate(0deg)}50%{transform:translateY(-6px) rotate(-2deg)}}
+.paper-float{animation:float 4s ease-in-out infinite}
+.paper-float-alt{animation:floatAlt 3.5s ease-in-out infinite}
+
+/* Sparks blink */
+@keyframes sparkle{0%,100%{opacity:1}50%{opacity:.3}}
+.spark{animation:sparkle 1.2s ease-in-out infinite}
+.spark-delay{animation:sparkle 1.2s ease-in-out infinite;animation-delay:.4s}
+
+/* Smoke rise */
+@keyframes rise{0%{opacity:.25;transform:translateY(0)}100%{opacity:0;transform:translateY(-15px)}}
+.smoke-anim{animation:rise 3s ease-out infinite}
+.smoke-anim-delay{animation:rise 3s ease-out infinite;animation-delay:1.5s}
+
+/* LED flicker */
+@keyframes flicker{0%,100%{opacity:.15}50%{opacity:.8}}
+.led-flicker{animation:flicker 0.8s ease-in-out infinite}
+</style>
+</head>
+<body>
+<div class="container" role="main">
+
+<!-- ========== ILLUSTRATION ========== -->
+<div class="illustration" aria-hidden="true">
+<svg viewBox="0 0 820 600" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+<stop offset="0%" stop-color="#fefcf3"/>
+<stop offset="100%" stop-color="#fef5e0"/>
+</linearGradient>
+<linearGradient id="rackG" x1="0" y1="0" x2="0" y2="1">
+<stop offset="0%" stop-color="#4a4a4a"/>
+<stop offset="100%" stop-color="#2d2d2d"/>
+</linearGradient>
+<filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+<feDropShadow dx="2" dy="3" stdDeviation="3" flood-opacity=".12"/>
+</filter>
+</defs>
+<rect width="820" height="600" fill="url(#bg)" rx="16"/>
+<rect x="0" y="455" width="820" height="145" fill="#e8e0d0" rx="0"/>
+<line x1="0" y1="455" x2="820" y2="455" stroke="#d5cabb" stroke-width="2"/>
+<line x1="200" y1="455" x2="180" y2="600" stroke="#ddd4c4" stroke-width="1"/>
+<line x1="420" y1="455" x2="410" y2="600" stroke="#ddd4c4" stroke-width="1"/>
+<line x1="640" y1="455" x2="650" y2="600" stroke="#ddd4c4" stroke-width="1"/>
+<ellipse cx="310" cy="60" rx="40" ry="22" fill="#e8e0d0" opacity=".35" class="smoke-anim"/>
+<ellipse cx="360" cy="45" rx="28" ry="16" fill="#e8e0d0" opacity=".30" class="smoke-anim-delay"/>
+<ellipse cx="280" cy="80" rx="22" ry="14" fill="#e8e0d0" opacity=".25" class="smoke-anim"/>
+<polygon points="400,55 404,66 415,68 406,74 409,85 400,78 391,85 394,74 385,68 396,66" fill="#f1c40f" class="spark"/>
+<polygon points="245,48 248,56 255,57 249,62 251,70 245,65 239,70 241,62 235,57 242,56" fill="#f39c12" class="spark-delay"/>
+<polygon points="420,130 423,138 430,139 424,144 426,152 420,147 414,152 416,144 410,139 417,138" fill="#e74c3c" class="spark"/>
+<polygon points="210,135 212,140 217,141 213,144 214,149 210,146 206,149 207,144 203,141 208,140" fill="#f1c40f" class="spark-delay"/>
+<g transform="rotate(-10,300,380)" filter="url(#shadow)">
+<rect x="220" y="100" width="160" height="358" rx="8" fill="url(#rackG)" stroke="#222" stroke-width="2.5"/>
+<rect x="240" y="108" width="120" height="4" rx="2" fill="#555"/>
+<rect x="240" y="116" width="120" height="4" rx="2" fill="#555"/>
+<rect x="240" y="124" width="120" height="4" rx="2" fill="#555"/>
+<rect x="232" y="140" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+<rect x="242" y="150" width="82" height="8" rx="2" fill="#555"/>
+<rect x="242" y="164" width="58" height="8" rx="2" fill="#555"/>
+<circle cx="348" cy="154" r="5" fill="#e74c3c" class="led-flicker"/>
+<circle cx="348" cy="170" r="5" fill="#e74c3c" class="led-flicker"/>
+<circle cx="336" cy="154" r="4" fill="#7f8c8d"/>
+<rect x="232" y="198" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+<rect x="242" y="208" width="82" height="8" rx="2" fill="#555"/>
+<rect x="242" y="222" width="58" height="8" rx="2" fill="#555"/>
+<circle cx="348" cy="212" r="5" fill="#e74c3c" class="led-flicker"/>
+<circle cx="348" cy="228" r="5" fill="#7f8c8d"/>
+<circle cx="336" cy="212" r="4" fill="#7f8c8d"/>
+<rect x="232" y="256" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+<rect x="242" y="266" width="82" height="8" rx="2" fill="#555"/>
+<rect x="242" y="280" width="58" height="8" rx="2" fill="#555"/>
+<circle cx="348" cy="270" r="5" fill="#e74c3c" class="led-flicker"/>
+<circle cx="348" cy="286" r="5" fill="#e74c3c" class="led-flicker"/>
+<circle cx="336" cy="270" r="4" fill="#7f8c8d"/>
+<rect x="232" y="314" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+<rect x="242" y="324" width="82" height="8" rx="2" fill="#555"/>
+<rect x="242" y="338" width="40" height="8" rx="2" fill="#555"/>
+<circle cx="348" cy="328" r="5" fill="#e74c3c" class="led-flicker"/>
+<circle cx="348" cy="344" r="5" fill="#7f8c8d"/>
+<rect x="248" y="354" width="65" height="35" rx="4" fill="#111" stroke="#444" stroke-width="1.5"/>
+<text x="280" y="378" font-size="16" fill="#e74c3c" text-anchor="middle" font-family="monospace" font-weight="bold" class="led-flicker">503</text>
+<path d="M232,400 Q218,425 228,450 Q232,460 222,470" stroke="#e74c3c" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+<path d="M250,458 Q240,475 252,492" stroke="#3498db" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+<path d="M370,420 Q385,440 375,460 Q368,475 380,485" stroke="#27ae60" stroke-width="2" fill="none" stroke-linecap="round"/>
+<ellipse cx="290" cy="132" rx="14" ry="8" fill="#bbb" opacity=".3" class="smoke-anim"/>
+<ellipse cx="340" cy="125" rx="10" ry="7" fill="#bbb" opacity=".25" class="smoke-anim-delay"/>
+</g>
+<g class="paper-float">
+<rect x="130" y="195" width="32" height="42" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(-22,146,216)"/>
+<line x1="137" y1="207" x2="155" y2="204" stroke="#ccc" stroke-width="1" transform="rotate(-22,146,216)"/>
+<line x1="138" y1="215" x2="152" y2="213" stroke="#ccc" stroke-width="1" transform="rotate(-22,146,216)"/>
+<line x1="139" y1="223" x2="150" y2="221" stroke="#ccc" stroke-width="1" transform="rotate(-22,146,216)"/>
+</g>
+<g class="paper-float-alt">
+<rect x="440" y="145" width="28" height="38" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(18,454,164)"/>
+<line x1="446" y1="157" x2="462" y2="159" stroke="#ccc" stroke-width="1" transform="rotate(18,454,164)"/>
+<line x1="447" y1="165" x2="460" y2="167" stroke="#ccc" stroke-width="1" transform="rotate(18,454,164)"/>
+</g>
+<g class="paper-float">
+<rect x="540" y="245" width="32" height="42" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(32,556,266)"/>
+<line x1="547" y1="259" x2="565" y2="263" stroke="#ccc" stroke-width="1" transform="rotate(32,556,266)"/>
+<line x1="548" y1="267" x2="562" y2="270" stroke="#ccc" stroke-width="1" transform="rotate(32,556,266)"/>
+<line x1="549" y1="275" x2="558" y2="277" stroke="#ccc" stroke-width="1" transform="rotate(32,556,266)"/>
+</g>
+<g class="paper-float-alt">
+<rect x="100" y="340" width="26" height="34" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(-12,113,357)"/>
+<line x1="106" y1="351" x2="120" y2="350" stroke="#ccc" stroke-width="1" transform="rotate(-12,113,357)"/>
+<line x1="107" y1="358" x2="118" y2="357" stroke="#ccc" stroke-width="1" transform="rotate(-12,113,357)"/>
+</g>
+<g filter="url(#shadow)">
+<ellipse cx="535" cy="455" rx="38" ry="7" fill="#000" opacity=".07"/>
+<rect x="518" y="383" width="14" height="68" rx="5" fill="#2c3e50"/>
+<rect x="540" y="383" width="14" height="68" rx="5" fill="#2c3e50"/>
+<ellipse cx="525" cy="453" rx="13" ry="6" fill="#1a1a1a"/>
+<ellipse cx="547" cy="453" rx="13" ry="6" fill="#1a1a1a"/>
+<rect x="506" y="298" width="60" height="90" rx="14" fill="#3498db"/>
+<line x1="536" y1="310" x2="536" y2="385" stroke="#2980b9" stroke-width="1.5"/>
+<rect x="514" y="350" width="18" height="14" rx="2" fill="#2980b9" stroke="#2471a3" stroke-width=".8"/>
+<rect x="490" y="304" width="18" height="58" rx="8" fill="#3498db" transform="rotate(8,499,304)"/>
+<circle cx="486" cy="368" r="9" fill="#f0c8a0"/>
+<rect x="564" y="260" width="18" height="60" rx="8" fill="#3498db" transform="rotate(-20,573,260)"/>
+<circle cx="582" cy="232" r="9" fill="#f0c8a0"/>
+<rect x="578" y="185" width="6" height="52" rx="2" fill="#95a5a6"/>
+<path d="M574,185 L574,170 L580,168 L586,170 L586,185" fill="#95a5a6" stroke="#7f8c8d" stroke-width="1"/>
+<path d="M577,170 L577,163 L583,163 L583,170" fill="#3498db"/>
+<rect x="529" y="280" width="14" height="22" rx="4" fill="#f0c8a0"/>
+<circle cx="536" cy="260" r="30" fill="#f0c8a0"/>
+<path d="M506,250 Q506,222 536,218 Q566,222 566,250 L566,268 Q566,260 558,256 L558,262 Q550,258 536,258 Q522,258 514,262 L514,256 Q506,260 506,268 Z" fill="#8B4513"/>
+<path d="M510,246 Q515,230 536,228 Q557,230 562,246" fill="#8B4513"/>
+<ellipse cx="525" cy="258" rx="5" ry="5.5" fill="white" stroke="#555" stroke-width=".5"/>
+<circle cx="526" cy="255" r="2.8" fill="#2c3e50"/>
+<circle cx="527" cy="254" r="1" fill="white"/>
+<ellipse cx="545" cy="258" rx="5" ry="5.5" fill="white" stroke="#555" stroke-width=".5"/>
+<circle cx="546" cy="255" r="2.8" fill="#2c3e50"/>
+<circle cx="547" cy="254" r="1" fill="white"/>
+<line x1="519" y1="249" x2="530" y2="247" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+<line x1="540" y1="247" x2="551" y2="249" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+<ellipse cx="536" cy="275" rx="5" ry="4" fill="#c0392b"/>
+<ellipse cx="518" cy="268" rx="5" ry="3" fill="#f0a0a0" opacity=".35"/>
+<ellipse cx="554" cy="268" rx="5" ry="3" fill="#f0a0a0" opacity=".35"/>
+</g>
+<g filter="url(#shadow)">
+<ellipse cx="700" cy="455" rx="38" ry="7" fill="#000" opacity=".07"/>
+<rect x="682" y="383" width="14" height="68" rx="5" fill="#34495e"/>
+<rect x="706" y="383" width="14" height="68" rx="5" fill="#34495e" transform="rotate(5,713,383)"/>
+<ellipse cx="689" cy="453" rx="13" ry="6" fill="#1a1a1a"/>
+<ellipse cx="716" cy="455" rx="13" ry="6" fill="#1a1a1a"/>
+<rect x="672" y="298" width="60" height="90" rx="14" fill="#9b59b6"/>
+<path d="M692,298 L702,312 L712,298" fill="#8e44ad" stroke="#7d3c98" stroke-width=".8"/>
+<rect x="653" y="300" width="18" height="52" rx="8" fill="#9b59b6" transform="rotate(25,662,300)"/>
+<circle cx="636" cy="350" r="9" fill="#dba67b"/>
+<g transform="rotate(-10,636,350)">
+<rect x="610" y="338" width="54" height="34" rx="3" fill="#555" stroke="#333" stroke-width="1.5"/>
+<rect x="614" y="342" width="46" height="26" rx="2" fill="#1a1a2e"/>
+<text x="637" y="360" font-size="10" fill="#e74c3c" text-anchor="middle" font-family="monospace" font-weight="bold" class="led-flicker">ERR</text>
+<rect x="606" y="372" width="62" height="5" rx="2" fill="#666" stroke="#444" stroke-width=".8"/>
+</g>
+<rect x="730" y="272" width="18" height="52" rx="8" fill="#9b59b6" transform="rotate(-28,739,272)"/>
+<circle cx="752" cy="244" r="9" fill="#dba67b"/>
+<line x1="748" y1="236" x2="744" y2="228" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="752" y1="235" x2="752" y2="226" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="756" y1="236" x2="760" y2="228" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+<line x1="759" y1="239" x2="764" y2="233" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+<rect x="695" y="280" width="14" height="22" rx="4" fill="#dba67b"/>
+<circle cx="702" cy="260" r="30" fill="#dba67b"/>
+<path d="M672,252 Q672,224 702,218 Q732,224 732,252 L732,246 Q732,232 702,228 Q672,232 672,246 Z" fill="#1a1a1a"/>
+<path d="M696,220 Q694,210 700,208 Q701,215 704,220" fill="#1a1a1a"/>
+<ellipse cx="691" cy="258" rx="6" ry="6.5" fill="white" stroke="#555" stroke-width=".5"/>
+<circle cx="692" cy="258" r="3.8" fill="#2c3e50"/>
+<circle cx="693" cy="256" r="1.3" fill="white"/>
+<ellipse cx="713" cy="258" rx="6" ry="6.5" fill="white" stroke="#555" stroke-width=".5"/>
+<circle cx="714" cy="258" r="3.8" fill="#2c3e50"/>
+<circle cx="715" cy="256" r="1.3" fill="white"/>
+<line x1="684" y1="245" x2="697" y2="244" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+<line x1="707" y1="244" x2="720" y2="245" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+<ellipse cx="702" cy="277" rx="7" ry="5" fill="#c0392b"/>
+<ellipse cx="702" cy="276" rx="5" ry="3" fill="#7b241c"/>
+<path d="M726,242 Q730,234 728,226" stroke="#3498db" stroke-width="2" fill="none" stroke-linecap="round" opacity=".7"/>
+<circle cx="729" cy="224" r="2.5" fill="#3498db" opacity=".7"/>
+<path d="M735,252 Q738,246 737,240" stroke="#3498db" stroke-width="1.5" fill="none" stroke-linecap="round" opacity=".5"/>
+<circle cx="737" cy="238" r="2" fill="#3498db" opacity=".5"/>
+</g>
+<rect x="370" y="462" width="32" height="22" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(-28,386,473)"/>
+<line x1="376" y1="470" x2="393" y2="466" stroke="#ddd" stroke-width=".8" transform="rotate(-28,386,473)"/>
+<rect x="435" y="468" width="26" height="18" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(18,448,477)"/>
+<path d="M280,468 Q340,482 400,465 Q450,450 500,468" stroke="#555" stroke-width="3" fill="none" stroke-linecap="round" opacity=".4"/>
+<circle cx="470" cy="460" r="3" fill="#95a5a6" stroke="#7f8c8d" stroke-width="1"/>
+<line x1="468" y1="460" x2="472" y2="460" stroke="#7f8c8d" stroke-width=".8"/>
+<line x1="470" y1="458" x2="470" y2="462" stroke="#7f8c8d" stroke-width=".8"/>
+<g transform="rotate(-10,300,380)">
+<rect x="244" y="410" width="72" height="24" rx="4" fill="#e74c3c"/>
+<text x="280" y="427" font-size="11" fill="white" text-anchor="middle" font-family="sans-serif" font-weight="bold">OFFLINE</text>
+</g>
+</svg>
+</div>
+<!-- ========== END ILLUSTRATION ========== -->
+
+<h1>We'll be back shortly!</h1>
+<p class="message">
+  Our services are currently undergoing scheduled maintenance or experiencing
+  an unexpected interruption. We apologise for the inconvenience and are
+  working to restore everything as quickly as possible.
+</p>
+
+<div class="contact-card">
+  <p>Need help or have questions?</p>
+  <p>
+    Contact us at
+    <a href="mailto:support@qbic.zendesk.com">support@qbic.zendesk.com</a>
+  </p>
+</div>
+
+<p class="provider">
+  Provided by
+  <a href="https://www.info.qbic.uni-tuebingen.de/" target="_blank" rel="noopener noreferrer">
+    QBiC &mdash; Quantitative Biology Center
+  </a><br>
+  University of T&uuml;bingen
+</p>
+
+</div>
+</body>
+</html>

--- a/haproxy/errors/maintenance-illustration.svg
+++ b/haproxy/errors/maintenance-illustration.svg
@@ -1,0 +1,276 @@
+<svg viewBox="0 0 820 600" xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#fefcf3"/>
+    <stop offset="100%" stop-color="#fef5e0"/>
+  </linearGradient>
+  <linearGradient id="rackG" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#4a4a4a"/>
+    <stop offset="100%" stop-color="#2d2d2d"/>
+  </linearGradient>
+  <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+    <feDropShadow dx="2" dy="3" stdDeviation="3" flood-opacity=".12"/>
+  </filter>
+</defs>
+
+<!-- Background -->
+<rect width="820" height="600" fill="url(#bg)" rx="16"/>
+
+<!-- Floor -->
+<rect x="0" y="455" width="820" height="145" fill="#e8e0d0" rx="0"/>
+<line x1="0" y1="455" x2="820" y2="455" stroke="#d5cabb" stroke-width="2"/>
+<!-- Floor tiles hints -->
+<line x1="200" y1="455" x2="180" y2="600" stroke="#ddd4c4" stroke-width="1"/>
+<line x1="420" y1="455" x2="410" y2="600" stroke="#ddd4c4" stroke-width="1"/>
+<line x1="640" y1="455" x2="650" y2="600" stroke="#ddd4c4" stroke-width="1"/>
+
+<!-- ========== SMOKE CLOUDS ========== -->
+<ellipse cx="310" cy="60" rx="40" ry="22" fill="#e8e0d0" opacity=".35" class="smoke-anim"/>
+<ellipse cx="360" cy="45" rx="28" ry="16" fill="#e8e0d0" opacity=".30" class="smoke-anim-delay"/>
+<ellipse cx="280" cy="80" rx="22" ry="14" fill="#e8e0d0" opacity=".25" class="smoke-anim"/>
+
+<!-- ========== SPARKS ========== -->
+<polygon points="400,55 404,66 415,68 406,74 409,85 400,78 391,85 394,74 385,68 396,66" fill="#f1c40f" class="spark"/>
+<polygon points="245,48 248,56 255,57 249,62 251,70 245,65 239,70 241,62 235,57 242,56" fill="#f39c12" class="spark-delay"/>
+<polygon points="420,130 423,138 430,139 424,144 426,152 420,147 414,152 416,144 410,139 417,138" fill="#e74c3c" class="spark"/>
+<polygon points="210,135 212,140 217,141 213,144 214,149 210,146 206,149 207,144 203,141 208,140" fill="#f1c40f" class="spark-delay"/>
+
+<!-- ========== SERVER RACK (tilted) ========== -->
+<g transform="rotate(-10,300,380)" filter="url(#shadow)">
+  <!-- Main body -->
+  <rect x="220" y="100" width="160" height="358" rx="8" fill="url(#rackG)" stroke="#222" stroke-width="2.5"/>
+  <!-- Top vents -->
+  <rect x="240" y="108" width="120" height="4" rx="2" fill="#555"/>
+  <rect x="240" y="116" width="120" height="4" rx="2" fill="#555"/>
+  <rect x="240" y="124" width="120" height="4" rx="2" fill="#555"/>
+
+  <!-- Server unit 1 -->
+  <rect x="232" y="140" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+  <rect x="242" y="150" width="82" height="8" rx="2" fill="#555"/>
+  <rect x="242" y="164" width="58" height="8" rx="2" fill="#555"/>
+  <circle cx="348" cy="154" r="5" fill="#e74c3c" class="led-flicker"/>
+  <circle cx="348" cy="170" r="5" fill="#e74c3c" class="led-flicker"/>
+  <circle cx="336" cy="154" r="4" fill="#7f8c8d"/>
+
+  <!-- Server unit 2 -->
+  <rect x="232" y="198" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+  <rect x="242" y="208" width="82" height="8" rx="2" fill="#555"/>
+  <rect x="242" y="222" width="58" height="8" rx="2" fill="#555"/>
+  <circle cx="348" cy="212" r="5" fill="#e74c3c" class="led-flicker"/>
+  <circle cx="348" cy="228" r="5" fill="#7f8c8d"/>
+  <circle cx="336" cy="212" r="4" fill="#7f8c8d"/>
+
+  <!-- Server unit 3 -->
+  <rect x="232" y="256" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+  <rect x="242" y="266" width="82" height="8" rx="2" fill="#555"/>
+  <rect x="242" y="280" width="58" height="8" rx="2" fill="#555"/>
+  <circle cx="348" cy="270" r="5" fill="#e74c3c" class="led-flicker"/>
+  <circle cx="348" cy="286" r="5" fill="#e74c3c" class="led-flicker"/>
+  <circle cx="336" cy="270" r="4" fill="#7f8c8d"/>
+
+  <!-- Server unit 4 (bottom, more damaged) -->
+  <rect x="232" y="314" width="136" height="48" rx="4" fill="#3a3a3a" stroke="#555" stroke-width="1"/>
+  <rect x="242" y="324" width="82" height="8" rx="2" fill="#555"/>
+  <rect x="242" y="338" width="40" height="8" rx="2" fill="#555"/>
+  <circle cx="348" cy="328" r="5" fill="#e74c3c" class="led-flicker"/>
+  <circle cx="348" cy="344" r="5" fill="#7f8c8d"/>
+
+  <!-- Error screen on bottom unit -->
+  <rect x="248" y="354" width="65" height="35" rx="4" fill="#111" stroke="#444" stroke-width="1.5"/>
+  <text x="280" y="378" font-size="16" fill="#e74c3c" text-anchor="middle" font-family="monospace" font-weight="bold" class="led-flicker">503</text>
+
+  <!-- Loose wires hanging from rack -->
+  <path d="M232,400 Q218,425 228,450 Q232,460 222,470" stroke="#e74c3c" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M250,458 Q240,475 252,492" stroke="#3498db" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <path d="M370,420 Q385,440 375,460 Q368,475 380,485" stroke="#27ae60" stroke-width="2" fill="none" stroke-linecap="round"/>
+
+  <!-- Small smoke wisps from rack -->
+  <ellipse cx="290" cy="132" rx="14" ry="8" fill="#bbb" opacity=".3" class="smoke-anim"/>
+  <ellipse cx="340" cy="125" rx="10" ry="7" fill="#bbb" opacity=".25" class="smoke-anim-delay"/>
+</g>
+
+<!-- ========== FLYING PAPERS ========== -->
+<g class="paper-float">
+  <rect x="130" y="195" width="32" height="42" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(-22,146,216)"/>
+  <line x1="137" y1="207" x2="155" y2="204" stroke="#ccc" stroke-width="1" transform="rotate(-22,146,216)"/>
+  <line x1="138" y1="215" x2="152" y2="213" stroke="#ccc" stroke-width="1" transform="rotate(-22,146,216)"/>
+  <line x1="139" y1="223" x2="150" y2="221" stroke="#ccc" stroke-width="1" transform="rotate(-22,146,216)"/>
+</g>
+<g class="paper-float-alt">
+  <rect x="440" y="145" width="28" height="38" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(18,454,164)"/>
+  <line x1="446" y1="157" x2="462" y2="159" stroke="#ccc" stroke-width="1" transform="rotate(18,454,164)"/>
+  <line x1="447" y1="165" x2="460" y2="167" stroke="#ccc" stroke-width="1" transform="rotate(18,454,164)"/>
+</g>
+<g class="paper-float">
+  <rect x="540" y="245" width="32" height="42" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(32,556,266)"/>
+  <line x1="547" y1="259" x2="565" y2="263" stroke="#ccc" stroke-width="1" transform="rotate(32,556,266)"/>
+  <line x1="548" y1="267" x2="562" y2="270" stroke="#ccc" stroke-width="1" transform="rotate(32,556,266)"/>
+  <line x1="549" y1="275" x2="558" y2="277" stroke="#ccc" stroke-width="1" transform="rotate(32,556,266)"/>
+</g>
+<g class="paper-float-alt">
+  <rect x="100" y="340" width="26" height="34" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(-12,113,357)"/>
+  <line x1="106" y1="351" x2="120" y2="350" stroke="#ccc" stroke-width="1" transform="rotate(-12,113,357)"/>
+  <line x1="107" y1="358" x2="118" y2="357" stroke="#ccc" stroke-width="1" transform="rotate(-12,113,357)"/>
+</g>
+
+<!-- ========== WOMAN (left, holding wrench) ========== -->
+<g filter="url(#shadow)">
+  <!-- Shadow on floor -->
+  <ellipse cx="535" cy="455" rx="38" ry="7" fill="#000" opacity=".07"/>
+
+  <!-- Legs -->
+  <rect x="518" y="383" width="14" height="68" rx="5" fill="#2c3e50"/>
+  <rect x="540" y="383" width="14" height="68" rx="5" fill="#2c3e50"/>
+  <!-- Shoes -->
+  <ellipse cx="525" cy="453" rx="13" ry="6" fill="#1a1a1a"/>
+  <ellipse cx="547" cy="453" rx="13" ry="6" fill="#1a1a1a"/>
+
+  <!-- Body (blue lab coat / shirt) -->
+  <rect x="506" y="298" width="60" height="90" rx="14" fill="#3498db"/>
+  <!-- Coat details -->
+  <line x1="536" y1="310" x2="536" y2="385" stroke="#2980b9" stroke-width="1.5"/>
+  <!-- Pocket -->
+  <rect x="514" y="350" width="18" height="14" rx="2" fill="#2980b9" stroke="#2471a3" stroke-width=".8"/>
+
+  <!-- Left arm down -->
+  <rect x="490" y="304" width="18" height="58" rx="8" fill="#3498db" transform="rotate(8,499,304)"/>
+  <!-- Left hand -->
+  <circle cx="486" cy="368" r="9" fill="#f0c8a0"/>
+
+  <!-- Right arm up holding wrench -->
+  <rect x="564" y="260" width="18" height="60" rx="8" fill="#3498db" transform="rotate(-20,573,260)"/>
+  <!-- Right hand -->
+  <circle cx="582" cy="232" r="9" fill="#f0c8a0"/>
+
+  <!-- Wrench -->
+  <rect x="578" y="185" width="6" height="52" rx="2" fill="#95a5a6"/>
+  <!-- Wrench jaw (open end) -->
+  <path d="M574,185 L574,170 L580,168 L586,170 L586,185" fill="#95a5a6" stroke="#7f8c8d" stroke-width="1"/>
+  <path d="M577,170 L577,163 L583,163 L583,170" fill="#3498db"/>
+
+  <!-- Neck -->
+  <rect x="529" y="280" width="14" height="22" rx="4" fill="#f0c8a0"/>
+
+  <!-- Head -->
+  <circle cx="536" cy="260" r="30" fill="#f0c8a0"/>
+
+  <!-- Hair (brown, shoulder-length bob) -->
+  <path d="M506,250 Q506,222 536,218 Q566,222 566,250 L566,268 Q566,260 558,256 L558,262 Q550,258 536,258 Q522,258 514,262 L514,256 Q506,260 506,268 Z" fill="#8B4513"/>
+  <!-- Hair bangs -->
+  <path d="M510,246 Q515,230 536,228 Q557,230 562,246" fill="#8B4513"/>
+
+  <!-- Eyes - worried, looking up -->
+  <ellipse cx="525" cy="258" rx="5" ry="5.5" fill="white" stroke="#555" stroke-width=".5"/>
+  <circle cx="526" cy="255" r="2.8" fill="#2c3e50"/>
+  <circle cx="527" cy="254" r="1" fill="white"/>
+  <ellipse cx="545" cy="258" rx="5" ry="5.5" fill="white" stroke="#555" stroke-width=".5"/>
+  <circle cx="546" cy="255" r="2.8" fill="#2c3e50"/>
+  <circle cx="547" cy="254" r="1" fill="white"/>
+
+  <!-- Worried eyebrows -->
+  <line x1="519" y1="249" x2="530" y2="247" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="540" y1="247" x2="551" y2="249" stroke="#5a3010" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Mouth - worried O -->
+  <ellipse cx="536" cy="275" rx="5" ry="4" fill="#c0392b"/>
+
+  <!-- Blush -->
+  <ellipse cx="518" cy="268" rx="5" ry="3" fill="#f0a0a0" opacity=".35"/>
+  <ellipse cx="554" cy="268" rx="5" ry="3" fill="#f0a0a0" opacity=".35"/>
+</g>
+
+<!-- ========== MAN (right, holding laptop, frantic) ========== -->
+<g filter="url(#shadow)">
+  <!-- Shadow on floor -->
+  <ellipse cx="700" cy="455" rx="38" ry="7" fill="#000" opacity=".07"/>
+
+  <!-- Legs (one bent, stumbled pose) -->
+  <rect x="682" y="383" width="14" height="68" rx="5" fill="#34495e"/>
+  <rect x="706" y="383" width="14" height="68" rx="5" fill="#34495e" transform="rotate(5,713,383)"/>
+  <!-- Shoes -->
+  <ellipse cx="689" cy="453" rx="13" ry="6" fill="#1a1a1a"/>
+  <ellipse cx="716" cy="455" rx="13" ry="6" fill="#1a1a1a"/>
+
+  <!-- Body (purple shirt) -->
+  <rect x="672" y="298" width="60" height="90" rx="14" fill="#9b59b6"/>
+  <!-- Shirt collar detail -->
+  <path d="M692,298 L702,312 L712,298" fill="#8e44ad" stroke="#7d3c98" stroke-width=".8"/>
+
+  <!-- Left arm forward holding laptop -->
+  <rect x="653" y="300" width="18" height="52" rx="8" fill="#9b59b6" transform="rotate(25,662,300)"/>
+  <!-- Left hand -->
+  <circle cx="636" cy="350" r="9" fill="#dba67b"/>
+
+  <!-- Laptop -->
+  <g transform="rotate(-10,636,350)">
+    <rect x="610" y="338" width="54" height="34" rx="3" fill="#555" stroke="#333" stroke-width="1.5"/>
+    <!-- Screen bezel -->
+    <rect x="614" y="342" width="46" height="26" rx="2" fill="#1a1a2e"/>
+    <!-- Error on screen -->
+    <text x="637" y="360" font-size="10" fill="#e74c3c" text-anchor="middle" font-family="monospace" font-weight="bold" class="led-flicker">ERR</text>
+    <!-- Laptop base -->
+    <rect x="606" y="372" width="62" height="5" rx="2" fill="#666" stroke="#444" stroke-width=".8"/>
+  </g>
+
+  <!-- Right arm up, open hand gesture -->
+  <rect x="730" y="272" width="18" height="52" rx="8" fill="#9b59b6" transform="rotate(-28,739,272)"/>
+  <!-- Right hand open -->
+  <circle cx="752" cy="244" r="9" fill="#dba67b"/>
+  <!-- Fingers spread (panic!) -->
+  <line x1="748" y1="236" x2="744" y2="228" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="752" y1="235" x2="752" y2="226" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="756" y1="236" x2="760" y2="228" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="759" y1="239" x2="764" y2="233" stroke="#dba67b" stroke-width="3.5" stroke-linecap="round"/>
+
+  <!-- Neck -->
+  <rect x="695" y="280" width="14" height="22" rx="4" fill="#dba67b"/>
+
+  <!-- Head -->
+  <circle cx="702" cy="260" r="30" fill="#dba67b"/>
+
+  <!-- Hair (short dark) -->
+  <path d="M672,252 Q672,224 702,218 Q732,224 732,252 L732,246 Q732,232 702,228 Q672,232 672,246 Z" fill="#1a1a1a"/>
+  <!-- Hair tuft sticking up (frantic) -->
+  <path d="M696,220 Q694,210 700,208 Q701,215 704,220" fill="#1a1a1a"/>
+
+  <!-- Eyes - wide, panicked -->
+  <ellipse cx="691" cy="258" rx="6" ry="6.5" fill="white" stroke="#555" stroke-width=".5"/>
+  <circle cx="692" cy="258" r="3.8" fill="#2c3e50"/>
+  <circle cx="693" cy="256" r="1.3" fill="white"/>
+  <ellipse cx="713" cy="258" rx="6" ry="6.5" fill="white" stroke="#555" stroke-width=".5"/>
+  <circle cx="714" cy="258" r="3.8" fill="#2c3e50"/>
+  <circle cx="715" cy="256" r="1.3" fill="white"/>
+
+  <!-- Panicked eyebrows raised high -->
+  <line x1="684" y1="245" x2="697" y2="244" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="707" y1="244" x2="720" y2="245" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Mouth - open in shock -->
+  <ellipse cx="702" cy="277" rx="7" ry="5" fill="#c0392b"/>
+  <ellipse cx="702" cy="276" rx="5" ry="3" fill="#7b241c"/>
+
+  <!-- Sweat drops -->
+  <path d="M726,242 Q730,234 728,226" stroke="#3498db" stroke-width="2" fill="none" stroke-linecap="round" opacity=".7"/>
+  <circle cx="729" cy="224" r="2.5" fill="#3498db" opacity=".7"/>
+  <path d="M735,252 Q738,246 737,240" stroke="#3498db" stroke-width="1.5" fill="none" stroke-linecap="round" opacity=".5"/>
+  <circle cx="737" cy="238" r="2" fill="#3498db" opacity=".5"/>
+</g>
+
+<!-- ========== FLOOR DEBRIS ========== -->
+<rect x="370" y="462" width="32" height="22" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(-28,386,473)"/>
+<line x1="376" y1="470" x2="393" y2="466" stroke="#ddd" stroke-width=".8" transform="rotate(-28,386,473)"/>
+<rect x="435" y="468" width="26" height="18" rx="2" fill="#fff" stroke="#ddd" stroke-width="1" transform="rotate(18,448,477)"/>
+<!-- Fallen cable on floor -->
+<path d="M280,468 Q340,482 400,465 Q450,450 500,468" stroke="#555" stroke-width="3" fill="none" stroke-linecap="round" opacity=".4"/>
+<!-- A screw or bolt -->
+<circle cx="470" cy="460" r="3" fill="#95a5a6" stroke="#7f8c8d" stroke-width="1"/>
+<line x1="468" y1="460" x2="472" y2="460" stroke="#7f8c8d" stroke-width=".8"/>
+<line x1="470" y1="458" x2="470" y2="462" stroke="#7f8c8d" stroke-width=".8"/>
+
+<!-- ========== Small "out of order" sign on rack ========== -->
+<g transform="rotate(-10,300,380)">
+  <rect x="244" y="410" width="72" height="24" rx="4" fill="#e74c3c"/>
+  <text x="280" y="427" font-size="11" fill="white" text-anchor="middle" font-family="sans-serif" font-weight="bold">OFFLINE</text>
+</g>
+
+</svg>


### PR DESCRIPTION
## Summary

Add a branded HAProxy maintenance/error landing page (503) for the QBiC Data Manager.

## Changes

### `haproxy/errors/503.http`
- Custom HTML error page served by HAProxy when backends are unavailable
- Inline SVG illustration (tilted server rack, floating papers, smoke, animated sparks/LEDs)
- Contact information (`support@qbic.zendesk.com`) and provider details (QBiC – University of Tübingen)
- Fully self-contained — no external CSS, JS, or image dependencies
- CSS animations bring the illustration to life in the browser

### `haproxy/errors/maintenance-illustration.svg`
- Standalone SVG of the calm illustration (for reuse outside HAProxy)

### `haproxy/README.md`
- Documentation for the error page files, HAProxy configuration, format requirements, and customisation guide

## HAProxy errorfile format fix

The file follows HAProxy 2.7+ `errorfile` requirements:

| Requirement | Value |
|---|---|
| Status line | `HTTP/1.1 503 Service Temporarily Unavailable` |
| Content-Length | Exactly matches body size (15913 bytes) |
| Line endings | CRLF (`\r\n`) throughout — required by RFC 7230 |
| Body size | **15,913 bytes** — under HAProxy's 16 KB limit |

> [!NOTE]
> HAProxy 2.7+ strictly validates error file headers. Without a `Content-Length` header and proper CRLF line endings, the parser raises `unable to parse headers` and HAProxy refuses to start. The `Content-Length` value must exactly match the byte count of the body after the blank separator line.