### PR TITLE
docs: user groups strategy for project sharing

### DIFF
--- a/docs/auth-glossary.md
+++ b/docs/auth-glossary.md
@@ -1,0 +1,191 @@
+# Authorization Glossary (Data Manager)
+
+> **Status:** Draft — open for review (docs-only, no code changes, no requirement changes)
+> **Date:** 2026-09-10
+>
+> Plain-language definitions of the authorization terms introduced and used in the Data Manager
+> access-control design. Terms are grouped by the area they belong to. See the companion strategy
+> at [`docs/user-groups-strategy.md`](user-groups-strategy.md).
+
+---
+
+## 1. Group domain terms
+
+These are the application's own domain concepts (managed by the application, not by Spring ACL).
+Spring Security ACL only ever sees their SID representation (see §2 and §3).
+
+### Group
+A named collection of users that a project can be shared with as a single unit, instead of adding
+users one by one.
+- **Notes:** Stored in application tables (e.g. `user_group`). Two types exist: **org group** and
+  **ad-hoc group**. Groups are keyed by a unique (case-insensitive) name for humans, but by a
+  stable numeric **id** for everything technical (the SID string, the ACE, the SID row).
+
+### Org group
+A group created and managed by QBiC administrators (e.g. an NGS lab).
+- **Notes:** Membership is admin-managed, not self-service. Pre-seeded at rollout. The QBiC admin
+  acts as the owner-equivalent.
+
+### Ad-hoc group
+A self-service group created by a regular user, with no admin involvement.
+- **Notes:** The creator becomes **OWNER**; managers can add/remove regular members; an empty
+  ad-hoc group auto-dissolves; a manager leaving is offered a guarded transfer-or-dissolve choice.
+
+### GroupMembership
+The application-level record linking a user to a group with an internal role.
+- **Notes:** One row per user–group pair, unique on `(group_id, username)`. Stored in an
+  application table (e.g. `group_membership`), entirely managed by a `GroupService`.
+
+### Group roles (OWNER / MANAGER / MEMBER)
+The *internal* role a user holds *within* a group.
+- **Notes:** This is **not** a Spring Security authority and **not** a project role. Used to govern
+  group-management actions (appoint managers, add/remove members) in the application layer. Org
+  groups treat the QBiC admin as owner-equivalent.
+
+---
+
+## 2. Core ACL / SID concepts
+
+These are Spring Security ACL concepts. The Data Manager uses them, sometimes through a subclass
+(`QbicPermissionEvaluator`).
+
+### SID (Security Identifier)
+The object that Spring ACL matches against an ACE to decide access. An abstract concept —
+concrete implementations carry the actual identity (a user, an authority, or a group).
+- **Notes:** In this application, a caller can have multiple SIDs (their own, their authorities',
+  and their groups'). Access is granted if **any** of the caller's SIDs matches a granting ACE.
+- **Related:** `PrincipalSid`, `GrantedAuthoritySid`, `GroupSid` (§3).
+
+### PrincipalSid
+The SID representing a specific user, built from the user's principal identifier.
+- **Notes:** This is today's manual "per-user" grant path. Keyed on the QBiC user id.
+- **OIDC:** resolved correctly. `QbicOidcUser.getName()` is overridden to return the QBiC user id
+  (see `QbicOidcUser.java`, "needed for ACL permission checks"), so `authentication.getName()` — and
+  therefore the `PrincipalSid` built from it — matches the QBiC user id for both local and OIDC
+  logins.
+
+### GrantedAuthoritySid
+The SID representing a Spring Security authority/role (e.g. `ROLE_ADMIN`).
+- **Notes:** This is today's "per-authority" grant path, used to hardcode `ROLE_ADMIN` /
+  `ROLE_PROJECT_MANAGER` grants on new projects. Groups deliberately do **not** reuse this type.
+
+### SidRetrievalStrategy
+The Spring Security component that maps an `Authentication` to the caller's set of `Sid`s at
+check time.
+- **Notes:** The Data Manager replaces it with `GroupAwareSidRetrievalStrategy` (§3) so group
+  membership is included. The membership lookup is cached keyed by **user id**; the cache entries
+  must be **evicted whenever a user's group assignment changes** so grant/revoke stay effective at
+  the next permission check (live rollout).
+
+### AclPermissionEvaluator
+Spring Security's `PermissionEvaluator` that turns `hasPermission(...)` into an ACL lookup.
+- **Notes:** The Data Manager subclasses it as `QbicPermissionEvaluator` (which only special-cases
+  empty `Optional` targets and otherwise delegates).
+
+### QbicPermissionEvaluator
+The Data Manager's `AclPermissionEvaluator` subclass, wired as the bean used by method security
+and UI permission gating.
+- **Notes:** All `@PreAuthorize("hasPermission(...)")` and `UserPermissionsImpl` checks funnel
+  through it, so the custom SID retrieval it delegates to is applied everywhere consistently.
+
+---
+
+## 3. GroupSid and the three customizations
+
+A **`GroupSid`** is a *custom* `Sid` the application introduces to keep groups conceptually
+distinct from roles/authorities. Because Spring ACL persistence/lookup only understands
+`PrincipalSid` and `GrantedAuthoritySid` by default, a custom Sid requires four coordinated
+pieces to work end to end.
+
+### GroupSid
+A custom `Sid` whose string identity is `"GROUP_<groupId>"` and whose `equals`/`hashCode` are
+based on the group id.
+- **Notes:** The *id* is used as the SID string (not the display name) so ACEs survive group
+  renames. The `principal` flag is `false` (stored as a non-principal SID).
+
+### GroupAwareJdbcMutableAclService (write path)
+A `JdbcMutableAclService` subclass that knows how to *persist* a `GroupSid`.
+- **Notes:** Overrides `createOrRetrieveSidPrimaryKey(Sid, boolean)` to store a `GroupSid` as a
+  non-principal SID string. Without it, the default throws `IllegalArgumentException: Unsupported
+  implementation of Sid`. Must preserve the existing MySQL `SELECT @@IDENTITY` identity queries.
+
+### GroupAwareBasicLookupStrategy (read path)
+A `BasicLookupStrategy` subclass that knows how to *reconstruct* a `GroupSid` when reading it
+back from storage.
+- **Notes:** Overrides `createSid(boolean, String)`. Without it, a stored group SID is read back
+  as a `GrantedAuthoritySid`, which never `.equals()` a `GroupSid` → access silently denied.
+  Resolves group SIDs lazily so groups created after startup are recognised.
+
+### GroupAwareSidRetrievalStrategy (check-time)
+A `SidRetrievalStrategy` that adds the caller's `GroupSid`s to their SID set.
+- **Notes:** Returns the caller's `PrincipalSid` + `GrantedAuthoritySid`s plus a `GroupSid` per
+  live group membership, resolved via a `user-groups-api` facade. This is what makes grant/revoke
+  effective on the next permission check (live rollout).
+
+---
+
+## 4. ACL data model terms
+
+The persistence layer Spring ACL uses to store object permissions.
+
+### ACL (Access Control List)
+The per-object record of who may do what. Each protected object has one ACL.
+- **Notes:** In this application ACLs exist only on `Project` objects; groups themselves get no
+  ACL (group management is enforced in the application layer).
+
+### ObjectIdentity
+The identity of a protected domain object within the ACL store.
+- **Notes:** Composed of the class (`life.qbic.projectmanagement.domain.model.project.Project`)
+  and the object's id. The ACL cache is keyed on this.
+
+### ACE (Access Control Entry)
+A single row within an ACL: one SID, one permission, and a granting flag.
+- **Notes:** One group grant = one or more ACEs pairing a `GroupSid` with a project permission.
+
+### Permission (READ / WRITE / ADMIN / OWNER)
+The project-level rights mapped to Spring `BasePermission`s (READ, WRITE, ADMINISTRATION, CREATE,
+DELETE).
+- **Notes:** Groups can be granted READ / WRITE / ADMIN — **never OWNER** (a group grant caps at
+  ADMIN).
+
+### acl_sid
+The table storing distinct SIDs (a `sid` string + a `principal` flag).
+- **Notes:** Unique on `(sid, principal)`. The `GROUP_<id>` prefix avoids collisions with `ROLE_*`
+  and user ids. Rows are auto-created on ACE insert.
+
+### acl_entry
+The table storing ACEs (permission, granting flag, SID, ACL object).
+- **Notes:** This is where a group grant is physically written.
+
+### acl_object_identity / acl_class
+Tables storing the protected objects and their Java class names, respectively.
+- **Notes:** `acl_class` carries one row for `life.qbic.projectmanagement.domain.model.project.Project`.
+
+### principal flag
+The boolean on a SID that distinguishes a *user* (`true`) from a *non-user* (`false`, e.g. roles
+and groups).
+- **Notes:** Used by `ProjectAccessService.listCollaborators()` to filter out non-user SIDs when
+  showing the "People" list.
+
+---
+
+## 5. Related behavioral terms
+
+### Live rollout
+The property that a membership change takes effect on the **next** permission check, with no login
+or session round-trip.
+- **Notes:** Achieved because `GroupAwareSidRetrievalStrategy` reads membership from the database
+  on every check. Supersedes the login-scoped authority-injection alternative.
+
+### Effective access
+The *resolved* access a user has to a project, considering direct ACEs, group ACEs, and role
+grants together.
+- **Notes:** A query for this is needed for notification de-duplication and member-count display.
+
+---
+
+## References
+
+- [`docs/user-groups-strategy.md`](user-groups-strategy.md) — the strategy this glossary supports.
+- Spring Security reference: *Access Control List* (ACL) documentation for `Sid`,
+  `PrincipalSid`, `GrantedAuthoritySid`, `SidRetrievalStrategy`, `AclPermissionEvaluator`.

--- a/docs/user-groups-strategy.md
+++ b/docs/user-groups-strategy.md
@@ -100,10 +100,10 @@ management and group-based sharing. Everything else builds on proven paths.
 | Internal group roles | **OWNER** (only the ad-hoc creator; appoints/removes managers), **MANAGER** (adds/removes regular members; org groups: rename/describe), **MEMBER**. For org groups the QBiC admin acts as owner-equivalent |
 | Governance | Org groups: admins manage membership. Ad-hoc groups: fully self-service — creator becomes owner; manager can add/remove members; members can self-remove; an empty ad-hoc group is auto-dissolved; a manager leaving is offered an explicit, guarded *transfer-or-dissolve* choice |
 | Sharing | Anyone with project *change-access* can share a group onto a project. Grant level: READ / WRITE / ADMIN — **never OWNER** |
-| Visibility | Group names + descriptions are **public** (searchable) and **unique** (case-insensitive). Memberships are visible only to group members and QBiC admins |
+| Visibility | Group names, descriptions, and memberships are visible to all users. Group names are **unique** (case-insensitive). As part of the DPA, users are informed beforehand that their ORCID, username, and Full Name are visible to other users |
 | Sensitive data | No project flag; transparency via notifications (see §5.3) |
 | Notifications | Email only members who **newly gain** access (deduplicated); digest on joining a group with existing grants; revocation email on removal; dissolution email listing affected projects; project admins informed about membership changes on groups shared with their projects; role-level changes are audit-log-only |
-| Project cards | Show group *names* only — never expanded member lists (view is readable by any project member) |
+| Project cards | Show group *names* on project cards (compact view; the card area is shared real estate) |
 
 ---
 
@@ -119,9 +119,8 @@ mirroring the `identity` module layout. Rationale:
 - Provides a clean `user-groups-api` facade consumed by `AuthorityService` (project-management)
   and the UI (datamanager-app), following the established `identity-api` pattern.
 
-Lighter alternative: model groups inside `project-management` next to `Role`/`UserRole` (fewer
-modules, less clean separation). Both options add Maven modules → **human approval required
-per AGENTS.md §12**, and the decision merits an ADR.
+This adds Maven modules → **human approval required per AGENTS.md §12**, and the decision
+merits an ADR.
 
 ### 4.2 Conceptual data model
 
@@ -143,7 +142,7 @@ per AGENTS.md §12**, and the decision merits an ADR.
 2. **Sharing:** reuse `addAuthorityAccess(projectId, "GROUP_<id>", role)` with validation blocking
    OWNER. `removeAuthorityAccess` / `changeAuthorityAccess` cover revoke and role change.
 3. **Listing:** extend `listCollaborators()` (or add `listSharedGroups()`) to surface authority
-   ACEs in the UI (name, description, member count; member list only for group members).
+   ACEs in the UI (name, description, member count, member list).
 4. **Effective-access query (new):** needed for notification dedupe and member-count display —
    "has member X effective access (direct ACE, via group, or via role) to project P?" Implemented
    as a batch query against `acl_entry` / `acl_sid` for the member's sid set.
@@ -163,8 +162,8 @@ Follow the existing pattern (`ProjectAccessGranted` → `ProjectAccessGrantedPol
 ### 4.5 UI surface
 
 1. **Project Access page** (`ProjectAccessComponent`) — two sections: **People** (current grid,
-   unchanged) and **Groups** (grid of shared groups + grant role; edit/remove; member names only
-   for group members — privacy rule enforced in UI).
+   unchanged) and **Groups** (grid of shared groups + grant role; edit/remove; member list visible
+   to all users).
 2. **Share dialog** (`AddCollaboratorToProjectDialog`) — "Add people or groups": a group tab with a
    searchable dropdown over public group names + role selection, same flow as adding a person.
 3. **My Groups view** (user-facing, in the account area) — groups I belong to with my role;
@@ -173,8 +172,8 @@ Follow the existing pattern (`ProjectAccessGranted` → `ProjectAccessGrantedPol
 4. **Admin Groups view** (QBiC admins) — org group CRUD: create, assign managers, manage
    membership, rename, dissolve; full directory of all groups; read-only oversight of ad-hoc
    groups.
-5. **Project cards** (overview) — show group names the project is shared with; never expand
-   members. Rebuild the `project_userinfo` / `project_overview` SQL views accordingly.
+5. **Project cards** (overview) — show group names the project is shared with. Rebuild the
+   `project_userinfo` / `project_overview` SQL views accordingly.
 
 ### 4.6 Revocation semantics — *known trade-off to document*
 
@@ -194,8 +193,8 @@ Recommendation: (a) now; revisit if auditors object.
 
 ### 5.1 Leakage
 
-- Memberships are members-only (name + description are public); member lists must never be exposed
-  in READ-visible views (`project_overview` shows group names only).
+- As part of the DPA, users are informed beforehand that their ORCID, username, and Full Name are
+  visible to other users. Group names, descriptions, and memberships are therefore not restricted.
 - The share dialog context already requires project `change-access`; `listCollaborators` requires
   ADMINISTRATION — who-has-access stays privileged.
 

--- a/docs/user-groups-strategy.md
+++ b/docs/user-groups-strategy.md
@@ -86,9 +86,11 @@ The ACL layer is already group-ready:
 3. `@PreAuthorize("hasPermission(...)")` evaluation (`QbicPermissionEvaluator`) works generically
    for any authority present in the authentication.
 
-The missing pieces are: a **group concept** (aggregate + membership + role hierarchy), **injecting
-`GROUP_<id>` authorities into the runtime authentication**, and the **UI surface** for group
-management and group-based sharing. Everything else builds on proven paths.
+The missing pieces are: a **group concept** (aggregate + membership + role hierarchy), a **way to
+surface `GROUP_<id>` in ACL evaluation** — either as login-scoped authorities (§4.3 Option A) or,
+recommended, as SIDs derived live at evaluation time via a custom `SidRetrievalStrategy` on the
+permission evaluator (§4.3 Option B) — and the **UI surface** for group management and group-based
+sharing. Everything else builds on proven paths.
 
 ---
 
@@ -135,10 +137,40 @@ merits an ADR.
 
 ### 4.3 Authorization plumbing
 
-1. **Authority injection (the crux):** extend `AuthorityService.getAuthoritiesByUserId()` to also
-   emit `GROUP_<id>` for all group memberships. Both login flows (`UserDetailsServiceImpl`,
-   `OidcUserDetailsService`) call this method, so local and OIDC users automatically carry group
-   authorities. Spring ACL evaluation and project listing then work unchanged.
+1. **Grant propagation mechanism.** The group grants (ACEs keyed by `GrantedAuthoritySid`,
+   `sid = "GROUP_<id>"`) must become visible to ACL evaluation *and* to project listing. Two
+   mechanisms exist; the PO-approved **live rollout** requirement (access takes effect
+   immediately when a member is added to a group shared with a project) decides between them:
+
+   - **Option A — login-scoped authority injection (original plan).** Extend
+     `AuthorityService.getAuthoritiesByUserId()` to also emit `GROUP_<id>` for all active group
+     memberships. Both login flows (`UserDetailsServiceImpl`, `OidcUserDetailsService`) call this
+     method, so local and OIDC users automatically carry group authorities; ACL evaluation and
+     project listing then work unchanged. *Trade-off:* the login snapshot makes membership
+     changes effective only at next login / session expiry (§4.6) — not live without adding
+     per-request freshness machinery.
+   - **Option B — evaluation-time SID derivation (recommended; the "adjust the permission
+     evaluator" alternative).** Groups are *never* written into the runtime authentication. A
+     custom `SidRetrievalStrategy` (wrapping `SidRetrievalStrategyImpl`) is wired onto
+     `QbicPermissionEvaluator` via `AclPermissionEvaluator.setSidRetrievalStrategy(...)` (bean in
+     `AclSecurityConfiguration`). On every `hasPermission(...)` call it appends
+     `GrantedAuthoritySid("GROUP_<id>")` for the caller's live memberships, resolved through a
+     `user-groups-api` facade (e.g. `listGroupSidsForUser(userId)`). Both
+     `@PreAuthorize("hasPermission(...)")` (method security) and `UserPermissionsImpl` (UI
+     gating) funnel through this bean, so grant **and** revoke are effective at the next
+     permission check — no session machinery, no authority cache to invalidate; the Spring ACL
+     cache stays valid because it is keyed by `ObjectIdentity` and `isGranted` re-evaluates the
+     freshly derived SIDs per call.
+     *Companion change (required):* `ProjectInformationService.retrieveAccessibleProjectIdsForUser()`
+     reads `authentication.getAuthorities()` directly, so it must additionally union the user's
+     group SIDs via the same facade — otherwise group-granted projects pass `hasPermission(READ)`
+     but never appear in the project overview.
+     *Constraint:* under Option B, group-aware checks must route through `hasPermission(...)` / the
+     listing helper; `hasRole` and view-level authority checks do not see groups.
+
+   Recommendation: **Option B** — it satisfies live rollout (grant and revocation) natively,
+   keeps the database as the single source of truth at decision time, and avoids the
+   session/context pitfalls of per-request freshness (§4.6).
 2. **Sharing:** reuse `addAuthorityAccess(projectId, "GROUP_<id>", role)` with validation blocking
    OWNER. `removeAuthorityAccess` / `changeAuthorityAccess` cover revoke and role change.
 3. **Listing:** extend `listCollaborators()` (or add `listSharedGroups()`) to surface authority
@@ -175,17 +207,32 @@ Follow the existing pattern (`ProjectAccessGranted` → `ProjectAccessGrantedPol
 5. **Project cards** (overview) — show group names the project is shared with. Rebuild the
    `project_userinfo` / `project_overview` SQL views accordingly.
 
-### 4.6 Revocation semantics — *known trade-off to document*
+### 4.6 Revocation semantics
 
-Authorities are captured at login, so membership changes take effect at **next login / session
-expiry**. This matches today's behaviour for role changes (also login-scoped). Options:
+- **Under Option A** (login-scoped authority injection), authorities are captured at login, so
+  membership changes take effect at **next login / session expiry** — matching today's behaviour
+  for role changes. If a live effect is nevertheless required there, the fallbacks are:
 
-- (a) Accept and document (recommended — no session infrastructure exists today).
-- (b) Broadcast a session-invalidation event on sensitive membership changes (no Spring Session
-  today — heavier).
-- (c) Per-request authority freshness for critical paths.
+  - (b) Broadcast a session-invalidation event on sensitive membership changes (no Spring Session
+    today — heavier).
+  - (c) Per-request authority freshness: a `OncePerRequestFilter` registered after
+    `SecurityContextHolderFilter` in `SecurityConfiguration.vaadinSecurityFilterChain(...)` that
+    re-resolves `AuthorityService.getAuthoritiesByUserId()` on every request. Vaadin constraint
+    (verified in `VaadinAwareSecurityContextHolderStrategy`, vaadin-spring 25.x): `setContext(...)`
+    writes **only the ThreadLocal**, while `getContext()` prefers the SecurityContext stored in the
+    HTTP session — the filter must therefore **mutate** `SecurityContextHolder.getContext()
+    .setAuthentication(...)` (and skip writes when the authority set is unchanged), otherwise the
+    refresh does not persist and every round-trip dirties the shared session object. Cost:
+    per-request recomputation (mitigate with EHCache + `GroupMembershipChanged` invalidation over
+    Artemis) and a second authority source of truth to keep consistent.
 
-Recommendation: (a) now; revisit if auditors object.
+- **Under Option B** (evaluation-time SID derivation, recommended), the database is consulted at
+  every permission check, so there is **no staleness window at all** — revocation is effective at
+  the next `hasPermission(...)` / listing evaluation, for Vaadin and REST requests alike, without
+  any session or filter machinery.
+
+Recommendation: Option B (§4.3); no session invalidation and no per-request freshness filter are
+required.
 
 ---
 
@@ -203,7 +250,8 @@ Recommendation: (a) now; revisit if auditors object.
 Org groups are a force multiplier: one membership mistake silently grants/revokes access on every
 project shared with the group. Mitigations baked into the design:
 
-1. Instant revocation (authority-based) + loud emails on removal.
+1. Instant revocation — under §4.3 Option B effective at the next permission check, under Option
+   A at next login (§4.6) — plus loud emails on removal.
 2. Project admins notified on membership changes of shared groups.
 3. Groups can never be OWNER; a group grant caps at ADMIN.
 4. Dissolution shows affected projects before confirming; ACEs cleaned up.
@@ -248,6 +296,10 @@ No flag/restriction on sensitive projects; transparency through the notification
 - Group size limits / group count limits per user.
 - Manager demotion path (owner action only).
 - Whether org groups pre-seed with any project grants at rollout.
+- Verify the `PrincipalSid` derivation for OIDC logins: `SidRetrievalStrategyImpl` builds the
+  user's principal SID from `authentication.getName()` (the OIDC user's name), while ACLs are
+  keyed on the QBiC user id — confirm OIDC users actually match on the QBiC user id today before
+  groups build on top.
 
 ---
 
@@ -259,7 +311,9 @@ No flag/restriction on sensitive projects; transparency through the notification
 - `project-management/.../application/authorization/authorities/AuthorityService.java`
 - `project-management/.../application/ProjectInformationService.java` (`retrieveAccessibleProjectIdsForUser`)
 - `project-management-infrastructure/.../project/ProjectRepositoryImpl.java`
-- `datamanager-app/.../security/AclSecurityConfiguration.java`, `UserPermissionsImpl.java`
+- `datamanager-app/.../security/AclSecurityConfiguration.java`, `SecurityConfiguration.java`,
+  `UserPermissionsImpl.java`
+- `project-management/.../application/authorization/acl/QbicPermissionEvaluator.java`
 - `datamanager-app/.../views/projects/project/access/ProjectAccessComponent.java`, `AddCollaboratorToProjectDialog.java`
 - `project-management/.../application/policy/directive/InformUserAboutGrantedAccess.java`
 - `sql/complete-schema.sql` (ACL tables, `project_userinfo` view)

--- a/docs/user-groups-strategy.md
+++ b/docs/user-groups-strategy.md
@@ -1,0 +1,266 @@
+# Strategy — User Groups for Project Sharing
+
+> **Status:** Draft — open for review (docs-only PR, no code changes, no requirement changes)
+> **Date:** 2025-07-15
+> **Scope:** Investigation of the current user & access management capabilities and a proposed
+> strategy to introduce *user groups* so projects can be shared with a group of people instead of
+> assigning them manually, one by one.
+
+---
+
+## 1. Motivation
+
+Today, sharing a project means adding individual users (Project Access Management → "Add people").
+This becomes tedious and error-prone as soon as recurring teams are involved:
+
+- QBiC internal labs (e.g. NGS labs) frequently need quick access to projects — for assistance or
+  review — without becoming project owners.
+- Ad-hoc collaboration teams (e.g. "everyone working on project X") must be re-assembled manually
+  per project and re-assembled again whenever the team changes.
+
+This document investigates the existing user & access management capabilities and proposes how to
+extend them with **user groups** that can be shared onto projects like a single user.
+
+**Guiding decisions (aligned with the product owner):**
+- Two group types: **org groups** (admin-managed, e.g. NGS labs) and **ad-hoc groups** (self-service
+  user feature, no admin involvement).
+- Groups have an internal role structure (owner / manager / member).
+- Anyone with project access-administration rights can share a project with a group.
+- No special handling for "sensitive" projects; transparency is achieved through notifications.
+- Members who *newly* gain access through a group grant are informed by email (deduplicated).
+
+---
+
+## 2. Current State Analysis
+
+### 2.1 User management (identity context)
+
+- The `identity` bounded context owns the user aggregate
+  (`identity/src/main/java/life/qbic/identity/domain/model/User.java`): user id, full name, user
+  name, email, password, OIDC entries. **No roles and no groups live on the aggregate.**
+- **System roles are an authorization concept in `project-management`**, not in `identity`:
+  - `roles`, `user_role`, `role_permission` tables (`sql/insert-default-values.sql` seeds
+    `ADMIN`, `USER`, `PROJECT_MANAGER`).
+  - `Role` implements `GrantedAuthority`; `getAuthority()` returns `ROLE_<name>`.
+  - Membership is resolved per user at login by
+    `AuthorityService.getAuthoritiesByUserId()` (in
+    `project-management/.../application/authorization/authorities/AuthorityService.java`) and
+    injected into `QbicUserDetails` — used by both local login (`UserDetailsServiceImpl`) and OIDC
+    login (`OidcUserDetailsService`).
+- `identity-api` exposes `UserInformationService` as the cross-context facade (find by email/id,
+  query active users, …).
+
+### 2.2 Project access (Spring Security ACL)
+
+- Every project is an ACL object (`acl_class` entry for
+  `life.qbic.projectmanagement.domain.model.project.Project`, string id). Access is expressed as
+  Access Control Entries (ACEs) in `acl_entry`, with SIDs in `acl_sid` (unique on
+  `(sid, principal)` — users vs. roles are distinguished by the `principal` flag).
+- `ProjectAccessService` / `ProjectAccessServiceImpl`
+  (`project-management/.../application/authorization/acl/`) offers **two parallel grant paths**:
+  - **Per-user** (`PrincipalSid`): `addCollaborator`, `removeCollaborator`, `changeRole` — this is
+    today's manual assignment.
+  - **Per-authority** (`GrantedAuthoritySid`): `addAuthorityAccess`, `removeAuthorityAccess`,
+    `changeAuthorityAccess` — currently only used to hardcode
+    `ROLE_ADMIN` + `ROLE_PROJECT_MANAGER` = ADMIN grants on every newly created project
+    (`project-management-infrastructure/.../project/ProjectRepositoryImpl.java`).
+- Project roles: `READ / WRITE / ADMIN / OWNER`, mapped to Spring `BasePermission`s
+  (READ, WRITE, ADMINISTRATION, CREATE, DELETE).
+- **Project listing already merges per-user and per-authority access:**
+  `ProjectInformationService.retrieveAccessibleProjectIdsForUser()` queries the ACL for the user's
+  own SID *and* for every authority in `authentication.getAuthorities()`.
+- UI: the "Project Access Management" page (`ProjectAccessComponent`) lists only users
+  (`listCollaborators()` filters to `PrincipalSid`) and supports add/remove/role-edit. Its Javadoc
+  already mentions "users and user groups" — groups were envisioned but never implemented.
+- Notifications: `addCollaborator` fires the `ProjectAccessGranted` domain event → email
+  (`InformUserAboutGrantedAccess`). Authority grants fire no events.
+- The SQL view `project_userinfo` (used by `project_overview`, shown on project cards) resolves
+  **principal SIDs only** — group grants would be invisible there and need to be reworked.
+
+### 2.3 Key insight
+
+The ACL layer is already group-ready:
+
+1. `GrantedAuthoritySid`-based grants exist and are exercised (the hardcoded role grants).
+2. Project listing already resolves access via the user's authorities.
+3. `@PreAuthorize("hasPermission(...)")` evaluation (`QbicPermissionEvaluator`) works generically
+   for any authority present in the authentication.
+
+The missing pieces are: a **group concept** (aggregate + membership + role hierarchy), **injecting
+`GROUP_<id>` authorities into the runtime authentication**, and the **UI surface** for group
+management and group-based sharing. Everything else builds on proven paths.
+
+---
+
+## 3. Aligned Product Decisions
+
+| Aspect | Decision |
+|---|---|
+| Group types | **Org groups** (admin-created and pre-seeded, e.g. NGS labs; membership admin-managed) and **ad-hoc groups** (self-service user feature; no admins involved) |
+| Internal group roles | **OWNER** (only the ad-hoc creator; appoints/removes managers), **MANAGER** (adds/removes regular members; org groups: rename/describe), **MEMBER**. For org groups the QBiC admin acts as owner-equivalent |
+| Governance | Org groups: admins manage membership. Ad-hoc groups: fully self-service — creator becomes owner; manager can add/remove members; members can self-remove; an empty ad-hoc group is auto-dissolved; a manager leaving is offered an explicit, guarded *transfer-or-dissolve* choice |
+| Sharing | Anyone with project *change-access* can share a group onto a project. Grant level: READ / WRITE / ADMIN — **never OWNER** |
+| Visibility | Group names + descriptions are **public** (searchable) and **unique** (case-insensitive). Memberships are visible only to group members and QBiC admins |
+| Sensitive data | No project flag; transparency via notifications (see §5.3) |
+| Notifications | Email only members who **newly gain** access (deduplicated); digest on joining a group with existing grants; revocation email on removal; dissolution email listing affected projects; project admins informed about membership changes on groups shared with their projects; role-level changes are audit-log-only |
+| Project cards | Show group *names* only — never expanded member lists (view is readable by any project member) |
+
+---
+
+## 4. Proposed Architecture
+
+### 4.1 Bounded context placement — *needs ADR + module approval*
+
+Recommendation: a **new bounded context `user-groups`** (domain + api + infrastructure modules),
+mirroring the `identity` module layout. Rationale:
+
+- Groups are a user-domain concept; keeping `identity` as pure accounts is cleaner.
+- Avoids coupling group management into `project-management`'s authorization package.
+- Provides a clean `user-groups-api` facade consumed by `AuthorityService` (project-management)
+  and the UI (datamanager-app), following the established `identity-api` pattern.
+
+Lighter alternative: model groups inside `project-management` next to `Role`/`UserRole` (fewer
+modules, less clean separation). Both options add Maven modules → **human approval required
+per AGENTS.md §12**, and the decision merits an ADR.
+
+### 4.2 Conceptual data model
+
+- `user_group(id, name unique-ci, description, type [ORG | ADHOC], status, created_by, created_at)`
+- `group_membership(group_id, user_id, role [OWNER | MANAGER | MEMBER], joined_at)`
+- ACL SID representation: `sid = "GROUP_" + groupId`, `principal = false` — the prefix avoids
+  collisions with `ROLE_*` and user ids under the `acl_sid` unique key.
+  `JdbcMutableAclService` auto-creates sid rows on ACE insert, so no special sid seeding is needed.
+- **No ACL objects for groups themselves** — group *management* permissions (owner/manager actions,
+  admin oversight) are enforced in the application layer via membership roles + `ROLE_ADMIN`
+  checks. Spring ACL remains exclusively on `Project` objects.
+
+### 4.3 Authorization plumbing
+
+1. **Authority injection (the crux):** extend `AuthorityService.getAuthoritiesByUserId()` to also
+   emit `GROUP_<id>` for all group memberships. Both login flows (`UserDetailsServiceImpl`,
+   `OidcUserDetailsService`) call this method, so local and OIDC users automatically carry group
+   authorities. Spring ACL evaluation and project listing then work unchanged.
+2. **Sharing:** reuse `addAuthorityAccess(projectId, "GROUP_<id>", role)` with validation blocking
+   OWNER. `removeAuthorityAccess` / `changeAuthorityAccess` cover revoke and role change.
+3. **Listing:** extend `listCollaborators()` (or add `listSharedGroups()`) to surface authority
+   ACEs in the UI (name, description, member count; member list only for group members).
+4. **Effective-access query (new):** needed for notification dedupe and member-count display —
+   "has member X effective access (direct ACE, via group, or via role) to project P?" Implemented
+   as a batch query against `acl_entry` / `acl_sid` for the member's sid set.
+
+### 4.4 Notifications (event → policy → directive)
+
+Follow the existing pattern (`ProjectAccessGranted` → `ProjectAccessGrantedPolicy` →
+`InformUserAboutGrantedAccess`, JobRunr-scheduled email). New events, e.g.:
+
+- `GroupSharedWithProject` — email every member who *newly* gains effective access (dedupe computed
+  via the effective-access query *before* the ACE is written).
+- `GroupMembershipChanged` — digest to the new member ("you can now access: X, Y, Z"); notify
+  project admins of affected projects.
+- `MemberRemovedFromGroup` — revocation email to the removed user; in-app notice to group managers.
+- `GroupDissolved` — email former members + admins of affected projects, listing the projects.
+
+### 4.5 UI surface
+
+1. **Project Access page** (`ProjectAccessComponent`) — two sections: **People** (current grid,
+   unchanged) and **Groups** (grid of shared groups + grant role; edit/remove; member names only
+   for group members — privacy rule enforced in UI).
+2. **Share dialog** (`AddCollaboratorToProjectDialog`) — "Add people or groups": a group tab with a
+   searchable dropdown over public group names + role selection, same flow as adding a person.
+3. **My Groups view** (user-facing, in the account area) — groups I belong to with my role;
+   manager controls for ad-hoc groups (add/remove members, rename, dissolve with confirmation and
+   transfer-or-dissolve guard).
+4. **Admin Groups view** (QBiC admins) — org group CRUD: create, assign managers, manage
+   membership, rename, dissolve; full directory of all groups; read-only oversight of ad-hoc
+   groups.
+5. **Project cards** (overview) — show group names the project is shared with; never expand
+   members. Rebuild the `project_userinfo` / `project_overview` SQL views accordingly.
+
+### 4.6 Revocation semantics — *known trade-off to document*
+
+Authorities are captured at login, so membership changes take effect at **next login / session
+expiry**. This matches today's behaviour for role changes (also login-scoped). Options:
+
+- (a) Accept and document (recommended — no session infrastructure exists today).
+- (b) Broadcast a session-invalidation event on sensitive membership changes (no Spring Session
+  today — heavier).
+- (c) Per-request authority freshness for critical paths.
+
+Recommendation: (a) now; revisit if auditors object.
+
+---
+
+## 5. Security Analysis
+
+### 5.1 Leakage
+
+- Memberships are members-only (name + description are public); member lists must never be exposed
+  in READ-visible views (`project_overview` shows group names only).
+- The share dialog context already requires project `change-access`; `listCollaborators` requires
+  ADMINISTRATION — who-has-access stays privileged.
+
+### 5.2 Blast radius
+
+Org groups are a force multiplier: one membership mistake silently grants/revokes access on every
+project shared with the group. Mitigations baked into the design:
+
+1. Instant revocation (authority-based) + loud emails on removal.
+2. Project admins notified on membership changes of shared groups.
+3. Groups can never be OWNER; a group grant caps at ADMIN.
+4. Dissolution shows affected projects before confirming; ACEs cleaned up.
+5. Audit events for every group operation (existing event → policy → directive pattern).
+6. Disabled users lose access at the login gate (no extra work).
+
+### 5.3 Sensitive-data posture (decision a)
+
+No flag/restriction on sensitive projects; transparency through the notification profile above.
+
+---
+
+## 6. Governance Next Steps (per AGENTS.md)
+
+1. **Requirements first:** this is new system capability → new requirement entries in
+   `docs/requirements.md` (proposed new domain, e.g. `GROUP-*` or `ACCESS-*`), as a **dedicated PR
+   with human approval** — never bundled with implementation.
+2. **ADR(s):** bounded-context placement + authority-based grant approach — ADR creation requires
+   human confirmation (MADR template at `docs/adr/templates/`).
+3. **Feature / Stories / Tasks:** `FEAT-<SLUG>` feature first, then stories with stable IDs
+   recorded in `docs/features.md` (draft → approved lifecycle), then tasks.
+4. **Schema migrations** under `docs/migrations/` + `sql/` per existing convention.
+
+---
+
+## 7. Suggested Implementation Phases
+
+| Phase | Scope |
+|---|---|
+| **P0 — Governance** | Requirements PR, ADR(s), Feature + Stories |
+| **P1 — Domain** | `user-groups` module: aggregate, membership, role hierarchy & policies (auto-dissolve, transfer-or-dissolve guard, unique names), JPA + migrations |
+| **P2 — Authorization** | Authority injection, share/list groups via ACL, effective-access query, OWNER block |
+| **P3 — Notifications** | Events + policies + email directives with dedupe/digests |
+| **P4 — UI** | My Groups, Admin Groups, access-page Groups section, share-dialog group tab, project-card view rebuild |
+| **P5 — Ops** | Org-group seeding, Spock specs + integration tests, audit logging, docs |
+
+---
+
+## 8. Open Items (no decision needed yet)
+
+- Org-group "owner" semantics: admin acts as owner-equivalent (recommended).
+- Group size limits / group count limits per user.
+- Manager demotion path (owner action only).
+- Whether org groups pre-seed with any project grants at rollout.
+
+---
+
+## 9. References
+
+- `identity/src/main/java/life/qbic/identity/domain/model/User.java`
+- `identity-api/src/main/java/life/qbic/identity/api/UserInformationService.java`
+- `project-management/.../application/authorization/acl/ProjectAccessService.java` (and `Impl`)
+- `project-management/.../application/authorization/authorities/AuthorityService.java`
+- `project-management/.../application/ProjectInformationService.java` (`retrieveAccessibleProjectIdsForUser`)
+- `project-management-infrastructure/.../project/ProjectRepositoryImpl.java`
+- `datamanager-app/.../security/AclSecurityConfiguration.java`, `UserPermissionsImpl.java`
+- `datamanager-app/.../views/projects/project/access/ProjectAccessComponent.java`, `AddCollaboratorToProjectDialog.java`
+- `project-management/.../application/policy/directive/InformUserAboutGrantedAccess.java`
+- `sql/complete-schema.sql` (ACL tables, `project_userinfo` view)

--- a/docs/user-groups-strategy.md
+++ b/docs/user-groups-strategy.md
@@ -5,6 +5,9 @@
 > **Scope:** Investigation of the current user & access management capabilities and a proposed
 > strategy to introduce *user groups* so projects can be shared with a group of people instead of
 > assigning them manually, one by one.
+>
+> **Companion:** a plain-language glossary of the authorization terms introduced here lives in
+> [`docs/auth-glossary.md`](auth-glossary.md).
 
 ---
 
@@ -87,10 +90,10 @@ The ACL layer is already group-ready:
    for any authority present in the authentication.
 
 The missing pieces are: a **group concept** (aggregate + membership + role hierarchy), a **way to
-surface `GROUP_<id>` in ACL evaluation** — either as login-scoped authorities (§4.3 Option A) or,
-recommended, as SIDs derived live at evaluation time via a custom `SidRetrievalStrategy` on the
-permission evaluator (§4.3 Option B) — and the **UI surface** for group management and group-based
-sharing. Everything else builds on proven paths.
+surface `GroupSid`s in ACL evaluation** — a dedicated custom `Sid` (with the four coordinated
+customizations of §4.3) whose SIDs are derived live at evaluation time via a custom
+`SidRetrievalStrategy` on the permission evaluator — and the **UI surface** for group management
+and group-based sharing. Everything else builds on proven paths.
 
 ---
 
@@ -128,8 +131,11 @@ merits an ADR.
 
 - `user_group(id, name unique-ci, description, type [ORG | ADHOC], status, created_by, created_at)`
 - `group_membership(group_id, user_id, role [OWNER | MANAGER | MEMBER], joined_at)`
-- ACL SID representation: `sid = "GROUP_" + groupId`, `principal = false` — the prefix avoids
-  collisions with `ROLE_*` and user ids under the `acl_sid` unique key.
+- ACL SID representation: a **dedicated `GroupSid`** implementing `Sid`, whose *string identity* is
+  `sid = "GROUP_" + groupId`, stored with `principal = false`. The prefix avoids collisions with
+  `ROLE_*` and user ids under the `acl_sid` unique key, and keying on the stable group *id* (rather
+  than the display name) keeps ACEs valid across group renames. The human-readable group *name* is
+  kept separately for display purposes only — it is never used as the SID string.
   `JdbcMutableAclService` auto-creates sid rows on ACE insert, so no special sid seeding is needed.
 - **No ACL objects for groups themselves** — group *management* permissions (owner/manager actions,
   admin oversight) are enforced in the application layer via membership roles + `ROLE_ADMIN`
@@ -137,47 +143,72 @@ merits an ADR.
 
 ### 4.3 Authorization plumbing
 
-1. **Grant propagation mechanism.** The group grants (ACEs keyed by `GrantedAuthoritySid`,
-   `sid = "GROUP_<id>"`) must become visible to ACL evaluation *and* to project listing. Two
-   mechanisms exist; the PO-approved **live rollout** requirement (access takes effect
-   immediately when a member is added to a group shared with a project) decides between them:
+Groups are represented in the ACL by a **dedicated `GroupSid`** (a custom `Sid`), not by reusing
+`GrantedAuthoritySid`. This keeps groups conceptually distinct from roles/authorities and avoids
+any ambiguity between a group id and a `ROLE_*` string. Because Spring Security's ACL persistence
+and lookup only understand `PrincipalSid` and `GrantedAuthoritySid` by default, a custom `Sid`
+requires **four coordinated customizations** to work end to end:
 
-   - **Option A — login-scoped authority injection (original plan).** Extend
-     `AuthorityService.getAuthoritiesByUserId()` to also emit `GROUP_<id>` for all active group
-     memberships. Both login flows (`UserDetailsServiceImpl`, `OidcUserDetailsService`) call this
-     method, so local and OIDC users automatically carry group authorities; ACL evaluation and
-     project listing then work unchanged. *Trade-off:* the login snapshot makes membership
-     changes effective only at next login / session expiry (§4.6) — not live without adding
-     per-request freshness machinery.
-   - **Option B — evaluation-time SID derivation (recommended; the "adjust the permission
-     evaluator" alternative).** Groups are *never* written into the runtime authentication. A
-     custom `SidRetrievalStrategy` (wrapping `SidRetrievalStrategyImpl`) is wired onto
-     `QbicPermissionEvaluator` via `AclPermissionEvaluator.setSidRetrievalStrategy(...)` (bean in
-     `AclSecurityConfiguration`). On every `hasPermission(...)` call it appends
-     `GrantedAuthoritySid("GROUP_<id>")` for the caller's live memberships, resolved through a
-     `user-groups-api` facade (e.g. `listGroupSidsForUser(userId)`). Both
-     `@PreAuthorize("hasPermission(...)")` (method security) and `UserPermissionsImpl` (UI
-     gating) funnel through this bean, so grant **and** revoke are effective at the next
-     permission check — no session machinery, no authority cache to invalidate; the Spring ACL
-     cache stays valid because it is keyed by `ObjectIdentity` and `isGranted` re-evaluates the
-     freshly derived SIDs per call.
-     *Companion change (required):* `ProjectInformationService.retrieveAccessibleProjectIdsForUser()`
-     reads `authentication.getAuthorities()` directly, so it must additionally union the user's
-     group SIDs via the same facade — otherwise group-granted projects pass `hasPermission(READ)`
-     but never appear in the project overview.
-     *Constraint:* under Option B, group-aware checks must route through `hasPermission(...)` / the
-     listing helper; `hasRole` and view-level authority checks do not see groups.
+a. **`GroupSid`** (`datamanager-app/.../security/GroupSid.java`) — implements `Sid`, with
+   `equals`/`hashCode` based on the group id, and a `toString` returning the persisted SID string
+   `"GROUP_<id>"`.
+b. **Write path — `GroupAwareJdbcMutableAclService`** (extends `JdbcMutableAclService`): overrides
+   `createOrRetrieveSidPrimaryKey(Sid, boolean)` so a `GroupSid` is persisted as a non-principal
+   SID string. Without this, the default throws `IllegalArgumentException: Unsupported
+   implementation of Sid`.
+c. **Read path — `GroupAwareBasicLookupStrategy`** (extends `BasicLookupStrategy`): overrides
+   `createSid(boolean, String)` to reconstruct a stored SID string as a `GroupSid` (resolved
+   lazily via a `GroupService::allGroupSids`-style lookup) instead of the default
+   `GrantedAuthoritySid`. Without this, a stored group SID is read back as a
+   `GrantedAuthoritySid`, which never `.equals()` a `GroupSid`, so access is always denied.
+d. **Check-time retrieval — `GroupAwareSidRetrievalStrategy`** (implements `SidRetrievalStrategy`):
+   returns the caller's `PrincipalSid` + `GrantedAuthoritySid`s **plus** a `GroupSid` per live group
+   membership, resolved through a `user-groups-api` facade (e.g. `listGroupSidsForUser(userId)`).
 
-   Recommendation: **Option B** — it satisfies live rollout (grant and revocation) natively,
-   keeps the database as the single source of truth at decision time, and avoids the
-   session/context pitfalls of per-request freshness (§4.6).
-2. **Sharing:** reuse `addAuthorityAccess(projectId, "GROUP_<id>", role)` with validation blocking
-   OWNER. `removeAuthorityAccess` / `changeAuthorityAccess` cover revoke and role change.
-3. **Listing:** extend `listCollaborators()` (or add `listSharedGroups()`) to surface authority
-   ACEs in the UI (name, description, member count, member list).
-4. **Effective-access query (new):** needed for notification dedupe and member-count display —
+Wiring in `AclSecurityConfiguration`:
+
+- The bean graph becomes `AclCache → LookupStrategy (GroupAwareBasicLookupStrategy) →
+  MutableAclService (GroupAwareJdbcMutableAclService) → AclPermissionEvaluator (QbicPermissionEvaluator)
+  → DefaultMethodSecurityExpressionHandler`. The `MethodSecurityExpressionHandler` must register the
+  evaluator via `setPermissionEvaluator(...)` — without it Spring silently uses the built-in
+  `DenyAllPermissionEvaluator` and every request is denied (already done today).
+- The two group-aware subclasses are wired in where the current config builds `BasicLookupStrategy`
+  and `JdbcMutableAclService`.
+- **Database identity queries:** `JdbcMutableAclService`'s default identity query is HSQLDB-only;
+  the current code already overrides both `classIdentityQuery` and `sidIdentityQuery` to
+  `SELECT @@IDENTITY` for MySQL (`ProjectAccessServiceImpl`). The group-aware subclass must preserve
+  this.
+
+**Check-time behaviour (live rollout):** because `GroupAwareSidRetrievalStrategy` derives the
+caller's `GroupSid`s from the database on every `hasPermission(...)` call, grant **and** revocation
+are effective at the next permission check — for `@PreAuthorize("hasPermission(...)")` (method
+security) and `UserPermissionsImpl` (UI gating) alike. No session machinery, no authority cache to
+invalidate; the Spring ACL cache stays valid because it is keyed by `ObjectIdentity`, while
+`isGranted` re-evaluates the freshly derived SIDs per call.
+
+- *Freshness / concurrency:* membership is read through a `@Cacheable` facade
+  (`GroupService.groupNamesForUser`-style); every `addMember`/`removeMember` must `evictCache`
+  so membership changes are seen on the next check. The read path resolves `GroupSid`s lazily (not
+  at bean construction), so groups created after startup are still recognised.
+- *Constraint:* group-aware checks must route through `hasPermission(...)` / the listing helper;
+  `hasRole` and view-level authority checks do not see groups.
+- *Key caveat:* the `GroupSid` string must match exactly between (a) the persisted ACE SID and
+  (b) what the retrieval strategy produces for a member — a mismatch silently denies access.
+  Using the stable group *id* (not the display name) as the SID string avoids breakage on renames.
+
+1. **Sharing:** reuse `addAuthorityAccess(projectId, groupSid, role)` with validation blocking
+   OWNER. `removeAuthorityAccess` / `changeAuthorityAccess` cover revoke and role change. The
+   `GroupSid` instance is derived from the group id at the call site.
+2. **Listing:** extend `listCollaborators()` (or add `listSharedGroups()`) to surface group ACEs
+   in the UI (group name, description, member count, member list).
+   *Companion change (required):* `ProjectInformationService.retrieveAccessibleProjectIdsForUser()`
+   reads `authentication.getAuthorities()` directly, so it must additionally union the user's
+   group SIDs via the same `user-groups-api` facade — otherwise group-granted projects pass
+   `hasPermission(READ)` but never appear in the project overview.
+3. **Effective-access query (new):** needed for notification dedupe and member-count display —
    "has member X effective access (direct ACE, via group, or via role) to project P?" Implemented
-   as a batch query against `acl_entry` / `acl_sid` for the member's sid set.
+   as a batch query against `acl_entry` / `acl_sid` for the member's sid set (including
+   `GroupSid`s for the member's memberships).
 
 ### 4.4 Notifications (event → policy → directive)
 
@@ -209,30 +240,16 @@ Follow the existing pattern (`ProjectAccessGranted` → `ProjectAccessGrantedPol
 
 ### 4.6 Revocation semantics
 
-- **Under Option A** (login-scoped authority injection), authorities are captured at login, so
-  membership changes take effect at **next login / session expiry** — matching today's behaviour
-  for role changes. If a live effect is nevertheless required there, the fallbacks are:
+Because `GroupAwareSidRetrievalStrategy` derives the caller's `GroupSid`s on every permission
+check (§4.3), revocation is effective at the **next `hasPermission(...)` / listing evaluation** —
+with no session invalidation or per-request freshness filter. This supersedes the login-scoped
+authority-injection alternative (which would defer changes to next login / session expiry and
+require session-invalidation or per-request-authority machinery).
 
-  - (b) Broadcast a session-invalidation event on sensitive membership changes (no Spring Session
-    today — heavier).
-  - (c) Per-request authority freshness: a `OncePerRequestFilter` registered after
-    `SecurityContextHolderFilter` in `SecurityConfiguration.vaadinSecurityFilterChain(...)` that
-    re-resolves `AuthorityService.getAuthoritiesByUserId()` on every request. Vaadin constraint
-    (verified in `VaadinAwareSecurityContextHolderStrategy`, vaadin-spring 25.x): `setContext(...)`
-    writes **only the ThreadLocal**, while `getContext()` prefers the SecurityContext stored in the
-    HTTP session — the filter must therefore **mutate** `SecurityContextHolder.getContext()
-    .setAuthentication(...)` (and skip writes when the authority set is unchanged), otherwise the
-    refresh does not persist and every round-trip dirties the shared session object. Cost:
-    per-request recomputation (mitigate with EHCache + `GroupMembershipChanged` invalidation over
-    Artemis) and a second authority source of truth to keep consistent.
-
-- **Under Option B** (evaluation-time SID derivation, recommended), the database is consulted at
-  every permission check, so there is **no staleness window at all** — revocation is effective at
-  the next `hasPermission(...)` / listing evaluation, for Vaadin and REST requests alike, without
-  any session or filter machinery.
-
-Recommendation: Option B (§4.3); no session invalidation and no per-request freshness filter are
-required.
+Caching the membership lookup is **optional and up to the implementation** (e.g. keyed by user id,
+as in the glossary). If caching is added, care must be taken that group-membership changes do not
+lead to **stale cache entries** — i.e. every `addMember`/`removeMember` must evict the affected
+user's entries so the change is reflected at the next check.
 
 ---
 
@@ -250,8 +267,8 @@ required.
 Org groups are a force multiplier: one membership mistake silently grants/revokes access on every
 project shared with the group. Mitigations baked into the design:
 
-1. Instant revocation — under §4.3 Option B effective at the next permission check, under Option
-   A at next login (§4.6) — plus loud emails on removal.
+1. Instant revocation — effective at the next permission check (§4.3, §4.6) — plus loud emails on
+   removal.
 2. Project admins notified on membership changes of shared groups.
 3. Groups can never be OWNER; a group grant caps at ADMIN.
 4. Dissolution shows affected projects before confirming; ACEs cleaned up.
@@ -269,7 +286,7 @@ No flag/restriction on sensitive projects; transparency through the notification
 1. **Requirements first:** this is new system capability → new requirement entries in
    `docs/requirements.md` (proposed new domain, e.g. `GROUP-*` or `ACCESS-*`), as a **dedicated PR
    with human approval** — never bundled with implementation.
-2. **ADR(s):** bounded-context placement + authority-based grant approach — ADR creation requires
+2. **ADR(s):** bounded-context placement + custom-`GroupSid` ACL approach — ADR creation requires
    human confirmation (MADR template at `docs/adr/templates/`).
 3. **Feature / Stories / Tasks:** `FEAT-<SLUG>` feature first, then stories with stable IDs
    recorded in `docs/features.md` (draft → approved lifecycle), then tasks.
@@ -283,7 +300,7 @@ No flag/restriction on sensitive projects; transparency through the notification
 |---|---|
 | **P0 — Governance** | Requirements PR, ADR(s), Feature + Stories |
 | **P1 — Domain** | `user-groups` module: aggregate, membership, role hierarchy & policies (auto-dissolve, transfer-or-dissolve guard, unique names), JPA + migrations |
-| **P2 — Authorization** | Authority injection, share/list groups via ACL, effective-access query, OWNER block |
+| **P2 — Authorization** | `GroupSid` + the four ACL customizations (write/read/check-time), share/list groups via ACL, effective-access query, OWNER block |
 | **P3 — Notifications** | Events + policies + email directives with dedupe/digests |
 | **P4 — UI** | My Groups, Admin Groups, access-page Groups section, share-dialog group tab, project-card view rebuild |
 | **P5 — Ops** | Org-group seeding, Spock specs + integration tests, audit logging, docs |
@@ -313,6 +330,10 @@ No flag/restriction on sensitive projects; transparency through the notification
 - `project-management-infrastructure/.../project/ProjectRepositoryImpl.java`
 - `datamanager-app/.../security/AclSecurityConfiguration.java`, `SecurityConfiguration.java`,
   `UserPermissionsImpl.java`
+- `datamanager-app/.../security/GroupSid.java`,
+  `datamanager-app/.../security/GroupAwareJdbcMutableAclService.java`,
+  `datamanager-app/.../security/GroupAwareBasicLookupStrategy.java`,
+  `datamanager-app/.../security/GroupAwareSidRetrievalStrategy.java` (proposed)
 - `project-management/.../application/authorization/acl/QbicPermissionEvaluator.java`
 - `datamanager-app/.../views/projects/project/access/ProjectAccessComponent.java`, `AddCollaboratorToProjectDialog.java`
 - `project-management/.../application/policy/directive/InformUserAboutGrantedAccess.java`

--- a/docs/user-groups-strategy.md
+++ b/docs/user-groups-strategy.md
@@ -1,7 +1,7 @@
 # Strategy — User Groups for Project Sharing
 
 > **Status:** Draft — open for review (docs-only PR, no code changes, no requirement changes)
-> **Date:** 2025-07-15
+> **Date:** 2026-09-07
 > **Scope:** Investigation of the current user & access management capabilities and a proposed
 > strategy to introduce *user groups* so projects can be shared with a group of people instead of
 > assigning them manually, one by one.


### PR DESCRIPTION
## Description

Adds `docs/user-groups-strategy.md` — a strategy document for introducing **user groups** so projects can be shared with a group of people (org groups like NGS labs, and self-service ad-hoc groups) instead of manual per-user assignment. The document records the investigation of the current user & access management capabilities (identity context, Spring Security ACL, existing authority-based grants) and the aligned product decisions, proposed architecture, security analysis, governance next steps, and implementation phases.

**Docs-only PR** — no code changes, no schema changes, no requirement changes.

## Issue and Traceability

### Linked Task Issue
- **Closes:** — (none; this PR is the review vehicle for the strategy. Task/Story issues will be created from it once approved, per AGENTS.md governance)

### Requirement IDs Addressed
- [x] Requirement IDs: — (none; this is a strategy/proposal document, not an implementation)

## Requirement Update Status

- [ ] **Requirements Updated:** —
- [x] **Justification Provided:** This PR adds a strategy/design document only. It changes no externally observable behavior. If the strategy is approved, the new capability will be specified in `docs/requirements.md` first (dedicated, human-approved requirement PR) and then implemented via Feature/Story/Task issues as required by AGENTS.md.

### Justification (if applicable)
Docs-only change: no production code, no behavior change. Governance steps following approval are outlined in §6 of the document itself ("Governance Next Steps").

## Changes Summary

### Modified Areas
- [ ] Domain layer (`domain/model/`, domain events, aggregates)
- [ ] Application layer (`application/` services, use cases)
- [ ] Infrastructure layer (JPA repositories, external integrations, config)
- [ ] UI / Views (`views/` components, Vaadin routes)
- [ ] Database schema (`sql/`, DDL changes)
- [ ] Tests (unit, integration, or Spock specs)
- [x] Documentation, CI/CD, or build configuration

### Behavioral Changes
- [x] No behavioral changes (internal refactoring, optimization, test addition, etc.)
- [ ] Yes, behavior changes: —

## Sensitive Changes Requiring Review
- [ ] **Database schema changes** (`sql/complete-schema.sql`, table/column DDL)
- [ ] **Spring Security configuration** (`security/`, ACL setup, authentication/authorization)
- [ ] **FAIR / RO-Crate export format** (`docs/fair/`, RO-Crate builder logic)
- [ ] **Artemis messaging topics** (JMS topic names, consumer configuration)
- [ ] **Requirement file edits** (`docs/requirements.md`)
- [x] None of the above

## Pre-Submission Checklist

- [ ] **Issue Linked:** PR references a Task issue (see "Linked Task Issue" section above) — *exception: docs-only strategy PR, no issue exists yet*
- [ ] **Requirements Listed:** — *exception: docs-only*
- [x] **No Constraint IDs:** No `C` (constraint) IDs are listed in the Requirement IDs section
- [x] **Behavior vs. Requirements:** Requirement update confirmed OR explicit justification provided
- [x] **Code Style:** N/A (Markdown)
- [x] **Tests:** N/A (docs-only)
- [x] **No Secrets:** No hardcoded credentials, API keys, passwords, or secrets committed
- [x] **Documentation:** Updated relevant docs

---

### Notes for Reviewers

Key decisions to review:
1. **Bounded-context placement** of the new `user-groups` module (new Maven modules require human approval per AGENTS.md §12; an ADR is proposed).
2. **Authority-based approach** — reusing the existing `GrantedAuthoritySid` path (`addAuthorityAccess`) and injecting `GROUP_<id>` authorities at login, avoiding per-user ACE bookkeeping.
3. **Notification profile** — email only members who *newly* gain access (dedupe), digests, revocation mails.
4. **Revocation semantics** — membership changes apply at next login (aligns with current role behaviour).
5. **Privacy** — memberships visible only to members & admins; project cards show group names, never member lists.