### PR TITLE
fix: reset dataset selection on repository change and fix sidebar footer layout on small screens

### DIFF
--- a/datamanager-app/frontend/themes/datamanager/components/connect-dataset-sidebar.css
+++ b/datamanager-app/frontend/themes/datamanager/components/connect-dataset-sidebar.css
@@ -194,6 +194,37 @@
   border-top: 1px solid var(--lumo-contrast-10pct);
 }
 
+/* ── Responsive hardening ──────────────────────────────────────────────── */
+
+/*
+ * The project-wide .flex-vertical utility class sets flex-wrap: wrap. In a
+ * column flex container with a definite height that is too short for all
+ * children (small / short viewports), flex line breaking ignores flex-shrink
+ * and wraps the overflowing items into a SECOND column laid out along the
+ * cross axis — i.e. the footer gets rendered to the RIGHT of the results
+ * grid. Forcing nowrap on every vertical flex chain of the sidebar keeps the
+ * header / scrollable-content / footer stack intact; overflow is handled by
+ * the scrollable content area (.cds-content) instead of wrapping.
+ */
+.connect-dataset-sidebar .cds-body,
+.connect-dataset-sidebar .cds-content,
+.connect-dataset-sidebar .cds-results,
+.connect-dataset-sidebar .cds-footer {
+  flex-wrap: nowrap;
+}
+
+/*
+ * On viewports narrower than the panel's min-width (460px) CSS min-width
+ * clamps max-width, so the panel would stick out past the left edge of the
+ * screen. Let it reclaim the full viewport width instead.
+ */
+@media only screen and (max-width: 460px) {
+  .connect-dataset-sidebar .cds-panel {
+    min-width: 0;
+    width: 100vw;
+  }
+}
+
 /* ── Search-result card ─────────────────────────────────────────────────── */
 
 .connect-dataset-sidebar .cds-card {

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectDatasetSidebar.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectDatasetSidebar.java
@@ -222,6 +222,13 @@ public class ConnectDatasetSidebar extends Div {
     instanceSelector.setPlaceholder("Select repository…");
     instanceSelector.setItemLabelGenerator(SourceInstanceDescriptor::displayName);
     instanceSelector.addValueChangeListener(e -> {
+      // Switching the repository invalidates the current selection: the
+      // selected search results belong to the previously chosen provider.
+      // Reset the grid selection so users can only keep selections for the
+      // currently selected repository. The selection listener takes care of
+      // updating the count label and disabling the connect button.
+      resetResultsForInstanceChange();
+
       // Always update the credential banner when instance changes
       updateCredentialBanner();
 
@@ -812,6 +819,30 @@ public class ConnectDatasetSidebar extends Div {
       selectionCountLabel.getStyle().remove("display");
     }
     connectButton.setEnabled(count > 0);
+  }
+
+  /**
+   * Clears any selection and cached search results that belong to a
+   * previously selected repository.
+   *
+   * <p>Called when the user switches the repository in the instance
+   * selector, so selections (and stale hits) can never carry over to the
+   * newly selected provider. Implemented as an instance method (rather than
+   * inline in the value-change listener) because the grid is a blank final
+   * field assigned later in the constructor — a direct field reference from
+   * the listener lambda would be rejected by javac's definite-assignment
+   * check.</p>
+   */
+  private void resetResultsForInstanceChange() {
+    resultsGrid.deselectAll();
+
+    // Drop the cached results of the previous provider immediately so no
+    // stale hits are rendered while a search for the new provider is in
+    // flight (or if the user never triggers one).
+    synchronized (cachedResults) {
+      cachedResults.clear();
+    }
+    resultsGrid.getDataProvider().refreshAll();
   }
 
   // ── Connect confirmation ────────────────────────────────────────────


### PR DESCRIPTION
## Description

Fixes two issues in the **Connect Dataset** sidebar (right-side panel for connecting InvenioRDM datasets to a project):

### 1. Dataset selection not reset when switching the repository

When users selected datasets and then changed the repository in the instance dropdown, the selection was kept — the selected cards belonged to the *previous* provider but stayed selected against the new provider's search results, which is confusing and could lead to connecting the wrong datasets.

**Fix:** whenever the selected repository changes, the sidebar now:
- deselects all grid rows (which also resets the "N selected" label and disables the "Connect Selected" button via the existing selection listener),
- clears the cached search results of the previous provider and refreshes the grid data provider, so no stale hits from another provider can ever be rendered.

This guarantees selections can only ever be made for the currently selected provider.

### 2. Sidebar footer displaced next to the results grid on small screens

On small/short viewports the footer (experiment picker + connect button) was rendered *to the right of* the results grid instead of pinned at the bottom of the panel.

**Root cause:** the project-wide `.flex-vertical` utility class sets `flex-wrap: wrap`. In a column flex container with a definite height (the panel is `height: 100%`) that is too short for all children, CSS flex line-breaking ignores `flex-shrink` and wraps the overflowing footer into a second flex line laid out along the cross axis — i.e. next to the grid.

Additionally, below 460px viewport width the panel's `min-width: 460px` clamped `max-width`, making the panel overflow the left edge of the screen.

**Fix (scoped to the sidebar, no other views affected):**
- `flex-wrap: nowrap` on the sidebar's vertical chains (`.cds-body`, `.cds-content`, `.cds-results`, `.cds-footer`); overflow is handled by the scrollable content area as intended, keeping the footer pinned at the bottom.
- `@media (max-width: 460px)` override so the panel spans the full viewport width instead of overflowing off-screen.

## Related issues

- Feature: #1466 — Connect associated InvenioRDM datasets with Data Manager projects
- Story: #1467 (FEAT-DATSET-01) — Connecting open, published datasets

## Requirement IDs

- `DATA-R-01`
- `COMM-R-01`

## Testing

- Select datasets in the sidebar, switch the repository in the dropdown → selection is cleared, connect button disabled.
- Resize the browser to a short/narrow viewport and open the sidebar → footer stays pinned at the bottom, panel does not overflow the screen.