### PR TITLE
chore: make log retention configurable via application properties

### DIFF
--- a/application.properties.template
+++ b/application.properties.template
@@ -23,6 +23,7 @@ logging.level.life.qbic=info
 logging.level.life.qbic.datamanager=info
 logging.level.life.qbic.projectmanagement.application.authorization.acl=debug
 logging.file.path=./logs
+logging.file.max-history=60
 
 ###############################################################################
 ### Security / Vault ##########################################################

--- a/datamanager-app/src/main/resources/application.properties
+++ b/datamanager-app/src/main/resources/application.properties
@@ -6,6 +6,7 @@ logging.level.life.qbic=${DM_LOG_LEVEL:info}
 logging.level.life.qbic.datamanager=${DM_LOG_LEVEL:info}
 logging.level.life.qbic.projectmanagement.application.authorization.acl=debug
 logging.file.path=${DM_LOG_PATH:./logs}
+logging.file.max-history=60
 
 ###############################################################################
 ################### Security ##################################################

--- a/datamanager-app/src/main/resources/logback-spring.xml
+++ b/datamanager-app/src/main/resources/logback-spring.xml
@@ -3,6 +3,7 @@
 
   <springProperty scope="context" name="LOGS" source="logging.file.path"/>
   <springProperty scope="context" name="LOG_LEVEL_ROOT" source="logging.level.root"/>
+  <springProperty scope="context" name="LOG_MAX_HISTORY" source="logging.file.max-history" defaultValue="60"/>
 
   <appender name="Console"
     class="ch.qos.logback.core.ConsoleAppender">
@@ -23,6 +24,7 @@
       <fileNamePattern>${LOGS}/archived/spring-boot-logger-%d{yyyy-MM-dd}.%i.log
       </fileNamePattern>
       <maxFileSize>10MB</maxFileSize>
+      <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
     </rollingPolicy>
     <encoder
       class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">


### PR DESCRIPTION
## Summary

Configures the log file rolling policy to use a configurable max retention period instead of a hardcoded value.

## Changes

- **application.properties**: Added `logging.file.max-history=60` (default: 60 days)
- **logback-spring.xml**: Reads the property via `<springProperty>` and passes it to the `SizeAndTimeBasedRollingPolicy`

## How to configure

Edit `logging.file.max-history` in `application.properties` to change the number of days archived logs are retained.

## Checklist

- [x] No hardcoded values — retention is fully configurable
- [x] Sensible default of 60 days