### PR TITLE
Fix jobrunr prefix and specify hibernate dialect for mariadb

### DIFF
--- a/datamanager-app/src/main/java/life/qbic/datamanager/configuration/JobRunrDatasourceConfig.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/configuration/JobRunrDatasourceConfig.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Configuration;
 public class JobRunrDatasourceConfig {
 
   @Bean(name = "jobRunrDatasourceProperties")
-  @ConfigurationProperties("org.jobrunr.database.datasource")
+  @ConfigurationProperties("jobrunr.database.datasource")
   public DataSourceProperties dataSourceProperties() {
     return new DataSourceProperties();
   }

--- a/datamanager-app/src/main/resources/application.properties
+++ b/datamanager-app/src/main/resources/application.properties
@@ -72,7 +72,7 @@ jobrunr.database.datasource.username=${JOBRUNR_DB_USER_NAME:${qbic.data-manageme
 jobrunr.database.datasource.password=${JOBRUNR_DB_USER_PW:${qbic.data-management.datasource.password}}
 ###############################################################################
 ################### JobRunr ###################################################
-# JobRunr configuration for background tasksq. Default port is 8000
+# JobRunr configuration for background tasks. Default port is 8000
 jobrunr.background-job-server.enabled=true
 jobrunr.dashboard.enabled=true
 jobrunr.dashboard.port=${JOBRUNR_DASHBOARD_PORT:8000}

--- a/datamanager-app/src/main/resources/application.properties
+++ b/datamanager-app/src/main/resources/application.properties
@@ -62,18 +62,20 @@ spring.h2.console.enabled=false
 spring.jpa.open-in-view=false
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+# Force Hibernate to use MariaDBDialect to function properly during pessimistic lockout
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
 ### JobrunR datasource
-org.jobrunr.database.datasource=jobRunrDatasource
-org.jobrunr.database.datasource.url=${JOBRUNR_DB_URL:${qbic.data-management.datasource.url}}
-org.jobrunr.database.datasource.driver-class-name=${JOBRUNR_DB_DRIVER:${qbic.data-management.datasource.driver-class-name}}
-org.jobrunr.database.datasource.username=${JOBRUNR_DB_USER_NAME:${qbic.data-management.datasource.username}}
-org.jobrunr.database.datasource.password=${JOBRUNR_DB_USER_PW:${qbic.data-management.datasource.password}}
+jobrunr.database.datasource=jobRunrDatasource
+jobrunr.database.datasource.url=${JOBRUNR_DB_URL:${qbic.data-management.datasource.url}}
+jobrunr.database.datasource.driver-class-name=${JOBRUNR_DB_DRIVER:${qbic.data-management.datasource.driver-class-name}}
+jobrunr.database.datasource.username=${JOBRUNR_DB_USER_NAME:${qbic.data-management.datasource.username}}
+jobrunr.database.datasource.password=${JOBRUNR_DB_USER_PW:${qbic.data-management.datasource.password}}
 ###############################################################################
 ################### JobRunr ###################################################
-# JobRunr configuration for background tasks. Default port is 8000
-org.jobrunr.background-job-server.enabled=true
-org.jobrunr.dashboard.enabled=true
-org.jobrunr.dashboard.port=${JOBRUNR_DASHBOARD_PORT:8000}
+# JobRunr configuration for background tasksq. Default port is 8000
+jobrunr.background-job-server.enabled=true
+jobrunr.dashboard.enabled=true
+jobrunr.dashboard.port=${JOBRUNR_DASHBOARD_PORT:8000}
 ###############################################################################
 ################### server location ###########################################
 server.port=${DM_PORT:8080}


### PR DESCRIPTION
## Description

This PR addresses the attribute name change in the `application.properties` associated with jobrunr during the migration from v7 to v8.

See here for more information.
https://www.jobrunr.io/en/guides/migration/v8/#breaking-changes

Additionally, it specifies the mariadb hibernate dialect to be used to fix the No longer supported default specification for pessmistic lookup of jobrunr jobs as shown below: 
`WARN o.h.d.Dialect: HHH000511: The 5.5.5 version for [org.hibernate.dialect.MySQLDialect] is no longer supported..`

If the dialect is not specified some jobs can fail with the following exception:

```
org.springframework.dao.InvalidDataAccessResourceUsageException: JDBC exception executing SQL [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'of p1_0' at line 1] 
Caused by: java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'of p1_0' at line 1
```

## Changes Summary

### Modified Areas
<!-- Indicate which parts of the codebase this PR touches. Check all that apply. -->
- [x] Application layer (`application/` services, use cases)
- [x] Infrastructure layer (JPA repositories, external integrations, config)

### Behavioral Changes
<!-- Does this PR change externally observable behavior? If yes, describe what changed and confirm it's covered by a requirement update above. -->
- [x] No behavioral changes (internal refactoring, optimization, test addition, etc.)
- [ ] Yes, behavior changes: <!-- Describe the changes and confirm requirement update or justification above -->

## Sensitive Changes Requiring Review
<!-- If your PR touches any of these areas, flag it explicitly below so reviewers pay attention. -->
- [ ] **Database schema changes** (`sql/complete-schema.sql`, table/column DDL)
- [ ] **Spring Security configuration** (`security/`, ACL setup, authentication/authorization)
- [ ] **FAIR / RO-Crate export format** (`docs/fair/`, RO-Crate builder logic)
- [ ] **Artemis messaging topics** (JMS topic names, consumer configuration)
- [ ] **Requirement file edits** (`docs/requirements.md`)
- [x] None of the above
