### PR TITLE
docs: ADRs for FEAT-DATASET-CONNECTION (InvenioRDM dataset integration)

### DIFF
--- a/docs/adr/0001-associated-datasets-domain-model.md
+++ b/docs/adr/0001-associated-datasets-domain-model.md
@@ -64,7 +64,7 @@ grow.
 
 ## Decision Outcome
 
-**Chosen option: B with soft delete (O-variant of Option F).** Package `associated-dataset`
+**Chosen option: B with soft delete.** Package `associated-dataset`
 within the `project-management` bounded context; source-agnostic aggregate root carrying
 `source_type`, `external_handle`, connection state, and universal fields as regular columns;
 source-specific metadata encapsulated in a sealed `ResourceMetadata` hierarchy stored in a

--- a/docs/adr/0001-associated-datasets-domain-model.md
+++ b/docs/adr/0001-associated-datasets-domain-model.md
@@ -1,0 +1,170 @@
+# 0001 — Domain model and bounded context for associated datasets
+
+* Status: proposed
+* Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
+* Date: 2026-07-13
+
+Technical Story: [Connect associated InvenioRDM datasets with Data Manager projects](https://github.com/qbicsoftware/data-manager-app/issues/1466) (FEAT-DATASET-CONNECTION)
+
+## Context and Problem Statement
+
+Data Manager operates as a hub for project data. Beyond first-class data types (raw data via OpenBIS,
+measurement metadata), researchers need to **associate** additional external data resources with
+their projects — data they cannot or do not want to maintain inside Data Manager as first-class
+datasets. The first concrete source is InvenioRDM (Zenodo, FDAT), but future sources (LIMS,
+other remote resources) are anticipated.
+
+Two pre-existing design pressures complicate the introduction of this concept:
+
+1. The `project-management` bounded context already contains a `dataset` package (under
+   `project-management-infrastructure/dataset/`) that handles **OpenBIS raw measurement data**
+   (`LocalRawDataset*`, `RemoteRawData*`). That package is conceptually unrelated to the new
+   concept of "associated datasets" and must not be conflated.
+2. The project uses a source-agnostic domain event dispatch infrastructure (`DomainEvent` +
+   `DomainEventDispatcher`) and a sealed, source-typed extension pattern for value objects is
+   desirable to avoid InvenioRDM-specific leakage into the aggregate.
+
+The question is: how do we model **AssociatedDataset** so it (a) fits naturally in
+`project-management`, (b) avoids the package name collision, (c) is source-agnostic at the
+domain boundary, (d) supports a clean persistence strategy, and (e) can scale if assumptions
+grow.
+
+## Decision Drivers
+
+* Bounded context ownership — the concept is inherently project-scoped; `project-management` is
+  the only candidate context among the three.
+* Product framing — the stakeholders use the term "associated datasets" deliberately, signalling
+  a generalised, open-ended concept.
+* Avoid naming collision with existing OpenBIS `dataset` package.
+* Source-agnostic aggregate design — aggregate must not embed InvenioRDM-specific concepts
+  (DOIs, PIDs, communities) at the domain boundary.
+* Storage ergonomics — universal fields need straightforward SQL for sorting/filtering
+  (stories #1476/#1477); source-specific fields are stored opaquely.
+* Scale assumption — a project is expected to have fewer than ~100 associated datasets; at this
+  scale, JSON-path extraction is fast enough that index optimisation is deferred.
+* Evolution path — the storage design must have a documented path forward when assumptions
+  change (e.g., cross-project API endpoints emerge).
+* Data stewardship — soft delete (not hard delete) preserves the connection as a tombstone in
+  the `REMOVED` state for audit purposes; there is currently no user story exposing removed
+  connections in the UI.
+* No event sourcing / no snapshot history — stakeholder confirmed this is not required.
+
+## Considered Options
+
+* [Option A] New bounded context (e.g., `dataset-connection`) dedicated to this concept
+* [Option B] Package `associated-dataset` within `project-management`, source-agnostic aggregate
+  + sealed-metadata hierarchy, universal columns + MariaDB `JSON` column for source-specific
+  fields
+* [Option C] Package `associated-dataset` within `project-management`, InvenioRDM-specific
+  aggregate (no generalisation) — simplest for v1, risky for long-term evolution
+* [Option D] Full event sourcing for lifecycle — events as source of truth, projection-only
+  aggregate
+* [Option E] Aggregate + append-only event log (O2) — dual-write to current state + event log
+  table
+
+## Decision Outcome
+
+**Chosen option: B with soft delete (O-variant of Option F).** Package `associated-dataset`
+within the `project-management` bounded context; source-agnostic aggregate root carrying
+`source_type`, `external_handle`, connection state, and universal fields as regular columns;
+source-specific metadata encapsulated in a sealed `ResourceMetadata` hierarchy stored in a
+MariaDB `JSON` column; connection removal is a soft-delete transitioning to `state = REMOVED` (tombstone retained for audit, no UI exposure in v1). No event sourcing; no event log table.
+
+This decision resolves five sub-decisions:
+
+1. **Bounded context** → `project-management`
+2. **Package name** → `associated-dataset` (distinct from existing OpenBIS `dataset` package)
+3. **Generalisation posture** → source-agnostic aggregate root + sealed per-source metadata
+   hierarchy
+4. **Storage strategy** → universal fields as regular columns (for SQL ergonomics: `ORDER BY`,
+   `WHERE`, joins); source-specific fields in a MariaDB `JSON` column (not PostgreSQL `JSONB`,
+   which MariaDB does not support)
+5. **Connection removal semantics** → soft delete; tombstone retained; audit-only in v1
+
+### Positive Consequences
+
+* Package `associated-dataset` is self-describing and cleanly isolated from the OpenBIS raw-data
+  code, removing any risk of conflation.
+* Adding a new external source (e.g., LIMS) is a straightforward extension: add a
+  `SourceType` enum value, implement the corresponding `ResourceMetadata` subtype, add an
+  adapter. The aggregate root shape does not change.
+* Universal columns give clean SQL for sort/filter without JSON-path gymnastics.
+* Explicit scale assumption (`~100 datasets per project`) makes the performance evolution path
+  a deliberate choice when revisited, not a surprise refactor.
+* Soft-delete tombstone preserves audit provenance without adding a separate history table.
+* No event sourcing avoids CQRS, snapshot strategies, and event-versioning discipline that
+  the project has no foundation to support today.
+
+### Negative Consequences
+
+* Column names (`source_type`, `external_handle`) are more generic than InvenioRDM-specific
+  names (`doi`), making individual-row queries slightly less direct (filter on `source_type`
+  is required to isolate InvenioRDM rows).
+* JSON-path queries on source-specific fields (e.g., "find all InvenioRDM datasets where
+  community = X") rely on MariaDB's `JSON_EXTRACT` and are not indexed — acceptable at
+  <100 rows per project, not acceptable at larger scale without the evolution path.
+* Soft-delete adds a `state != 'REMOVED'` filter to the default query path; if this is
+  forgotten in one place, dead connections could surface.
+* Future evolution (generated columns, CQRS) is available but requires active maintenance when
+  assumptions are violated.
+
+## Pros and Cons of the Options
+
+### Option A — New bounded context (e.g., `dataset-connection`)
+
+* Good, because it gives the concept a clearly bounded home with its own identity.
+* Bad, because `project-management` is already the natural home — creating a new context adds
+  cross-context integration complexity that is not justified.
+* Bad, because it fragments the project-level aggregate (`Project` + its associated datasets
+  live in separate contexts).
+
+### Option B — `associated-dataset` package, source-agnostic aggregate, universal columns + JSON
+
+* Good, because it isolates the concept from the existing `dataset` package (OpenBIS) without
+  conflation.
+* Good, because the aggregate is source-agnostic — adding LIMS or another source is an
+  extension, not a refactor.
+* Good, because universal columns + JSON split matches the sort/filter/display needs at the
+  stakeholder-specified scale.
+* Good, because soft delete preserves audit provenance without a separate history table.
+* Bad, because the aggregate and DB schema carry generic field names (`external_handle`) instead
+  of source-specific ones (`doi`, `pid`), which is slightly less intuitive for InvenioRDM-only
+  readers.
+* Bad, because JSON-path indexing must be explicitly added (via generated columns) when scale
+  assumptions are violated.
+
+### Option C — InvenioRDM-specific aggregate within `project-management`
+
+* Good, because it is the simplest v1 design — no generalisation to pay for upfront.
+* Bad, because the product framing explicitly anticipates future sources; this option requires
+  a painful aggregate-level refactor whenever a second source type is added.
+* Bad, because InvenioRDM-specific concepts (DOIs, PIDs, communities) leak into the aggregate
+  root, violating the product's generalised framing.
+
+### Option D — Full event sourcing for lifecycle
+
+* Good, because it provides a complete audit trail and rebuild-any-point-in-time capability.
+* Good, because the project has half-built event-sourcing infrastructure (`DomainEvent`,
+  `DomainEventDispatcher`).
+* Bad, because this project has no tooling for the write-side/read-side split, snapshots, or
+  event-versioning discipline that full event sourcing requires.
+* Bad, because stakeholders explicitly rejected this need as unnecessary.
+* Bad, because it is over-investment for a feature with no audit-trail requirement.
+
+### Option E — Aggregate + append-only event log (O2)
+
+* Good, because it delivers audit history without CQRS or snapshot complexity.
+* Good, because it keeps the upgrade path to full event sourcing (Option D) open if the need
+  ever materialises.
+* Bad, because it introduces dual-write consistency risk (aggregate + log must stay in sync).
+* Bad, because the stakeholder confirmed audit history is not required.
+* Bad, because it adds a storage table and operational complexity that delivers no v1 value.
+
+## Links
+
+* Related by [ADR-0002](0002-invenio-rdm-api-client-credentials.md) — the `DatasetSource`
+  port contract defined there is the external-facing half of this aggregate's persistence.
+* Related by [ADR-0003](0003-connection-lifecycle-stewardship.md) — lifecycle semantics
+  (soft-delete, sync, notifications) build on this aggregate.
+* Superseded-in-part by [ADR-0004](0004-fair-signposting-deferred.md) — InvenioRDM
+  Signposting integration is deferred; this ADR's REST-based aggregate is the v1 decision.

--- a/docs/adr/0001-associated-datasets-domain-model.md
+++ b/docs/adr/0001-associated-datasets-domain-model.md
@@ -1,6 +1,6 @@
 # 0001 — Domain model and bounded context for associated datasets
 
-* Status: proposed
+* Status: approved
 * Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
 * Date: 2026-07-13
 

--- a/docs/adr/0002-invenio-rdm-api-client-credentials.md
+++ b/docs/adr/0002-invenio-rdm-api-client-credentials.md
@@ -101,6 +101,8 @@ Concretely:
 
 2. **Instance discovery (I2):** Instances are configured via `application.properties`:
    ```properties
+   # Example config, evaluate other extendable options for external instances
+   # No decision on array usage yet
    qbic.external-service.invenio-rdm.instances[0].name=Zenodo
    qbic.external-service.invenio-rdm.instances[0].url=https://zenodo.org
    qbic.external-service.invenio-rdm.instances[1].name=FDAT
@@ -126,7 +128,7 @@ Concretely:
 
 5. **Result types (R2):** Two distinct types — `SearchResult` (transient, paginated, drives the
    UI search display via `List<SearchHit>`) and `ResourceMetadata` (sealed hierarchy, persisted
-   as the canonical metadata snapshot on the aggregate). They overlap heavily in fields because
+   as the canonical metadata snapshot on the aggregate). `SearchResult` and `ResourceMetadata` overlap heavily in fields because
    InvenioRDM search hits carry most metadata inline, but they differ in purpose: one is
    "what the API returned right now" (transient), the other is "what we persist as the
    snapshot of truth."

--- a/docs/adr/0002-invenio-rdm-api-client-credentials.md
+++ b/docs/adr/0002-invenio-rdm-api-client-credentials.md
@@ -1,0 +1,262 @@
+# 0002 — InvenioRDM API client design and external credential security
+
+* Status: proposed
+* Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
+* Date: 2026-07-13
+
+Technical Story: [Connect associated InvenioRDM datasets with Data Manager projects](https://github.com/qbicsoftware/data-manager-app/issues/1466) (FEAT-DATASET-CONNECTION)
+
+## Context and Problem Statement
+
+Data Manager needs to talk to external InvenioRDM instances (Zenodo, FDAT) over HTTPS to
+**search** records, **resolve** record metadata, and **validate** user-provided Personal
+Access Tokens. The InvenioRDM REST API uses per-request token authentication; there is no
+session concept. Tokens are user-scoped: each user provides their own tokens for each
+instance they want to access.
+
+This introduces a design problem with three intertwined axes:
+
+1. **Port design** — how does the integration fit the codebase's existing patterns? The
+   codebase has two reference patterns for external integration: stateful session connectors
+   (OpenBIS, with session + keepalive + vault-backed credentials loaded at startup) and
+   stateless HTTP ports (TIB Terminology, ROR API). The InvenioRDM integration is neither
+   (there is no session with the external service), but it must be instance-parameterised
+   because we talk to multiple InvenioRDM instances.
+2. **Credential lifecycle** — tokens are per-user + per-instance, added by users at runtime.
+   This is neither a pre-wired service account (which the PKCS12 vault is set up for) nor
+   a one-way-hashed credential (which Data Manager's own PATs are). They must be **readable
+   at runtime**, not just verifiable.
+3. **Security boundary** — the production environment is HA (multiple application nodes).
+   Credential storage must be safe under concurrent writes on any node, and the plaintext
+   token value must never leak across architectural boundaries (into logs, persisted events,
+   UI state, cross-layer DTOs, or other users' invocations).
+
+## Decision Drivers
+
+* The InvenioRDM API is stateless; no session concept means no long-lived connector.
+* Multiple external instances (Zenodo, FDAT, and future ones) mean the client must be
+  parameterised by instance, not a singleton.
+* Tokens are user-scoped (not service-account scoped) — each user brings their own.
+* HA production environment — shared PKCS12 keystore on a local filesystem is not safe
+  under many concurrent runtime writes from multiple users.
+* The `DataManagerVault` writes to a local file on every `add()`; HA-safe only for secrets
+  that are set at deploy time (like OpenBIS credentials).
+* Tokens represent user access to external platforms; loss of a token is a security incident
+  for the affected researcher and possibly for the hosted external platform.
+* The architecture must make it structurally impossible to accidentally log, serialise, or
+  pass the plaintext token through higher layers.
+* Existing error-mapping infrastructure (`ErrorMessageTranslationService` +
+  `ApplicationException` + `UiExceptionHandler`) should be used for user-visible errors.
+* The port design must be source-agnostic at the domain boundary, consistent with the
+  generalised `associated-dataset` aggregate in [ADR-0001](0001-associated-datasets-domain-model.md).
+
+## Considered Options
+
+### Port design
+
+* [P1] OpenBIS-style session connector (login → session → HTTP calls on session)
+* [P2] Stateless port, instance-parameterised (recommended)
+* [P3] Hardcoded single-instance client (Zenodo-only)
+
+### Instance discovery
+
+* [I1] Hardcoded instances in code (only Zenodo + FDAT)
+* [I2] Configurable via `application.properties` (admin-controlled)
+* [I3] UI-managed instance list (users add arbitrary URLs)
+
+### Token scoping
+
+* [T1] Per-user-per-instance tokens (user brings their own)
+* [T2] Platform-wide service-account tokens (institutional token for everyone)
+* [T3] Hybrid (per-user default + optional service-account override)
+
+### Credential storage
+
+* [S1] Share the existing PKCS12 vault at runtime (writes go to local file, synced via FS)
+* [S2] Master AES-256 key in vault, encrypted token blobs in DB (HA-safe)
+* [S3] External secret manager (HashiCorp Vault, AWS Secrets Manager)
+* [S4] Plaintext in DB (unacceptable — ruled out)
+
+### Result type strategy
+
+* [R1] Single unified type for search hit and persisted metadata
+* [R2] Separate `SearchResult` (transient, paginated) and `ResourceMetadata` (persisted,
+  canonical snapshot)
+
+### Decryption boundary
+
+* [D1] Decryption at infrastructure boundary; plaintext never escapes method scope
+* [D2] Decrypted token passed as DTO in application layer
+
+## Decision Outcome
+
+**Chosen option: P2 + I2 + T1 + S2 + R2 + D1, with bounded sync retry, existing error
+mapping, and deferred strict-vs-lenient parsing policy.**
+
+Concretely:
+
+1. **Port design (P2):** A stateless `DatasetSource` port, instance-parameterised. The caller
+   provides `(query, InstanceConfig)` where `InstanceConfig` bundles `baseUrl` and optional
+   `AccessToken`. The port is responsible for the HTTP call and returns a result.
+
+2. **Instance discovery (I2):** Instances are configured via `application.properties`:
+   ```properties
+   qbic.external-service.invenio-rdm.instances[0].name=Zenodo
+   qbic.external-service.invenio-rdm.instances[0].url=https://zenodo.org
+   qbic.external-service.invenio-rdm.instances[1].name=FDAT
+   qbic.external-service.invenio-rdm.instances[1].url=https://fdat.uni-tuebingen.de
+   ```
+   Adding a new instance is an admin config change + redeploy. Never a UI entry (keeps the
+   security surface small — no arbitrary URLs).
+
+3. **Token scoping (T1):** Tokens are strictly per-user + per-instance. Each user owns their
+   tokens; the system never uses one user's token to fulfil another user's action
+   (**never-borrow-credentials principle**). This rule has forensic (InvenioRDM logs truthfully
+   represent who initiated each call) and privacy (one user never transparently gains access
+   to data their own token wouldn't grant them) implications.
+
+4. **Credential storage (S2):** The existing PKCS12 keystore vault holds **only the master
+   AES-256 encryption key** (distributed to each node at deploy time — already HA-safe
+   because the existing OpenBIS flow already uses this deployment pattern). Each user's
+   InvenioRDM PAT is individually AES-GCM-encrypted (`nonce + ciphertext + tag`) and stored
+   as a `VARBINARY` blob in the DB. Any node can decrypt (same key, shared DB). No local-file
+   concurrency problem. This is analogous to the existing `PersonalAccessTokenEncoder` pattern
+   (which uses PBKDF2 one-way hashing for DM PATs), upgraded to symmetric (reversible)
+   encryption because we *need* the plaintext.
+
+5. **Result types (R2):** Two distinct types — `SearchResult` (transient, paginated, drives the
+   UI search display via `List<SearchHit>`) and `ResourceMetadata` (sealed hierarchy, persisted
+   as the canonical metadata snapshot on the aggregate). They overlap heavily in fields because
+   InvenioRDM search hits carry most metadata inline, but they differ in purpose: one is
+   "what the API returned right now" (transient), the other is "what we persist as the
+   snapshot of truth."
+
+6. **Decryption boundary (D1):** The plaintext token value **never crosses an architectural
+   layer boundary**. It exists only within a `char[]` local variable in the infrastructure
+   adapter method that performs the HTTP call, and is zeroed after use (`Arrays.fill(token, '\0')`
+   in a `finally` block). The method returns only the result of the HTTP call
+   (`SearchResult` or `ResourceMetadata`), never the token.
+
+7. **Retry policy:** Bounded synchronous retry (3 attempts, exponential backoff, 5-second
+   ceiling) for **transient errors only**: HTTP 5xx, network timeouts, HTTP 429
+   (honouring the `Retry-After` header if present). No retry on 401/403/404 — these are
+   access/credential semantics, not transient failures.
+
+8. **Error surface:** User-visible errors use the existing
+   `ErrorMessageTranslationService` + `ApplicationException` + `UiExceptionHandler` pipeline.
+   Raw upstream errors go to server logs only. No correlation IDs are carried to the user
+   (no existing concept for them; users don't copy from toasts).
+
+9. **Credential status updates:** The `status` field of a stored credential (`VALID`,
+   `INVALIDATED`, `UNKNOWN`) is updated **only on explicit verification** (user clicks "Add"
+   or "Validate" in the UI). A failed sync due to 401/403 does **not** silently update the
+   credential status; it surfaces only an error to the user.
+
+10. **Parsing strictness (deferred):** The strict-vs-lenient JSON parsing question "for sync"
+    is **deferred** — it must be resolved before the sync logic is implemented, but is not
+    architectural in nature. Suggested policy (to be confirmed at implementation time):
+    lenient on search (preview, transient), strict on sync (preserve existing metadata if
+    the InvenioRDM response is not parsable in an expected format — don't silently corrupt
+    the snapshot).
+
+### Positive Consequences
+
+* Stateless port fits the codebase's established stateless-HTTP-adapter pattern (TIB, ROR).
+* No new external integration (no HashiCorp Vault); leverages the existing PKCS12 vault and
+  its HA distribution pattern.
+* The `DatasetSource` port is source-agnostic, consistent with the generalised aggregate
+  design — adding a LIMS source is an adapter-level change.
+* HA-safe: every node can read and decrypt tokens using the shared master key in the DB.
+* Decryption boundary rule makes accidental token bleed a structural impossibility: the
+  plaintext type (`char[]`) and scope (single method local) are the enforcement mechanism.
+* The bounded retry policy limits runaway load on InvenioRDM (especially important for rate
+  limits on anonymous endpoints).
+* Separation of `SearchResult` and `ResourceMetadata` keeps the persisted snapshot decoupled
+  from whatever InvenioRDM's search response happens to include today.
+
+### Negative Consequences
+
+* Users must maintain their own tokens per instance, and must re-add them when tokens expire
+  or are revoked on the external platform. UX must surface this clearly.
+* The master-key-from-vault pattern requires ops to deploy the same keystore to every HA node
+  — a dependency on deployment discipline.
+* Decryption-boundary discipline is a **convention**, not a language-level guarantee. It must
+  be reinforced in code review. There is no compiler-enforced barrier.
+* Separation of search result from persisted metadata means more types to maintain, though
+  the overlap is large and the benefit is clear.
+* Retry-and-fail on 401/403 gives a "transient-looking" transient failure for a credential
+  problem. The error message must clearly distinguish between "transient (try again)" and
+  "credential invalid (re-enter token)".
+
+## Pros and Cons of the Options
+
+### P1 — OpenBIS-style session connector
+
+* Good, because it is a familiar pattern in this codebase.
+* Bad, because InvenioRDM is not session-based; a session abstraction would be fictitious and
+  add operational complexity.
+* Bad, because it is inherently per-instance singleton; doesn't map to per-user token scoping.
+
+### P2 — Stateless `DatasetSource` port, instance-parameterised
+
+* Good, because it matches the actual API contract (per-request stateless HTTP).
+* Good, because it is source-agnostic at the port level.
+* Good, because it accommodates multiple instances trivially.
+* Bad, because it is a new pattern relative to the OpenBIS connector (slight familiarity cost
+  for maintainers).
+
+### I2 — Instances via `application.properties`
+
+* Good, because it is admin-controlled (no arbitrary URL injection via UI).
+* Good, because it fits the existing external-integration configuration pattern
+  (`qbic.external-service.*.*`).
+* Bad, because adding a new instance requires redeploy. For the known instances (Zenodo, FDAT)
+  this is fine.
+* Bad, because ops cannot update instances from within the running application.
+
+### T1 — Per-user-per-instance tokens only
+
+* Good, because it is the simplest mental model and eliminates credential-borrowing risk.
+* Good, because it aligns InvenioRDM audit logs ("user X performed action Y") with DM's
+  logical model.
+* Bad, because each user must maintain their own token; no shared institutional token path.
+* Bad, because a user leaving the project can orphan a connected dataset's sync path (mitigated
+  by the soft-delete + historical-snapshot retention).
+
+### S2 — Master key in vault + AES-GCM-encrypted blobs in DB
+
+* Good, because it eliminates the local-file concurrency problem of the existing PKCS12 vault
+  for runtime-written entries.
+* Good, because any HA node can decrypt using the shared master key + the shared DB.
+* Good, because the PKCS12 vault remains consistent with the existing OpenBIS secret-loading
+  pattern (same deployment discipline).
+* Bad, because it introduces a symmetric-encryption layer on top of the vault rather than
+  using the vault directly for token storage.
+
+### R2 — Separate `SearchResult` and `ResourceMetadata`
+
+* Good, because search (transient, paginated, UI-driving) and persistence (canonical snapshot)
+  are fundamentally different concerns with different lifetimes and ownership.
+* Good, because the persisted type is source-typed (sealed hierarchy) while search hits are
+  source-agnostic previews.
+* Bad, because overlapping field sets across two types adds maintenance surface.
+
+### D1 — Decryption boundary at infrastructure, plaintext never escapes scope
+
+* Good, because token bleed into logs, UI state, domain events, and application-layer DTOs
+  is made structurally impossible (the plaintext simply doesn't exist at those layers).
+* Good, because the enforcement mechanism is a local `char[]` variable + `finally`-block
+  zeroing — deterministic and auditable.
+* Good, because it reinforces the same invariant across the entire codebase.
+* Bad, because it is a **convention**, not a language-enforced barrier. Requires code review.
+* Bad, because `char[]` is slightly more awkward than `String` for Java developers accustomed
+  to `String` APIs.
+
+## Links
+
+* Depends on [ADR-0001](0001-associated-datasets-domain-model.md) — the `DatasetSource`
+  port is the external-facing half of the aggregate defined there.
+* Refined by [ADR-0003](0003-connection-lifecycle-stewardship.md) — lifecycle semantics
+  (sync, notifications, ACL) build on this port and credential storage.
+* Related to [ADR-0004](0004-fair-signposting-deferred.md) — InvenioRDM Signposting is
+  deferred; this ADR's REST-based client is the current integration mechanism.

--- a/docs/adr/0002-invenio-rdm-api-client-credentials.md
+++ b/docs/adr/0002-invenio-rdm-api-client-credentials.md
@@ -150,7 +150,7 @@ Concretely:
    (no existing concept for them; users don't copy from toasts).
 
 9. **Credential status updates:** The `status` field of a stored credential (`VALID`,
-   `INVALIDATED`, `UNKNOWN`) is updated **only on explicit verification** (user clicks "Add"
+   `INVALIDATED`) is updated **only on explicit verification** (user clicks "Add"
    or "Validate" in the UI). A failed sync due to 401/403 does **not** silently update the
    credential status; it surfaces only an error to the user.
 

--- a/docs/adr/0002-invenio-rdm-api-client-credentials.md
+++ b/docs/adr/0002-invenio-rdm-api-client-credentials.md
@@ -1,6 +1,6 @@
 # 0002 — InvenioRDM API client design and external credential security
 
-* Status: proposed
+* Status: approved
 * Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
 * Date: 2026-07-13
 

--- a/docs/adr/0003-connection-lifecycle-stewardship.md
+++ b/docs/adr/0003-connection-lifecycle-stewardship.md
@@ -1,0 +1,219 @@
+# 0003 — Dataset connection lifecycle and data stewardship
+
+* Status: proposed
+* Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
+* Date: 2026-07-13
+
+Technical Story: [Connect associated InvenioRDM datasets with Data Manager projects](https://github.com/qbicsoftware/data-manager-app/issues/1466) (FEAT-DATASET-CONNECTION)
+
+## Context and Problem Statement
+
+An *associated dataset* connects an external record (hosted on Zenodo, FDAT, or a future
+LIMS) to a Data Manager project. Once connected, the dataset has a lifecycle within the
+project: it can be viewed, synced, and removed. Each step in that lifecycle raises
+questions about:
+
+1. **Who can perform the action?** (ACL interaction — see
+   [ADR-0001 §Security](0001-associated-datasets-domain-model.md) for the domain model;
+   this ADR focuses on the lifecycle.)
+2. **What happens on the external platform?** (Do we use the user's own token, or do we
+   borrow someone else's?)
+3. **What do other project members see when things change?** (notification model)
+4. **What is preserved when the connection is removed?** (data stewardship)
+5. **How is sync structured?** (manual vs. background; user-initiated vs. automated)
+
+The project has existing patterns for project ACL (Spring Security ACL tables + permission
+model) and for email communication (`subscription-provider` SMTP). The design problem is
+which patterns to reuse and which to extend, and how to document the invariants
+operationally.
+
+## Decision Drivers
+
+* Project ACL is the natural authority for "who sees what in this project." Dataset
+  connections are attached to a project, not independent resources.
+* A sync operation against an external platform is an authenticated action on behalf of a
+  user. That user's identity and access privileges must flow through transparently. The
+  system must not silently use another user's credentials.
+* Notification should be user-actionable and not flood inboxes. The granularity should be:
+  "actor gets immediate feedback, other members get email" — not "every event goes to
+  everyone."
+* The existing `NotificationService` + `Exchange` in-memory bus (in the `broadcasting`
+  module) is acknowledged scaffolding — its own JavaDoc marks it "development purposes
+  only" — and does not actually reach users. Building on it would be cargo-culting.
+* Cross-context Artemis pub/sub is used in the project for one specific integration
+  (identity events flowing from `identity` into `project-management`). It is not a
+  general-purpose notification dispatch system for within-context events, and there is no
+  v1 need for another bounded context to observe dataset connection events.
+* Stakeholders confirmed that snapshot-sync history (who synced when, what metadata
+  snapshot was before) is **not required**. Data stewardship is provided by the soft-delete
+  tombstone and the last-known snapshot retention ([ADR-0001](0001-associated-datasets-domain-model.md)).
+
+## Considered Options
+
+### Sync model
+
+* [Y1] User-initiated sync only (v1); background refresh is an explicitly deferred future path
+* [Y2] Automatic sync on project page load
+* [Y3] Scheduled background sync (recurring JobRunr job)
+* [Y4] Per-connection opt-in auto-refresh with consent (`autoRefreshEnabled` flag on aggregate)
+
+### Sync credential policy
+
+* [C1] Invoking user's own token; public records don't need token; no credential borrowing
+* [C2] ConnectedBy user's stored token (credential borrowing)
+* [C3] Service-account token (institutional)
+
+### Notification delivery
+
+* [N1] Actor sees Vaadin toast synchronously; other project members receive email via
+  `subscription-provider`; domain events drive the email dispatch
+* [N2] Use `NotificationService` + `Exchange` in-memory bus
+* [N3] Use Artemis pub/sub for all notifications (including in-app)
+* [N4] Email only (no toast)
+
+### Notification scope (event → audience)
+
+| Event | Audience in recommended mapping |
+|---|---|
+| Dataset connected | All project members except actor |
+| Dataset connection removed | All project members except actor |
+| Sync succeeded (metadata updated) | Only `connectedBy` (low-signal) |
+| Sync changed access status | All project members except actor |
+| Sync failed (credential issue) | Only invoking user (actionable by them) |
+| User added / removed their own token | Only that user (personal credential action) |
+
+### Removed-connection visibility
+
+* [V1] Soft-deleted tombstone retained for audit; no UI exposure in v1
+* [V2] Soft-deleted tombstone retained; visible to project WRITE users via a "history" toggle
+
+## Decision Outcome
+
+**Chosen option: Y1 + C1 + N1 + V1 (with the event→audience mapping above).**
+
+Concretely:
+
+1. **Sync is user-initiated only** for v1. Background / scheduled sync is an explicitly
+   deferred future enhancement path. When it becomes a concern, the credential policy from
+   option Y4 (per-connection consent) is the natural evolution.
+
+2. **Never-borrow-credentials principle** in full:
+   * Each sync attempt uses the invoking user's own InvenioRDM token.
+   * Public records sync without a token.
+   * For restricted records: if the invoking user has no token → they are informed ("Add a
+     [instance] token to sync this restricted dataset"); if their token is insufficient →
+     "Your token does not grant access to this restricted record."
+   * The original `connectedBy` user's token is **never reused** to fulfil another user's sync.
+   * Historical metadata + `connectedBy` + `lastSyncedAt` are preserved permanently even if
+     the original connecting user leaves the project.
+
+3. **Notification delivery** via Vaadin toast + `subscription-provider` email. No use of
+   `NotificationService` / `Exchange` (dead scaffolding). No Artemis pub/sub for within-context
+   events (no v1 need; deferred if another bounded context ever needs to observe this feature).
+   Domain events emitted by the application layer drive the email dispatch to project members.
+   Actor is excluded from the project-member recipient list by design (the toast already tells
+   them what happened). A project-member email lookup (which does not yet exist as a query in
+   the codebase) needs to be built as a prerequisite. Email delivery is not guaranteed —
+   SMTP failures silently drop notifications; this is an accepted risk consistent with the
+   rest of the application.
+
+4. **Removed-connection rows retained for audit.** No user story currently exposes them;
+   exposing removed connections in the UI is a future decision if it arises.
+
+5. **ACL inheritance:** Connections inherit project ACL without separate ACL entries. The
+   role mapping from the project ACL tables applies uniformly:
+
+   | Action | Minimum permission |
+   |---|---|
+   | View connected datasets | `READ` on project |
+   | Connect a dataset | `WRITE` on project |
+   | Remove a connection | `WRITE` on project |
+   | Sync a dataset | `READ` on project |
+   | Manage own InvenioRDM tokens | Authenticated (no project permission needed —
+     credentials are user-level) |
+
+6. **Cross-user visibility principle** (recorded for ADR reference):
+
+   > Visibility of a connected dataset follows project ACL. Operations requiring external
+   > authentication (e.g., sync of a restricted record) succeed if the invoking user has
+   > configured the instance with a valid token granting sufficient access to the external
+   > record; otherwise they fail. Failure is reported to the invoking user as a user-facing
+   > error per the error-mapping pipeline ([ADR-0002](0002-invenio-rdm-api-client-credentials.md)).
+
+### Positive Consequences
+
+* Lifecycle semantics are simple and explicit — fewer failure modes, easier debugging.
+* No JobRunr integration for sync reduces the v1 scope significantly.
+* Never-borrow-credentials gives forensic and privacy correctness: external platform logs
+  and DM logs both accurately reflect who initiated each action.
+* Toast + email matches the mental model users expect: "I get immediate feedback when I'm
+  looking; my teammates get an email when they aren't."
+* No new notification persistence model is built; we rely on email SMTP + the existing
+  `subscription-provider`, which is production-grade.
+* Soft-delete audit retention leaves the door open for future UI without requiring schema
+  migrations.
+
+### Negative Consequences
+
+* No background sync means stale metadata between syncs. Mitigation: the UX makes sync
+  state visible (last-synced timestamp) so users know when they might want to re-sync.
+* Project-member email lookup needs to be built as a new service — not a major cost, but
+  a prerequisite that must be scheduled.
+* Email delivery is not guaranteed; users relying on email for notifications could miss
+  changes if SMTP has issues. Mitigation (if it becomes a real problem): introduce an
+  in-app unread-notification model later.
+* Actor is excluded from the "other members" mailing list by convention. This is
+  deliberate (they already saw it via toast), but it means actor-initiated events never
+  reach their own email inbox, even when the actor is offline. This is a reasonable
+  trade-off in v1.
+
+## Pros and Cons of the Options
+
+### Y1 — User-initiated sync only (chosen)
+
+* Good, because it keeps the v1 surface minimal and explicit.
+* Good, because no "who is the background user?" design problem arises.
+* Good, because credential-borrowing risk cannot exist without automation.
+* Bad, because metadata can go stale between explicit syncs.
+
+### Y4 — Per-connection opt-in auto-refresh (deferred future)
+
+* Good, because it preserves the never-borrow-credentials principle via explicit user
+  consent.
+* Good, because it's the natural evolution path if v1 stakeholders later want background
+  refresh.
+* Bad, because it adds aggregate state and JobRunr integration that isn't needed in v1.
+
+### C1 — Invoking user's own token; no borrowing (chosen)
+
+* Good, because it preserves forensic non-repudiation and privacy boundaries.
+* Good, because a user who lacks access to a record cannot silently gain visibility.
+* Bad, because a user who has no token cannot sync a restricted dataset they can otherwise
+  "see" in DM. The UX must explain this clearly.
+
+### N1 — Toast + email via domain events + SMTP (chosen)
+
+* Good, because it uses production-grade paths (`subscription-provider`).
+* Good, because it doesn't depend on dead scaffolding (`NotificationService`).
+* Good, because it keeps in-app and out-of-band notifications aligned (actor sees immediate
+  feedback; others get email).
+* Bad, because email delivery is not guaranteed. If SMTP fails, a silent drop occurs.
+
+### V1 — Soft-delete tombstone, no UI exposure (chosen)
+
+* Good, because it preserves audit provenance without adding UI complexity that has no
+  user story driving it.
+* Good, because it is non-irreversible: exposing the history is a UI-layer decision that
+  doesn't require schema changes later.
+* Bad, because audit rows in the DB are invisible to end users by default; the audit
+  capability is latent until a story is raised.
+
+## Links
+
+* Depends on [ADR-0001](0001-associated-datasets-domain-model.md) — the aggregate and
+  soft-delete semantics are defined there.
+* Depends on [ADR-0002](0002-invenio-rdm-api-client-credentials.md) — the
+  never-borrow-credentials principle and credential storage shape the sync + token flows here.
+* Related to [ADR-0004](0004-fair-signposting-deferred.md) — if InvenioRDM Signposting
+  becomes the primary integration in 1-2 years, the lifecycle semantics here remain intact;
+  only the client layer changes ([ADR-0002](0002-invenio-rdm-api-client-credentials.md)).

--- a/docs/adr/0003-connection-lifecycle-stewardship.md
+++ b/docs/adr/0003-connection-lifecycle-stewardship.md
@@ -1,6 +1,6 @@
 # 0003 — Dataset connection lifecycle and data stewardship
 
-* Status: proposed
+* Status: approved
 * Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
 * Date: 2026-07-13
 

--- a/docs/adr/0004-fair-signposting-deferred.md
+++ b/docs/adr/0004-fair-signposting-deferred.md
@@ -1,0 +1,100 @@
+# 0004 — FAIR Signposting integration deferred
+
+* Status: proposed
+* Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
+* Date: 2026-07-13
+
+Technical Story: [Connect associated InvenioRDM datasets with Data Manager projects](https://github.com/qbicsoftware/data-manager-app/issues/1466) (FEAT-DATASET-CONNECTION)
+
+## Context and Problem Statement
+
+The feature originally envisioned integration with published InvenioRDM datasets via
+**FAIR Signposting** — an HTTP-header-based discovery mechanism where resources advertise
+machine-readable metadata links via RFC 8288 `Link:` headers (e.g.,
+`Link: <doi:...>; rel="describedby"`). FAIR Signposting would have let Data Manager follow
+a signpost to discover structured metadata without calling the InvenioRDM API directly.
+
+An upstream bug in InvenioRDM's FAIR Signposting serialization has been reported. The fix
+is slated for a future major release. Adopting FAIR Signposting today would mean either:
+
+(a) Implementing around the bug (fragile, incorrect behaviour for signposted metadata), or
+(b) Delaying the feature until the upstream fix lands, which is on an unknown timeline
+    that is likely more than 1-2 years out.
+
+The team must decide whether to (i) proceed now with a conventional InvenioRDM REST API
+integration, (ii) wait for the upstream fix, or (iii) pursue some hybrid path.
+
+## Decision Drivers
+
+* The upstream bug blocks FAIR Signposting-based integration today.
+* The fix's timeline is ~1-2 years out, making a hold-the-feature strategy unacceptable.
+* FAIR Signposting, when correctly implemented, is a metadata-discovery mechanism — it
+  does not replace the need to fetch actual record data. It is a companion to (not a
+  replacement for) the REST API.
+* Data Manager's InvenioRDM integration, designed via
+  [ADR-0002](0002-invenio-rdm-api-client-credentials.md), uses a source-agnostic
+  `DatasetSource` port that can naturally accommodate a future `InvenioRdmSignpostingSource`
+  adapter alongside or in place of the REST adapter.
+* There is no current business requirement to surface signposted metadata through a
+  different channel than the REST API; the REST API provides all the record data we need.
+
+## Considered Options
+
+* [A] Implement the feature using FAIR Signposting today — infeasible because of the bug.
+* [B] Hold the entire feature until the upstream fix is released (timeline: 1-2+ years).
+* [C] Implement the feature using the InvenioRDM REST OpenAPI now; defer FAIR Signposting
+  as a future enhancement that can be picked up when the upstream fix is stable.
+
+## Decision Outcome
+
+**Chosen option: C.**
+
+The feature proceeds against the conventional InvenioRDM REST OpenAPI, as documented in
+[ADR-0002](0002-invenio-rdm-api-client-credentials.md). Integration with FAIR Signposting
+is **explicitly deferred**, not abandoned.
+
+### Positive Consequences
+
+* The feature can ship on the timeline stakeholders need (now), not the upstream bug-fix
+  timeline.
+* The source-agnostic `DatasetSource` port design in [ADR-0002](0002-invenio-rdm-api-client-credentials.md)
+  already leaves room for a future `InvenioRdmSignpostingSource` adapter. When the upstream
+  fix lands, adding the new adapter is a localized change; the aggregate, storage, and
+  lifecycle semantics defined in [ADR-0001](0001-associated-datasets-domain-model.md) and
+  [ADR-0003](0003-connection-lifecycle-stewardship.md) do not change.
+* The aggregate shape, DB schema, sealed metadata hierarchy, connection lifecycle,
+  credential security, and notification model are all independent of the integration
+  transport. Replacing or complementing the REST client with a Signposting client is an
+  infrastructure-layer change, not an aggregate-layer change.
+
+### Negative Consequences
+
+* The project does not use FAIR Signposting today, which means Data Manager does not model
+  the discovery mechanism that the FAIR ecosystem is converging toward. When Signposting
+  is revisited, the team must re-acquire context on how to integrate it (mitigated by the
+  existence of this ADR, which records the "why now, why not yet" rationale).
+* If the upstream bug takes longer to fix than expected (>2 years), the deferral
+  decision remains valid but may need a formal revisit — the horizon in this ADR is
+  explicit.
+
+## Revisit Criteria
+
+This ADR should be revisited (and possibly superseded) when:
+
+1. InvenioRDM ships a stable major release with a working FAIR Signposting
+   serialization bug fix.
+2. A new user story explicitly calls for Data Manager to support FAIR Signposting
+   discovery (e.g., a story requiring metadata to follow linked-data chains across
+   platforms).
+
+Until either criterion is met, the REST-based integration in
+[ADR-0002](0002-invenio-rdm-api-client-credentials.md) remains the chosen path.
+
+## Links
+
+* Deferment of: the originally intended integration mechanism for
+  [ADR-0002](0002-invenio-rdm-api-client-credentials.md).
+* Refinable by a future ADR when Signposting becomes the primary integration (likely
+  to supersede part of ADR-0002, not ADRs 0001 or 0003).
+* Depends on [ADR-0001](0001-associated-datasets-domain-model.md) — the aggregate and
+  storage shape are independent of whether the integration is REST or Signposting.

--- a/docs/adr/0004-fair-signposting-deferred.md
+++ b/docs/adr/0004-fair-signposting-deferred.md
@@ -1,6 +1,6 @@
 # 0004 — FAIR Signposting integration deferred
 
-* Status: proposed
+* Status: approved
 * Deciders: project team (interviewed via [`interview-feat-dataset-connection.md`](interview-feat-dataset-connection.md))
 * Date: 2026-07-13
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,7 +52,10 @@ Where `NNNN` is a zero-padded, four-digit sequential number assigned in creation
 
 | # | Title | Status | Date |
 |---|---|---|---|
-| *(no ADRs recorded yet)* | | | |
+| [0001](0001-associated-datasets-domain-model.md) | Domain model and bounded context for associated datasets | proposed | 2026-07-13 |
+| [0002](0002-invenio-rdm-api-client-credentials.md) | InvenioRDM API client design and external credential security | proposed | 2026-07-13 |
+| [0003](0003-connection-lifecycle-stewardship.md) | Dataset connection lifecycle and data stewardship | proposed | 2026-07-13 |
+| [0004](0004-fair-signposting-deferred.md) | FAIR Signposting integration deferred | proposed | 2026-07-13 |
 
 *Update this table whenever a new ADR is added.*
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,10 +52,10 @@ Where `NNNN` is a zero-padded, four-digit sequential number assigned in creation
 
 | # | Title | Status | Date |
 |---|---|---|---|
-| [0001](0001-associated-datasets-domain-model.md) | Domain model and bounded context for associated datasets | proposed | 2026-07-13 |
-| [0002](0002-invenio-rdm-api-client-credentials.md) | InvenioRDM API client design and external credential security | proposed | 2026-07-13 |
-| [0003](0003-connection-lifecycle-stewardship.md) | Dataset connection lifecycle and data stewardship | proposed | 2026-07-13 |
-| [0004](0004-fair-signposting-deferred.md) | FAIR Signposting integration deferred | proposed | 2026-07-13 |
+| [0001](0001-associated-datasets-domain-model.md) | Domain model and bounded context for associated datasets | approved | 2026-07-13 |
+| [0002](0002-invenio-rdm-api-client-credentials.md) | InvenioRDM API client design and external credential security | approved | 2026-07-13 |
+| [0003](0003-connection-lifecycle-stewardship.md) | Dataset connection lifecycle and data stewardship | approved | 2026-07-13 |
+| [0004](0004-fair-signposting-deferred.md) | FAIR Signposting integration deferred | approved | 2026-07-13 |
 
 *Update this table whenever a new ADR is added.*
 

--- a/docs/adr/interview-feat-dataset-connection.md
+++ b/docs/adr/interview-feat-dataset-connection.md
@@ -1,0 +1,152 @@
+# Interview: Architectural Decisions for FEAT-DATASET-CONNECTION
+
+> **Feature:** [Connect associated InvenioRDM datasets with Data Manager projects](https://github.com/qbicsoftware/data-manager-app/issues/1466)
+> **Purpose:** Aligned understanding of architectural decisions before implementation, to be captured in ADRs.
+> **Started:** 2026-07-13
+> **Status:** 🟡 In Progress
+
+6a## Interview Timeline
+
+| # | Topic / Question | Status | Decision / Notes |
+|---|---|---|---|
+| 1 | Bounded context ownership | ✅ Resolved | **`project-management`** bounded context. Associated-dataset concept is inherently tied to a project. |
+| 2 | Package / domain naming | ✅ Resolved | **`associated-dataset`** — deliberately generalised, distinct from existing OpenBIS `dataset` package. Product language: users connect "associated data" beyond first-class raw data. |
+| 3 | Domain model generalisation strategy | ✅ Resolved | Source-agnostic aggregate (identity + lifecycle) + sealed per-source metadata hierarchy. Aggregate columns carry generic identity fields (`source_type`, `external_handle`, connection state). Source-specific metadata lives in a sealed-value-object type hierarchy (`ResourceMetadata`). |
+| 3a | Storage strategy for source-specific metadata | ✅ Resolved | **Option 2:** Universal fields as regular columns (`title`, `publishedAt`, `accessLevel`, `accessLink`) — needed for querying/sorting per stories #1476/#1477. Source-specific fields in a **JSONB column**. |
+| 4 | Integration mechanism — InvenioRDM API client design | ✅ Resolved | Stateless `DatasetSource` port, instance-parameterised. **Per-user-per-instance** token scoping (no service-account tokens). Instances configurable via `application.properties` (admin-controlled, no free-form UI entry = small security surface). Separate `SearchResult` (transient, paginated, UI display) and `ResourceMetadata` (persisted value object). |
+| 5 | Credential management — where and how are tokens stored? | ✅ Resolved (pending confirmation of 5a–5c) | **Three-layer strategy:** At-rest = AES-GCM-encrypted in DB column. In-transit = HTTPS only. In-memory = `char[]` confined to the infrastructure adapter method performing the HTTP call, zeroed after use. **Decryption boundary rule:** plaintext token value never crosses an architectural layer boundary. See ADR candidate 0003. Open sub-q: 5a (background sync fit), 5b (JobRunr fit), 5c (master key source). |
+| 6 | Synchronisation model | ✅ Resolved | **User-initiated only for v1** (no background JobRunr sync for now — future enhancement path). Sync uses the invoking user's own token (**never-borrow-credentials rule** — see ADR 0003). Public records sync without token. Restricted records: invoking user must have their own token; if absent or insufficient, user is informed. Historical metadata + `connectedBy` + `lastSyncedAt` preserved permanently. Sync updates: metadata + access status + notify project members. |
+| 7 | Notification mechanism | ✅ Resolved | **Actor sees Vaadin toast** (synchronous, no infrastructure). **Other project members receive email** via `subscription-provider` (SMTP), driven by domain events emitted from application layer. `NotificationService` + `Exchange` NOT used (dead scaffolding, never reaches users). Cross-context Artemis deferred (no v1 need). Caveats: project-member email lookup needs to be built; email delivery not guaranteed (existing risk); actor excluded from recipient list by design. |
+| 8 | Database schema | ✅ Resolved | **Soft delete** on connection removal (`state = REMOVED`). Two new tables in `data-management` datasource: `associated_dataset` (source_type + external_handle, state, universal columns for title/access_level/access_link/published_at, `metadata_json` typed **`JSON` (MariaDB)** for source-specific fields, connected_by_user_id as soft FK to identity, linked_experiment_id as hard FK, connected_at, last_synced_at) + `user_invenio_rdm_credential` (user_id, instance_key plaintext, encrypted_token VARBINARY AES-GCM, status, timestamps; unique on (user_id, instance_key)). Instances NOT stored in DB (application.properties config). **Schema migration pattern**: incremental script `sql/migrations/...` added alongside `complete-schema.sql` (establishes pattern for the project; first entry of this type). **No event sourcing / no event log / no snapshot history** (stakeholder call). **Explicit design assumption:** ~100 associated datasets per project (stated in ADR). **Performance evolution path** (for when assumptions change — e.g., cross-project API endpoints): (a) generated virtual column + index on JSON path, (b) promote field to regular column, (c) CQRS read model, (d) EHCache application cache. MariaDB views do NOT improve JSON-path performance (no materialized views); views are for query ergonomics only. |
+| 9 | Security & ACL implications | ✅ Resolved | (1) Dataset connections **inherit project ACL** — no per-connection ACL entries. (2) Role mapping: VIEW=READ on project, CONNECT/REMOVE=WRITE, SYNC=READ, own-credential-management=authenticated. (3) Principle for ADR (reframed): "Visibility of a connected dataset follows project ACL. Operations requiring external authentication (e.g., sync of restricted records) succeed if the invoking user has configured the instance with a valid token granting sufficient access to the external record; otherwise they fail." (4) Soft-deleted rows retained **for audit purposes**; there is **no user story** exposing removed-connection visibility in the UI — that is a future decision if it arises. |
+| 10 | UI placement | 🚫 Out of scope — design concern, not architectural | UI placement (tab / sidebar / page) is a design-layer decision delegated to the design system / UX, not a structural architectural decision. The `AssociatedDatasetsDemoV2` prototype is a UX artifact for discussing user stories with users, not an architectural reference. This falls outside ADR scope. Principle: ADRs capture structural invariants; UI placement does not constrain architectural evolution. |
+| 11 | Error handling & resilience | ✅ Resolved | (11a) Bounded sync retry: 3 attempts, exponential backoff, 5s max. For transient errors only (5xx, timeout, 429). Honour `Retry-After` header. No retry on 401/403/404. (11b) No correlation ID. Use existing `ErrorMessageTranslationService` + `ApplicationException` + `UiExceptionHandler` pipeline. Raw upstream errors in server logs only. (11c) **Deferred** — must be resolved before sync logic implementation. Open q: strict vs. lenient parsing on sync, lenient on search. (11d) Credential `status` updates only on explicit verification calls (token add/validate from UI), never from a failed sync call. |
+| 12 | FAIR Signposting future-proofing | ✅ Resolved | Dedicated ADR: (a) decision to defer; (b) reason = upstream serialization bug in InvenioRDM; (c) horizon ≈ 1-2 years. Minimal commitment: existing port design naturally accommodates future adapter. ADR is decision-only, no structural-commitment chapter. |
+
+---
+
+## ADR Plan (to be drafted after interview)
+
+| # | Title | Scope | Status |
+|---|---|---|---|
+| 0001 | Bounded context, packaging, and domain model for associated datasets | Questions 1, 2, 3, 3a — the domain-modelling cluster | 📋 Ready to draft (pending final sign-off on storage choice, question 3a) |
+| 0002 | InvenioRDM API client — stateless port, instance-parameterised | Question 4 | ✅ Ready to draft (pending Q5 — where tokens live) |
+| 0003 | InvenioRDM credential storage strategy | Question 5 | 📋 Pending interview |
+| 0004 | Dataset connection synchronisation model | Question 6 | 📋 Pending interview |
+| 0005 | Project change notification for dataset connection events | Question 7 | 📋 Pending interview |
+| ... | *(additional ADRs as discovered)* | | 📋 |
+
+---
+
+## Key Context (gathered from codebase)
+
+- **Feature issue:** #1466 — 13 child stories (#1467–#1479), all 🔴 Open
+- **Target platforms:** Zenodo, FDAT (both InvenioRDM instances; future: LIMS, other remote resources)
+- **Integration approach:** Conventional InvenioRDM OpenAPI (FAIR Signposting dropped due to upstream bug)
+- **Existing demo:** `AssociatedDatasetsDemoV2.java` (sidebar prototype; uses "Associated Datasets" terminology)
+- **Existing `dataset` package (`project-management-infrastructure/dataset/`):** OpenBIS raw data only — `LocalRawDataset*`, `RemoteRawData*`. Distinct concept. Must NOT be conflated.
+- **Domain event pattern:** `DomainEvent` subclasses + `DomainEventDispatcher` (in-process)
+- **External integration reference patterns:** OpenBIS (`infrastructure/sample/openbis/`) uses session + connector + vault + mock for `development` profile; TIB/ROR are stateless HTTP clients
+- **Notification pattern:** `NotificationService` via `MessageBusSubmission` (Artemis/JMS pub-sub)
+- **Secret storage:** PKCS12 keystore vault (used for OpenBIS + personal access tokens)
+- **Existing data sources pattern:** Two datasources (`data-management`, `finance`) with separate entity managers
+
+---
+
+## InvenioRDM Client Design (Q4, recorded for ADR 0002)
+
+```java
+interface DatasetSource {
+    SearchResult search(String query, InstanceConfig instance);
+    Optional<ResourceMetadata> resolve(String externalHandle, InstanceConfig instance);
+    boolean validateToken(InstanceConfig instance);
+}
+
+record SearchResult(List<SearchHit> hits, int totalCount) {}
+record InstanceConfig(String baseUrl, Optional<AccessToken> token) {}
+
+// Transient — from search hits
+record SearchHit(
+    String externalHandle, String title, String creator, String resourceType,
+    String community, AccessStatus accessStatus, String accessLink, Instant publishedAt
+) {}
+
+// Persisted — sealed value object on AssociatedDataset aggregate (see ADR 0001)
+record InvenioRdmResourceMetadata(...) implements ResourceMetadata {}
+```
+
+**Instance list** is configured via `application.properties`:
+```properties
+qbic.external-service.invenio-rdm.instances[0].name=Zenodo
+qbic.external-service.invenio-rdm.instances[0].url=https://zenodo.org
+qbic.external-service.invenio-rdm.instances[1].name=FDAT
+qbic.external-service.invenio-rdm.instances[1].url=https://fdat.uni-tuebingen.de
+```
+
+---
+
+## Key Product Insights (recorded from interview)
+
+1. "Associated dataset" is **deliberately generalised**. Data Manager is a hub; beyond first-class data types (raw data via OpenBIS, measurement metadata), users associate other external data they cannot maintain inside Data Manager. InvenioRDM is the first concrete source; LIMS and other remote resources are plausible future sources.
+2. The aggregate design must not narrow the concept to InvenioRDM-specific structures (DOIs, PIDs) at the domain boundary.
+3. Source-agnostic aggregate root + sealed per-source metadata hierarchy is acceptable: minimal investment now (two things: `source_type + external_handle` instead of `doi`; `DatasetSource` port interface) avoids aggregate-level refactoring later.
+4. For DB storage: universal fields as regular columns (query/sort/filter needs), source-specific fields in JSONB.
+
+---
+
+## Concrete Domain Example (recorded for ADR 0001 context)
+
+```java
+// ── Aggregate: identity + lifecycle (generic) ──
+@Entity
+class AssociatedDataset {
+    AssociatedDatasetId id;
+    ProjectId projectId;
+    SourceType sourceType;              // enum: INVENIO_RDM
+    String externalHandle;              // DOI / LIMS ID / URL — opaque to root
+    DatasetConnectionState state;       // CONNECTED, SYNCING, ERROR, REMOVED
+    UserId connectedBy;
+    ExperimentId linkedExperiment;      // optional
+    Instant connectedAt;
+    Instant lastSyncedAt;
+    ResourceMetadata resourceMetadata;  // sealed, source-typed
+}
+
+// ── Source-specific metadata: sealed hierarchy ──
+sealed interface ResourceMetadata
+    permits InvenioRdmResourceMetadata /*, LimsResourceMetadata */ {
+    String title();
+    String accessLevel();
+    String accessLink();
+    Instant publishedAt();
+}
+
+record InvenioRdmResourceMetadata(
+    String title, String pid, String version,
+    String accessLevel, String accessLink, Instant publishedAt,
+    String resourceProvider, String creator, String resourceType, String community
+) implements ResourceMetadata {}
+
+// ── DB: associated_dataset ──
+// PK + project_id + source_type + external_handle + state + connected_by
+//   + linked_experiment + connected_at + last_synced_at
+//   + title + published_at + access_level + access_link     ← universal columns
+//   + metadata_json   (JSONB)                               ← source-specific
+```
+
+---
+
+*This file is updated incrementally as the interview progresses.*
+
+## Progress bar
+
+- [x] Q1–Q3, Q3a: Domain modelling cluster → ADR 0001
+- [x] Q4: Integration mechanism → ADR 0002
+- [x] Q5: Credential storage → ADR 0003
+- [x] Q6: Synchronisation model
+- [x] Q7: Notification mechanism
+- [x] Q8: Database schema
+- [x] Q9: Security & ACL
+- [ ] Q10: UI placement
+- [x] Q11: Error handling & resilience
+- [x] Q12: FAIR Signposting future-proofing


### PR DESCRIPTION
## Summary

Capture architectural decisions for the InvenioRDM dataset connection feature (#1466) as four Architecture Decision Records, drafted after a structured design interview with the team.

## ADRs

| # | Title | Scope |
|---|---|---|
| [0001](docs/adr/0001-associated-datasets-domain-model.md) | Domain model and bounded context for associated datasets | `project-management` bounded context; `associated-dataset` package; source-agnostic aggregate + sealed metadata hierarchy; MariaDB JSON column; soft-delete; scale assumption (~100 datasets/project) |
| [0002](docs/adr/0002-invenio-rdm-api-client-credentials.md) | InvenioRDM API client and credential security | Stateless `DatasetSource` port; per-user-per-instance tokens; 3-layer credential security (AES-GCM at rest / HTTPS in transit / `char[]` confined in memory); decryption boundary rule |
| [0003](docs/adr/0003-connection-lifecycle-stewardship.md) | Dataset connection lifecycle and data stewardship | User-initiated sync only; never-borrow-credentials principle; actor toast + email to other project members; project ACL inheritance |
| [0004](docs/adr/0004-fair-signposting-deferred.md) | FAIR Signposting integration deferred | Deferred due to upstream InvenioRDM bug; 1-2 year horizon |

## Additional files

- **Interview record**: [`docs/adr/interview-feat-dataset-connection.md`](docs/adr/interview-feat-dataset-connection.md) — preserved as historical documentation of the decision rationale
- **Index**: [`docs/adr/README.md`](docs/adr/README.md) — updated

## Status

All four ADRs are `Status: proposed` and ready for team review.

## Notes for reviewers

- The interview file is kept alongside the ADRs per project convention (it's historical context, not itself an ADR)
- One decision was explicitly deferred during the interview (11c: strict-vs-lenient JSON parsing on sync) — this must be resolved before sync logic is implemented

Relates to #1466