### PR TITLE
Prepare release 1.18.0

### DIFF
--- a/application.properties.template
+++ b/application.properties.template
@@ -191,6 +191,8 @@ routing.password-reset.reset-parameter=user-id
 # Route to project resources
 routing.projects.endpoint=/projects
 routing.projects.info.endpoint=/projects/%s/info
+# Route to the project's connected-datasets view (used by dataset notification emails)
+routing.projects.datasets.endpoint=/projects/%s/datasets
 routing.projects.samples.enpoint=/projects/%s/experiments/%s/samples
 routing.registration.oidc.orcid.endpoint=/register/oidc
 routing.registration.error.pending-email-verification=/register/pending-email-confirmation

--- a/datamanager-app/frontend/themes/datamanager/components/all.css
+++ b/datamanager-app/frontend/themes/datamanager/components/all.css
@@ -1328,13 +1328,20 @@ Older stuff -
 .section-header-row {
   display: flex;
   width: 100%;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.actionbar {
+  display: flex;
+  gap: var(--lumo-space-s);
+  align-items: center;
 }
 
 .section-title {
   font-weight: bold;
   color: var(--secondary-text-color);
   margin-bottom: 0.5rem;
-  width: 100%;
 }
 
 

--- a/datamanager-app/frontend/themes/datamanager/components/connect-dataset-sidebar.css
+++ b/datamanager-app/frontend/themes/datamanager/components/connect-dataset-sidebar.css
@@ -194,6 +194,37 @@
   border-top: 1px solid var(--lumo-contrast-10pct);
 }
 
+/* ── Responsive hardening ──────────────────────────────────────────────── */
+
+/*
+ * The project-wide .flex-vertical utility class sets flex-wrap: wrap. In a
+ * column flex container with a definite height that is too short for all
+ * children (small / short viewports), flex line breaking ignores flex-shrink
+ * and wraps the overflowing items into a SECOND column laid out along the
+ * cross axis — i.e. the footer gets rendered to the RIGHT of the results
+ * grid. Forcing nowrap on every vertical flex chain of the sidebar keeps the
+ * header / scrollable-content / footer stack intact; overflow is handled by
+ * the scrollable content area (.cds-content) instead of wrapping.
+ */
+.connect-dataset-sidebar .cds-body,
+.connect-dataset-sidebar .cds-content,
+.connect-dataset-sidebar .cds-results,
+.connect-dataset-sidebar .cds-footer {
+  flex-wrap: nowrap;
+}
+
+/*
+ * On viewports narrower than the panel's min-width (460px) CSS min-width
+ * clamps max-width, so the panel would stick out past the left edge of the
+ * screen. Let it reclaim the full viewport width instead.
+ */
+@media only screen and (max-width: 460px) {
+  .connect-dataset-sidebar .cds-panel {
+    min-width: 0;
+    width: 100vw;
+  }
+}
+
 /* ── Search-result card ─────────────────────────────────────────────────── */
 
 .connect-dataset-sidebar .cds-card {

--- a/datamanager-app/frontend/themes/datamanager/components/custom.css
+++ b/datamanager-app/frontend/themes/datamanager/components/custom.css
@@ -7,6 +7,7 @@
 @import "combobox.css";
 @import "dialog.css";
 @import "connect-dataset-sidebar.css";
+@import "sync-results-sidebar.css";
 @import "div.css";
 @import "image.css";
 @import "info.css";

--- a/datamanager-app/frontend/themes/datamanager/components/sync-results-sidebar.css
+++ b/datamanager-app/frontend/themes/datamanager/components/sync-results-sidebar.css
@@ -1,0 +1,152 @@
+/* ────────────────────────────────────────────────────────────────────────────
+ * Sync Results Sidebar
+ *
+ * All styles are scoped under the .sync-results-sidebar root class so they
+ * cannot leak into other components. Layout and spacing that can be
+ * expressed with Lumo utility classes are applied via addClassName() in the
+ * Java view; this file contains only panel chrome and the spinner.
+ *
+ * Hierarchy (see SyncResultsSidebar.java):
+ *   .sync-results-sidebar          ← root Div (the sidebar itself)
+ *     .srs-backdrop                 semi-transparent overlay behind panel
+ *     .srs-panel                    the sliding panel
+ *       .srs-body                   full-height flex column
+ *         .srs-header               top bar with title + close button
+ *         .srs-summary              summary line (x updated · y up to date · …)
+ *         .srs-rows                 scrollable row list
+ *           .srs-row                one dataset row
+ *             .srs-spinner          inline spinner while syncing
+ *         .srs-footer               credential hint + Done button
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/* ── Backdrop (behind the panel) ─────────────────────────────────────────── */
+
+.sync-results-sidebar .srs-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 999;
+}
+
+/* ── Panel ───────────────────────────────────────────────────────────────── */
+
+.sync-results-sidebar .srs-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(55%, 720px);
+  min-width: 460px;
+  max-width: 100vw;
+  height: 100%;
+  background-color: var(--lumo-base-color);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.12);
+  z-index: 1000;
+  box-sizing: border-box;
+}
+
+/* ── Body (full-height flex column inside panel) ─────────────────────────── */
+
+.sync-results-sidebar .srs-body {
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  flex-wrap: nowrap;
+}
+
+/* ── Header (title + close button) ───────────────────────────────────────── */
+
+.sync-results-sidebar .srs-header {
+  padding: var(--lumo-space-m) var(--lumo-space-l);
+  border-bottom: 1px solid var(--lumo-contrast-10pct);
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+}
+
+/* ── Summary line ────────────────────────────────────────────────────────── */
+
+.sync-results-sidebar .srs-summary {
+  padding: var(--lumo-space-m) var(--lumo-space-l);
+  border-bottom: 1px solid var(--lumo-contrast-10pct);
+  background-color: var(--lumo-contrast-5pct);
+  flex-shrink: 0;
+}
+
+/* ── Rows (scrollable) ───────────────────────────────────────────────────── */
+
+.sync-results-sidebar .srs-rows {
+  flex-grow: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--lumo-space-m) var(--lumo-space-l);
+  gap: var(--lumo-space-m);
+  flex-shrink: 1;
+  flex-wrap: nowrap;
+}
+
+.sync-results-sidebar .srs-row {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  border: 1px solid var(--lumo-contrast-10pct);
+  border-radius: 6px;
+  padding: var(--lumo-space-m);
+  background-color: var(--lumo-base-color);
+  gap: var(--lumo-space-s);
+}
+
+.sync-results-sidebar .srs-row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  width: 100%;
+}
+
+.sync-results-sidebar .srs-status-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-width: 0;
+  gap: var(--lumo-space-s);
+}
+
+.sync-results-sidebar .srs-status-text {
+  overflow-wrap: break-word;
+  word-break: break-word;
+  min-width: 0;
+  flex: 1;
+}
+
+/* ── Inline spinner (small ring, centered) ──────────────────────────────── */
+
+.sync-results-sidebar .srs-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--lumo-contrast-20pct);
+  border-top-color: var(--lumo-primary-color);
+  border-radius: 50%;
+  animation: srs-spin 0.8s linear infinite;
+  box-sizing: border-box;
+}
+
+@keyframes srs-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Footer (credential hint + Done) ─────────────────────────────────────── */
+
+.sync-results-sidebar .srs-footer {
+  padding: var(--lumo-space-m) var(--lumo-space-l);
+  border-top: 1px solid var(--lumo-contrast-10pct);
+  background-color: var(--lumo-base-color);
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+}
+
+.sync-results-sidebar .srs-credentials-hint {
+  color: var(--lumo-warning-text-color);
+  max-width: 340px;
+}

--- a/datamanager-app/src/main/java/life/qbic/datamanager/AppConfig.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/AppConfig.java
@@ -39,6 +39,7 @@ import life.qbic.projectmanagement.application.experiment.ExperimentInformationS
 import life.qbic.projectmanagement.application.measurement.MeasurementLookupService;
 import life.qbic.projectmanagement.application.policy.AssociatedDatasetConnectedPolicy;
 import life.qbic.projectmanagement.application.policy.AssociatedDatasetRemovedPolicy;
+import life.qbic.projectmanagement.application.policy.AssociatedDatasetsSyncedPolicy;
 import life.qbic.projectmanagement.application.policy.BatchRegisteredPolicy;
 import life.qbic.projectmanagement.application.policy.ExperimentCreatedPolicy;
 import life.qbic.projectmanagement.application.policy.ExperimentUpdatedPolicy;
@@ -56,6 +57,7 @@ import life.qbic.projectmanagement.application.policy.directive.CreateNewSampleS
 import life.qbic.projectmanagement.application.policy.directive.DeleteSampleFromBatch;
 import life.qbic.projectmanagement.application.policy.directive.InformProjectCollaboratorsAboutDatasetConnection;
 import life.qbic.projectmanagement.application.policy.directive.InformProjectCollaboratorsAboutDatasetRemoval;
+import life.qbic.projectmanagement.application.policy.directive.InformProjectCollaboratorsAboutDatasetSync;
 import life.qbic.projectmanagement.application.policy.directive.InformUserAboutGrantedAccess;
 import life.qbic.projectmanagement.application.policy.directive.InformUsersAboutBatchRegistration;
 import life.qbic.projectmanagement.application.policy.directive.UpdateProjectUponBatchCreation;
@@ -361,6 +363,20 @@ public class AppConfig {
         emailService, projectAccessService, userInformationService,
         projectInformationService, appContextProvider, jobScheduler);
     return new AssociatedDatasetRemovedPolicy(informCollaborators);
+  }
+
+  @Bean
+  public AssociatedDatasetsSyncedPolicy associatedDatasetsSyncedPolicy(
+      life.qbic.projectmanagement.application.communication.EmailService emailService,
+      ProjectAccessService projectAccessService,
+      UserInformationService userInformationService,
+      ProjectInformationService projectInformationService,
+      AppContextProvider appContextProvider,
+      JobScheduler jobScheduler) {
+    var informCollaborators = new InformProjectCollaboratorsAboutDatasetSync(
+        emailService, projectAccessService, userInformationService,
+        projectInformationService, appContextProvider, jobScheduler);
+    return new AssociatedDatasetsSyncedPolicy(informCollaborators);
   }
 
   /*

--- a/datamanager-app/src/main/java/life/qbic/datamanager/DataManagerContextProvider.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/DataManagerContextProvider.java
@@ -21,6 +21,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class DataManagerContextProvider implements AppContextProvider {
 
   private final String projectInfoEndpoint;
+  private final String projectDatasetsEndpoint;
 
   private final URL baseUrlApplication;
   private final String samplesEndpoint;
@@ -37,8 +38,10 @@ public class DataManagerContextProvider implements AppContextProvider {
       @Value("${service.host.port}") int port,
       @Value("${server.servlet.context-path}") String contextPath,
       @Value("${routing.projects.info.endpoint}") String projectEndpoint,
+      @Value("${routing.projects.datasets.endpoint}") String projectDatasetsEndpoint,
       @Value("${routing.projects.samples.enpoint}") String samplesEndpoint) {
     this.projectInfoEndpoint = projectEndpoint;
+    this.projectDatasetsEndpoint = projectDatasetsEndpoint;
     this.samplesEndpoint = samplesEndpoint;
     try {
       // The base path must end in a slash so that relative endpoint paths are resolved
@@ -76,6 +79,18 @@ public class DataManagerContextProvider implements AppContextProvider {
     try {
       return baseUrlApplication.toURI()
           .resolve(stripLeadingSlashes(samplesEndpoint.formatted(projectId, experimentId)))
+          .toURL()
+          .toExternalForm();
+    } catch (MalformedURLException | URISyntaxException e) {
+      throw new ApplicationException("Data Manager context creation failed.", e);
+    }
+  }
+
+  @Override
+  public String urlToDatasets(String projectId) {
+    try {
+      return baseUrlApplication.toURI()
+          .resolve(stripLeadingSlashes(projectDatasetsEndpoint.formatted(projectId)))
           .toURL()
           .toExternalForm();
     } catch (MalformedURLException | URISyntaxException e) {

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectDatasetSidebar.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectDatasetSidebar.java
@@ -222,6 +222,13 @@ public class ConnectDatasetSidebar extends Div {
     instanceSelector.setPlaceholder("Select repository…");
     instanceSelector.setItemLabelGenerator(SourceInstanceDescriptor::displayName);
     instanceSelector.addValueChangeListener(e -> {
+      // Switching the repository invalidates the current selection: the
+      // selected search results belong to the previously chosen provider.
+      // Reset the grid selection so users can only keep selections for the
+      // currently selected repository. The selection listener takes care of
+      // updating the count label and disabling the connect button.
+      resetResultsForInstanceChange();
+
       // Always update the credential banner when instance changes
       updateCredentialBanner();
 
@@ -812,6 +819,30 @@ public class ConnectDatasetSidebar extends Div {
       selectionCountLabel.getStyle().remove("display");
     }
     connectButton.setEnabled(count > 0);
+  }
+
+  /**
+   * Clears any selection and cached search results that belong to a
+   * previously selected repository.
+   *
+   * <p>Called when the user switches the repository in the instance
+   * selector, so selections (and stale hits) can never carry over to the
+   * newly selected provider. Implemented as an instance method (rather than
+   * inline in the value-change listener) because the grid is a blank final
+   * field assigned later in the constructor — a direct field reference from
+   * the listener lambda would be rejected by javac's definite-assignment
+   * check.</p>
+   */
+  private void resetResultsForInstanceChange() {
+    resultsGrid.deselectAll();
+
+    // Drop the cached results of the previous provider immediately so no
+    // stale hits are rendered while a search for the new provider is in
+    // flight (or if the user never triggers one).
+    synchronized (cachedResults) {
+      cachedResults.clear();
+    }
+    resultsGrid.getDataProvider().refreshAll();
   }
 
   // ── Connect confirmation ────────────────────────────────────────────

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectedDatasetsMain.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectedDatasetsMain.java
@@ -66,6 +66,7 @@ public class ConnectedDatasetsMain extends Main implements BeforeEnterObserver {
   private final ConnectedResourcesComponent connectedResourcesComponent;
   private final AuthenticationToUserIdTranslator authenticationToUserIdTranslator;
   private ConnectDatasetSidebar connectDatasetSidebar;
+  private SyncResultsSidebar syncResultsSidebar;
 
   private Context context = new Context();
   private final UiHandle uiHandle = new UiHandle();
@@ -97,6 +98,9 @@ public class ConnectedDatasetsMain extends Main implements BeforeEnterObserver {
     connectedResourcesComponent.addConnectDatasetsClickListener(e -> openConnectSidebar());
     connectedResourcesComponent.addRemoveDatasetClickListener(
         e -> onRemoveDataset(e.getDatasetId()));
+    connectedResourcesComponent.addSyncDatasetClickListener(
+        e -> onSyncDatasets(List.of(e.getDatasetId())));
+    connectedResourcesComponent.addSyncAllDatasetsClickListener(e -> onSyncAllDatasets());
     add(connectedResourcesComponent);
   }
 
@@ -267,5 +271,51 @@ public class ConnectedDatasetsMain extends Main implements BeforeEnterObserver {
       add(connectDatasetSidebar);
     }
     connectDatasetSidebar.open();
+  }
+
+  // ── Sync flow ────────────────────────────────────────────────────
+
+  /**
+   * Drives a sync trigger for the given dataset connections: opens the
+   * {@link SyncResultsSidebar}, starts the reactive sync, and refreshes
+   * the card list when the trigger completes.
+   */
+  private void onSyncDatasets(List<String> datasetIds) {
+    if (context.projectId().isEmpty() || datasetIds.isEmpty()) {
+      return;
+    }
+    var projectId = context.projectId().orElseThrow();
+    List<ConnectedDatasetView> views = associatedDatasetService.listConnectedDatasetViews(projectId)
+        .stream()
+        .filter(view -> datasetIds.contains(view.id()))
+        .toList();
+    if (views.isEmpty()) {
+      return;
+    }
+    var userId = resolveCurrentUserId();
+    ensureSyncSidebar().startSync(projectId, views, userId);
+  }
+
+  private void onSyncAllDatasets() {
+    if (context.projectId().isEmpty()) {
+      return;
+    }
+    var projectId = context.projectId().orElseThrow();
+    List<ConnectedDatasetView> views = associatedDatasetService.listConnectedDatasetViews(projectId);
+    if (views.isEmpty()) {
+      return;
+    }
+    var userId = resolveCurrentUserId();
+    ensureSyncSidebar().startSync(projectId, views, userId);
+  }
+
+  private SyncResultsSidebar ensureSyncSidebar() {
+    if (syncResultsSidebar == null) {
+      syncResultsSidebar = new SyncResultsSidebar(associatedDatasetService);
+      syncResultsSidebar.addDatasetsSyncedListener(
+          e -> connectedResourcesComponent.refresh());
+      add(syncResultsSidebar);
+    }
+    return syncResultsSidebar;
   }
 }

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectedResourcesComponent.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/ConnectedResourcesComponent.java
@@ -53,9 +53,9 @@ import life.qbic.projectmanagement.application.associated_dataset.ConnectedDatas
  * layer (never domain entities directly). User and experiment display names
  * are already resolved by the service — this component renders them as-is.</p>
  *
- * <p>Per FEAT-DATSET-01 this component <b>does not</b> render per-row actions
- * (Sync, Remove) — those belong to later stories (FEAT-DATSET-04 and
- * beyond).</p>
+ * <p>Per FEAT-DATSET-04/08 this component renders write-gated per-row
+ * actions: <b>Sync</b> (synchronise one dataset with its source) and
+ * <b>Remove</b>, plus a <b>Sync All</b> action-bar button.</p>
  *
  * @since 1.12.0
  */
@@ -73,6 +73,7 @@ public class ConnectedResourcesComponent extends Div {
   private final Section section;
   private final Div cardsContainer;
   private final Button connectButton;
+  private final Button syncAllButton;
 
   private Context context;
 
@@ -88,7 +89,13 @@ public class ConnectedResourcesComponent extends Div {
     connectButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
     connectButton.addClickListener(e -> fireConnectDatasetsClick());
 
-    var actionBar = new ActionBar(connectButton);
+    syncAllButton = new Button("Sync All", VaadinIcon.REFRESH.create());
+    syncAllButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+    syncAllButton.getElement().setAttribute("title",
+        "Synchronise all connected datasets with their source instances");
+    syncAllButton.addClickListener(e -> fireSyncAllDatasetsClick());
+
+    var actionBar = new ActionBar(connectButton, syncAllButton);
 
     var note = new SectionNote(
         "External datasets connected to this project and its experiments. "
@@ -125,6 +132,7 @@ public class ConnectedResourcesComponent extends Div {
   /** Controls whether the "Remove" button is rendered on each card. */
   public void setWriteAllowed(boolean writeAllowed) {
     this.writeAllowed = writeAllowed;
+    syncAllButton.setVisible(writeAllowed);
   }
 
   /** Reloads connected datasets and re-renders the content area. */
@@ -170,6 +178,30 @@ public class ConnectedResourcesComponent extends Div {
   public Registration addRemoveDatasetClickListener(
       ComponentEventListener<RemoveDatasetClickEvent> listener) {
     return addListener(RemoveDatasetClickEvent.class, listener);
+  }
+
+  /**
+   * Registers a listener invoked when the "Sync All" action-bar button
+   * is clicked.
+   *
+   * @since 1.13.0
+   */
+  public Registration addSyncAllDatasetsClickListener(
+      ComponentEventListener<SyncAllDatasetsClickEvent> listener) {
+    return addListener(SyncAllDatasetsClickEvent.class, listener);
+  }
+
+  /**
+   * Registers a listener invoked when the "Sync" button on a dataset
+   * card is clicked. Listener receives the aggregate ID of the clicked
+   * dataset. Only fires when {@link #setWriteAllowed(boolean)} is
+   * {@code true}.
+   *
+   * @since 1.13.0
+   */
+  public Registration addSyncDatasetClickListener(
+      ComponentEventListener<SyncDatasetClickEvent> listener) {
+    return addListener(SyncDatasetClickEvent.class, listener);
   }
 
   // ── Empty state ─────────────────────────────────────────────────────
@@ -273,8 +305,15 @@ public class ConnectedResourcesComponent extends Div {
       headerRow.add(dateSpan);
     }
 
-    // Remove button (write-access only, right-aligned as a primary action).
+    // Sync + Remove buttons (write-access only, right-aligned).
     if (writeAllowed) {
+      var syncButton = new Button(VaadinIcon.REFRESH.create());
+      syncButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+      syncButton.getElement().setAttribute("title", "Synchronise this dataset with its source");
+      syncButton.getElement().setAttribute("aria-label", "Synchronise dataset");
+      syncButton.addClickListener(e -> fireSyncDatasetClick(view.id()));
+      headerRow.add(syncButton);
+
       var removeButton = new Button(VaadinIcon.TRASH.create());
       removeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE,
           ButtonVariant.LUMO_ERROR);
@@ -497,6 +536,14 @@ public class ConnectedResourcesComponent extends Div {
     fireEvent(new ConnectDatasetsClickEvent(this));
   }
 
+  private void fireSyncAllDatasetsClick() {
+    fireEvent(new SyncAllDatasetsClickEvent(this));
+  }
+
+  private void fireSyncDatasetClick(String datasetId) {
+    fireEvent(new SyncDatasetClickEvent(this, datasetId));
+  }
+
   private void fireRemoveDatasetClick(String datasetId) {
     fireEvent(new RemoveDatasetClickEvent(this, datasetId));
   }
@@ -537,6 +584,47 @@ public class ConnectedResourcesComponent extends Div {
     }
 
     /** Aggregate ID (UUID string) of the dataset to remove. */
+    public String getDatasetId() {
+      return datasetId;
+    }
+  }
+
+  /**
+   * Custom event fired when the "Sync All" action-bar button is clicked.
+   *
+   * @since 1.13.0
+   */
+  public static class SyncAllDatasetsClickEvent
+      extends com.vaadin.flow.component.ComponentEvent<ConnectedResourcesComponent> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public SyncAllDatasetsClickEvent(ConnectedResourcesComponent source) {
+      super(source, false);
+    }
+  }
+
+  /**
+   * Custom event fired when the "Sync" button on a dataset card is
+   * clicked. Carries the aggregate ID of the dataset to synchronise.
+   *
+   * @since 1.13.0
+   */
+  public static class SyncDatasetClickEvent
+      extends com.vaadin.flow.component.ComponentEvent<ConnectedResourcesComponent> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String datasetId;
+
+    public SyncDatasetClickEvent(ConnectedResourcesComponent source, String datasetId) {
+      super(source, false);
+      this.datasetId = datasetId;
+    }
+
+    /** Aggregate ID (UUID string) of the dataset to synchronise. */
     public String getDatasetId() {
       return datasetId;
     }

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/DatasetsSyncedEvent.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/DatasetsSyncedEvent.java
@@ -1,0 +1,22 @@
+package life.qbic.datamanager.views.projects.project.datasets;
+
+import com.vaadin.flow.component.ComponentEvent;
+import java.io.Serial;
+
+/**
+ * Fired when a sync trigger (single dataset or Sync All) has completed —
+ * regardless of how many records were updated. The parent view refreshes
+ * the connected-resources grid in response so the cards show the latest
+ * version / access status.
+ *
+ * @see SyncResultsSidebar
+ */
+public class DatasetsSyncedEvent extends ComponentEvent<SyncResultsSidebar> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  public DatasetsSyncedEvent(SyncResultsSidebar source) {
+    super(source, false);
+  }
+}

--- a/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/SyncResultsSidebar.java
+++ b/datamanager-app/src/main/java/life/qbic/datamanager/views/projects/project/datasets/SyncResultsSidebar.java
@@ -1,0 +1,408 @@
+package life.qbic.datamanager.views.projects.project.datasets;
+
+import static java.util.Objects.requireNonNull;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.AnchorTarget;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.shared.Registration;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import life.qbic.datamanager.views.UiHandle;
+import life.qbic.datamanager.views.account.ExternalProvidersMain;
+import life.qbic.projectmanagement.application.associated_dataset.AssociatedDatasetService;
+import life.qbic.projectmanagement.application.associated_dataset.ConnectedDatasetView;
+import life.qbic.projectmanagement.application.associated_dataset.SyncDatasetError;
+import life.qbic.projectmanagement.application.associated_dataset.SyncDatasetResponse;
+import life.qbic.projectmanagement.domain.model.associated_dataset.AssociatedDatasetId;
+import life.qbic.projectmanagement.domain.model.project.ProjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+
+/**
+ * <b>Sync Results Sidebar</b>
+ *
+ * <p>A right-side sliding panel that shows the outcome of a sync trigger
+ * (single dataset or Sync All) with one row per dataset. Rows flip live
+ * from "Syncing…" to their final state as the per-dataset responses
+ * arrive:</p>
+ * <ul>
+ *   <li><b>Updated</b> — shows the new version (green).</li>
+ *   <li><b>Up to date</b> — no changes on the source.</li>
+ *   <li><b>Cannot be synced</b> — inline guidance (insufficient rights,
+ *       provider not configured, access link refresh requires the record
+ *       owner, record no longer exists, …).</li>
+ * </ul>
+ *
+ * <p>Per ADR-0006 (A1) per-record access is only known after the HTTP
+ * call — rows therefore resolve live; only the "provider not configured"
+ * case for metadata-restricted records is short-circuited locally.</p>
+ *
+ * <p>Fires {@link DatasetsSyncedEvent} when the trigger completes so the
+ * parent view can refresh the connected-datasets grid.</p>
+ *
+ * @since 1.13.0
+ */
+public class SyncResultsSidebar extends Div {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger log = LoggerFactory.getLogger(SyncResultsSidebar.class);
+
+  private static final String SUCCESS_COLOR = "var(--lumo-success-text-color)";
+  private static final String SECONDARY_COLOR = "var(--lumo-secondary-text-color)";
+  private static final String ERROR_COLOR = "var(--lumo-error-text-color)";
+
+  private final AssociatedDatasetService associatedDatasetService;
+  private final UiHandle uiHandle = new UiHandle();
+  private final Div overlay;
+  private final Div panel;
+  private final Span summaryLabel;
+  private final Div rowsContainer;
+  private final Div credentialsHint;
+
+  private final Map<String, RowState> rows = new HashMap<>();
+  private final List<String> rowOrder = new ArrayList<>();
+
+  private Registration detachRegistration;
+  private Disposable activeSubscription;
+
+  public SyncResultsSidebar(AssociatedDatasetService associatedDatasetService) {
+    this.associatedDatasetService = requireNonNull(associatedDatasetService,
+        "associatedDatasetService must not be null");
+
+    addClassName("sync-results-sidebar");
+
+    // ── Overlay (semi-transparent backdrop) ──────────────────────────
+    overlay = new Div();
+    overlay.addClassName("srs-backdrop");
+    overlay.getStyle().set("display", "none");
+    overlay.addClickListener(e -> close());
+    add(overlay);
+
+    // ── Panel ────────────────────────────────────────────────────────
+    panel = new Div();
+    panel.addClassName("srs-panel");
+    panel.getStyle().set("display", "none");
+
+    var body = new Div();
+    body.addClassNames("srs-body", "flex-vertical");
+    panel.add(body);
+
+    // Header: title + close button
+    var header = new Div();
+    header.addClassNames("srs-header", "flex-horizontal", "items-center");
+    var title = new Span("Synchronisation results");
+    title.addClassName("heading-4");
+    var closeButton = new Button(VaadinIcon.CLOSE.create());
+    closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+    closeButton.getElement().setAttribute("title", "Close");
+    closeButton.getElement().setAttribute("aria-label", "Close");
+    closeButton.addClickListener(e -> close());
+    var titleSpacer = new Div();
+    titleSpacer.getStyle().set("flex-grow", "1");
+    header.add(title, titleSpacer, closeButton);
+    body.add(header);
+
+    // Summary line
+    summaryLabel = new Span();
+    summaryLabel.addClassNames("normal-body-text", "color-secondary");
+    var summaryContainer = new Div();
+    summaryContainer.addClassNames("srs-summary");
+    summaryContainer.add(summaryLabel);
+    body.add(summaryContainer);
+
+    // Rows
+    rowsContainer = new Div();
+    rowsContainer.addClassNames("srs-rows", "flex-vertical");
+    body.add(rowsContainer);
+
+    // Footer: hint + Done
+    credentialsHint = new Div();
+    credentialsHint.addClassNames("srs-credentials-hint", "extra-small-body-text");
+    credentialsHint.getStyle().set("display", "none");
+
+    var hintText = new Span(
+        "Some datasets could not be updated because of missing or insufficient "
+            + "provider connections. ");
+    var manageLink = new Anchor(
+        RouteConfiguration.forSessionScope()
+            .getUrl(ExternalProvidersMain.class),
+        "Manage provider connections");
+    manageLink.setTarget(AnchorTarget.BLANK);
+    manageLink.addClassName("extra-small-body-text");
+    credentialsHint.add(hintText, manageLink);
+
+    var footer = new Div();
+    footer.addClassNames("srs-footer", "flex-horizontal", "items-center", "gap-03");
+    var doneButton = new Button("Close", VaadinIcon.CLOSE.create());
+    doneButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+    doneButton.addClickListener(e -> close());
+    var footerSpacer = new Div();
+    footerSpacer.getStyle().set("flex-grow", "1");
+    footer.add(credentialsHint, footerSpacer, doneButton);
+    body.add(footer);
+
+    add(panel);
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────
+
+  /**
+   * Starts a sync for the given datasets and opens the sidecar. One row
+   * per dataset is rendered immediately with a "Syncing…" status and
+   * resolved live as responses arrive.
+   *
+   * @param projectId the project the datasets belong to
+   * @param datasets  the datasets to sync (defines row order and titles)
+   * @param userId    the invoking user (credentials are never borrowed)
+   */
+  public void startSync(ProjectId projectId, List<ConnectedDatasetView> datasets, String userId) {
+    requireNonNull(projectId, "projectId must not be null");
+    requireNonNull(datasets, "datasets must not be null");
+    requireNonNull(userId, "userId must not be null");
+
+    if (activeSubscription != null) {
+      activeSubscription.dispose();
+      activeSubscription = null;
+    }
+
+    UI ui = UI.getCurrent();
+    uiHandle.bind(ui);
+    if (detachRegistration == null) {
+      detachRegistration = ui.addDetachListener(e -> disposeOnDetach());
+    }
+
+    renderRows(datasets);
+    // Reset the summary counters — the sidebar instance is reused across
+    // triggers, so totals from a previous sync must not leak into the next.
+    updated = 0;
+    upToDate = 0;
+    failed = 0;
+    summaryLabel.getStyle().set("color", SECONDARY_COLOR);
+    summaryLabel.setText("Syncing %d dataset%s…".formatted(
+        datasets.size(), datasets.size() == 1 ? "" : "s"));
+    show();
+
+    List<AssociatedDatasetId> ids = datasets.stream()
+        .map(ConnectedDatasetView::id)
+        .map(AssociatedDatasetId::parse)
+        .toList();
+
+    credentialsHint.getStyle().set("display", "none");
+    activeSubscription = associatedDatasetService
+        .syncDatasets(projectId, ids, userId)
+        .subscribe(
+            response -> uiHandle.onUiAndPush(() -> resolveRow(response)),
+            error -> {
+              log.error("Unexpected error on sync subscription: %s".formatted(error.getMessage()),
+                  error);
+              uiHandle.onUiAndPush(() -> resolveStreamError());
+            },
+            () -> uiHandle.onUiAndPush(() -> {
+              resolveStreamComplete();
+              fireEvent(new DatasetsSyncedEvent(this));
+            })
+        );
+  }
+
+  /**
+   * Closes the sidebar, releases the UI binding, and disposes any
+   * in-flight subscription.
+   */
+  public void close() {
+    if (activeSubscription != null) {
+      activeSubscription.dispose();
+      activeSubscription = null;
+    }
+    if (detachRegistration != null) {
+      detachRegistration.remove();
+      detachRegistration = null;
+    }
+    uiHandle.unbind();
+    overlay.getStyle().set("display", "none");
+    panel.getStyle().set("display", "none");
+  }
+
+  private void show() {
+    overlay.getStyle().set("display", "block");
+    panel.getStyle().set("display", "block");
+  }
+
+  /**
+   * Registers a listener invoked when a sync trigger completes (regardless
+   * of how many records were updated). The parent view refreshes the
+   * connected-datasets grid in response.
+   */
+  public com.vaadin.flow.shared.Registration addDatasetsSyncedListener(
+      com.vaadin.flow.component.ComponentEventListener<DatasetsSyncedEvent> listener) {
+    return addListener(DatasetsSyncedEvent.class, listener);
+  }
+
+  private void disposeOnDetach() {
+    if (activeSubscription != null) {
+      activeSubscription.dispose();
+      activeSubscription = null;
+    }
+    detachRegistration = null;
+  }
+
+  // ── Row rendering ───────────────────────────────────────────────────
+
+  private static final class RowState {
+    final String rowId;
+    final String resourceProvider;
+    final Div row;
+    final Div spinner;
+    final Span statusText;
+
+    RowState(String rowId, String resourceProvider, Div row, Div spinner, Span statusText) {
+      this.rowId = rowId;
+      this.resourceProvider = resourceProvider;
+      this.row = row;
+      this.spinner = spinner;
+      this.statusText = statusText;
+    }
+  }
+
+  private void renderRows(List<ConnectedDatasetView> datasets) {
+    rows.clear();
+    rowOrder.clear();
+    rowsContainer.removeAll();
+    for (ConnectedDatasetView view : datasets) {
+      var row = new Div();
+      row.addClassNames("srs-row");
+
+      var titleSpan = new Span(view.title());
+      titleSpan.addClassNames("normal-body-text", "srs-row-title");
+      titleSpan.getStyle().set("font-weight", "600");
+      titleSpan.getElement().setAttribute("title", view.title());
+
+      var statusRow = new Div();
+      statusRow.addClassName("srs-status-row");
+
+      var spinner = new Div();
+      spinner.addClassName("srs-spinner");
+      spinner.getStyle().set("flex-shrink", "0");
+
+      var statusText = new Span("Syncing…");
+      statusText.addClassNames("extra-small-body-text", "srs-status-text");
+      statusText.getStyle().set("color", SECONDARY_COLOR);
+
+      statusRow.add(spinner, statusText);
+      row.add(titleSpan, statusRow);
+      rowsContainer.add(row);
+
+      rows.put(view.id(), new RowState(view.id(), view.resourceProvider(), row, spinner, statusText));
+      rowOrder.add(view.id());
+    }
+  }
+
+  /**
+   * Resolves one per-dataset response into its row.
+   */
+  private void resolveRow(SyncDatasetResponse response) {
+    RowState state = rows.get(response.datasetId().value());
+    if (state == null) {
+      log.debug("Sync response for unknown dataset {} — sidebar closed?", state);
+      return;
+    }
+    state.spinner.getStyle().set("display", "none");
+    switch (response.status()) {
+      case UPDATED -> {
+        state.statusText.getStyle().set("color", SUCCESS_COLOR);
+        StringBuilder text = new StringBuilder("Updated");
+        if (response.newVersion() != null && !response.newVersion().isBlank()) {
+          text.append(" — now ").append(normalizeVersion(response.newVersion()));
+        }
+        if (response.accessStatusChanged()) {
+          text.append(" (access status changed)");
+        }
+        state.statusText.setText(text.toString());
+        updateSummary(updated + 1, upToDate, failed);
+      }
+      case UP_TO_DATE -> {
+        state.statusText.getStyle().set("color", SECONDARY_COLOR);
+        state.statusText.setText("Up to date");
+        updateSummary(updated, upToDate + 1, failed);
+      }
+      case FAILED -> {
+        state.statusText.getStyle().set("color", ERROR_COLOR);
+        state.statusText.setText(failureText(response.error(), state.resourceProvider));
+        if (response.error() == SyncDatasetError.CREDENTIAL_REQUIRED
+            || response.error() == SyncDatasetError.CREDENTIAL_INSUFFICIENT
+            || response.error() == SyncDatasetError.ACCESS_LINK_REFRESH_FAILED) {
+          credentialsHint.getStyle().set("display", "block");
+        }
+        updateSummary(updated, upToDate, failed + 1);
+      }
+      default -> { }
+    }
+  }
+
+  private String failureText(SyncDatasetError error, String resourceProvider) {
+    return switch (error) {
+      case CREDENTIAL_REQUIRED ->
+          "Cannot be synced — configure a connection for the " + resourceProvider
+              + " provider first.";
+      case CREDENTIAL_INSUFFICIENT ->
+          "Cannot be synced — your token does not grant access to this restricted record.";
+      case ACCESS_LINK_REFRESH_FAILED ->
+          "Cannot be synced — only the record owner can refresh the access link for the new version.";
+      case RECORD_NOT_FOUND ->
+          "Record no longer exists on the source. Connection kept.";
+      case ALREADY_CONNECTED ->
+          "Not synced — a connection to this version already exists in the project.";
+      case DATASET_NOT_FOUND ->
+          "Dataset connection no longer available.";
+      case SYNC_FAILED ->
+          "Sync failed. Please try again in a moment.";
+    };
+  }
+
+  private static String normalizeVersion(String version) {
+    return "v" + version.replaceFirst("^v", "");
+  }
+
+  // ── Summary ─────────────────────────────────────────────────────────
+
+  private int updated;
+  private int upToDate;
+  private int failed;
+
+  private void updateSummary(int updated, int upToDate, int failed) {
+    this.updated = updated;
+    this.upToDate = upToDate;
+    this.failed = failed;
+    summaryLabel.setText("%d updated · %d up to date · %d not synced".formatted(
+        updated, upToDate, failed));
+  }
+
+  private void resolveStreamComplete() {
+    summaryLabel.setText("%d updated · %d up to date · %d not synced".formatted(
+        updated, upToDate, failed));
+    summaryLabel.getStyle().set("color",
+        failed == 0 && updated > 0 ? SUCCESS_COLOR : SECONDARY_COLOR);
+  }
+
+  private void resolveStreamError() {
+    int unresolved = rows.size() - updated - upToDate - failed;
+    if (unresolved > 0) {
+      failed += unresolved;
+    }
+    summaryLabel.setText("%d updated · %d up to date · %d not synced".formatted(
+        updated, upToDate, failed));
+    summaryLabel.getStyle().set("color", ERROR_COLOR);
+  }
+}

--- a/datamanager-app/src/main/resources/application.properties
+++ b/datamanager-app/src/main/resources/application.properties
@@ -140,6 +140,7 @@ routing.password-reset.reset-parameter=${PASSWORD_RESET_PARAMETER:user-id}
 # route to project resource
 routing.projects.endpoint=/projects
 routing.projects.info.endpoint=/projects/%s/info
+routing.projects.datasets.endpoint=/projects/%s/datasets
 routing.projects.samples.enpoint=/projects/%s/experiments/%s/samples
 routing.registration.oidc.orcid.endpoint=/register/oidc
 routing.registration.error.pending-email-verification=/register/pending-email-confirmation

--- a/datamanager-app/src/test/groovy/life/qbic/datamanager/DataManagerContextProviderSpec.groovy
+++ b/datamanager-app/src/test/groovy/life/qbic/datamanager/DataManagerContextProviderSpec.groovy
@@ -8,6 +8,7 @@ class DataManagerContextProviderSpec extends Specification {
     private static final String HOST = "data-manager.example.com"
     private static final String CONTEXT_PATH = ""
     private static final String PROJECT_ENDPOINT = "/projects/%s/info"
+    private static final String DATASETS_ENDPOINT = "/projects/%s/datasets"
     private static final String SAMPLES_ENDPOINT = "/projects/%s/experiments/%s/samples"
 
     def "builds base url without port when no port is specified"() {
@@ -37,7 +38,7 @@ class DataManagerContextProviderSpec extends Specification {
 
     def "preserves the context path for an absolute project endpoint"() {
         given:
-        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, PROJECT_ENDPOINT, SAMPLES_ENDPOINT)
+        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, PROJECT_ENDPOINT, DATASETS_ENDPOINT, SAMPLES_ENDPOINT)
 
         expect:
         provider.urlToProject("QABCD001") == expected
@@ -53,7 +54,7 @@ class DataManagerContextProviderSpec extends Specification {
 
     def "preserves the context path for a relative project endpoint"() {
         given:
-        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, "projects/%s/info", SAMPLES_ENDPOINT)
+        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, "projects/%s/info", DATASETS_ENDPOINT, SAMPLES_ENDPOINT)
 
         expect:
         provider.urlToProject("QABCD001") == expected
@@ -67,9 +68,41 @@ class DataManagerContextProviderSpec extends Specification {
         "dev/"      | "https://data-manager.example.com/dev/projects/QABCD001/info"
     }
 
+    def "builds base url without port for the datasets page when no port is specified"() {
+        given:
+        def provider = providerWithPort(-1)
+
+        expect:
+        provider.urlToDatasets("QABCD001") == "https://data-manager.example.com/projects/QABCD001/datasets"
+    }
+
+    def "builds base url with port for the datasets page when a port is specified"() {
+        given:
+        def provider = providerWithPort(8443)
+
+        expect:
+        provider.urlToDatasets("QABCD001") == "https://data-manager.example.com:8443/projects/QABCD001/datasets"
+    }
+
+    def "preserves the context path for the datasets page endpoint"() {
+        given:
+        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, PROJECT_ENDPOINT, DATASETS_ENDPOINT, SAMPLES_ENDPOINT)
+
+        expect:
+        provider.urlToDatasets("QABCD001") == expected
+
+        where:
+        contextPath | expected
+        ""          | "https://data-manager.example.com/projects/QABCD001/datasets"
+        "/"         | "https://data-manager.example.com/projects/QABCD001/datasets"
+        "dev"       | "https://data-manager.example.com/dev/projects/QABCD001/datasets"
+        "/dev"      | "https://data-manager.example.com/dev/projects/QABCD001/datasets"
+        "dev/"      | "https://data-manager.example.com/dev/projects/QABCD001/datasets"
+    }
+
     def "preserves the context path for the sample page endpoint"() {
         given:
-        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, PROJECT_ENDPOINT, SAMPLES_ENDPOINT)
+        def provider = new DataManagerContextProvider(PROTOCOL, HOST, -1, contextPath, PROJECT_ENDPOINT, DATASETS_ENDPOINT, SAMPLES_ENDPOINT)
 
         expect:
         provider.urlToSamplePage("QABCD001", "E12345") == expected
@@ -90,6 +123,7 @@ class DataManagerContextProviderSpec extends Specification {
                 port,
                 CONTEXT_PATH,
                 PROJECT_ENDPOINT,
+                DATASETS_ENDPOINT,
                 SAMPLES_ENDPOINT)
     }
 }

--- a/datamanager-app/src/test/java/TestReactorContextDoesNotLeak.java
+++ b/datamanager-app/src/test/java/TestReactorContextDoesNotLeak.java
@@ -1,0 +1,92 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Has tests that verify that the reactor context is per Subscriber and does not leak in contrast to
+ * manually set ThreadLocal variables.
+ */
+public class TestReactorContextDoesNotLeak {
+
+  @Test
+  void contextDoesNotLeakAcrossThreadReuse() {
+    AtomicReference<String> seenInTaskB = new AtomicReference<>();
+
+    // Task A writes to context, runs on boundedElastic
+    Mono.deferContextual(ctx ->
+            Mono.just(ctx.getOrDefault("secret", "ABSENT")))
+        .contextWrite(c -> c.put("secret", "A"))
+        .subscribeOn(Schedulers.boundedElastic())
+        .subscribe();
+
+    // Task B — may reuse the same thread; must NOT see "A"
+    Mono.deferContextual(ctx ->
+            Mono.fromRunnable(() ->
+                seenInTaskB.set(ctx.getOrDefault("secret", "ABSENT"))))
+        .subscribeOn(Schedulers.boundedElastic())
+        .block();
+
+    assertEquals("ABSENT", seenInTaskB.get());
+  }
+
+  @Test
+  void threadLocalCanLeakButContextDoesNot() {
+    ThreadLocal<String> tl = new ThreadLocal<>();
+    Scheduler s = Schedulers.newSingle("tl-test");
+
+    try {
+      // Task A sets a ThreadLocal and DOESN'T clean up
+      Mono.fromRunnable(() -> tl.set("LEAKED"))
+          .subscribeOn(s).block();
+
+      // Task B on the same thread
+      String tlValue = Mono.fromCallable(tl::get)
+          .subscribeOn(s).block();
+
+      assertEquals("LEAKED", tlValue); // ThreadLocal leaks!
+    } finally {
+      s.dispose();
+    }
+  }
+
+  @Test
+  void contextDoesNotLeakOnReusedSingleThread() {
+    Scheduler single = Schedulers.newSingle("reuse-test");
+
+    try {
+      Mono.deferContextual(ctx -> Mono.just(ctx.getOrDefault("k", "ABSENT")))
+          .contextWrite(c -> c.put("k", "value"))
+          .subscribeOn(single)
+          .block(); // runs and releases the thread
+
+      String second = Mono.deferContextual(ctx -> Mono.just(ctx.getOrDefault("k", "ABSENT")))
+          .subscribeOn(single)   // same thread, no contextWrite
+          .block();
+
+      assertEquals("ABSENT", second);
+    } finally {
+      single.dispose();
+    }
+  }
+
+  @Test
+  void eachSubscriptionGetsFreshContext() {
+    AtomicReference<Object> ctxA = new AtomicReference<>();
+    AtomicReference<Object> ctxB = new AtomicReference<>();
+
+    Mono<String> source = Mono.deferContextual(ctx -> {
+      ctxA.set(ctx);
+      return Mono.just("x");
+    });
+
+    source.subscribe();
+    source.subscribe();
+
+    assertNotSame(ctxA.get(), ctxB.get()); // different instances
+  }
+}

--- a/docs/adr/0006-associated-datasets-sync-semantics.md
+++ b/docs/adr/0006-associated-datasets-sync-semantics.md
@@ -1,0 +1,202 @@
+# 0006 — Associated dataset synchronisation semantics
+
+* Status: accepted
+* Deciders: project team (via architecture interview on #1470 / #1474)
+* Date: 2026-07-15
+
+Technical Story: [FEAT-DATSET-04 — Sync a connected open, published dataset](https://github.com/qbicsoftware/data-manager-app/issues/1470) · [FEAT-DATSET-08 — Sync a connected restricted, published dataset](https://github.com/qbicsoftware/data-manager-app/issues/1474) (FEAT-DATASET-CONNECTION, #1466)
+
+## Context and Problem Statement
+
+[ADR-0003](0003-connection-lifecycle-stewardship.md) fixed the sync *model* (user-initiated Y1,
+never-borrow-credentials C1, toast+email N1) but deliberately left the concrete sync mechanics open.
+Implementing DATA-R-05 requires deciding four things that the earlier ADRs did not pin down:
+
+1. How a "new version on the source platform" (story AC-3) is detected and followed — InvenioRDM
+   publishes each version as a *new record with a new DOI*; the stored `external_handle` points at the
+   record the user connected at connect time.
+2. Which project permission gates a sync — the story ACs require **write** access, while
+   [ADR-0003 §5](0003-connection-lifecycle-stewardship.md) listed sync as `READ`.
+3. How access-link integrity is preserved when a restricted dataset's version moves — the shareable
+   access link created at connect time is tied to a concrete record (version), not the concept.
+4. How notifications behave under multi-dataset syncs — per-record emails would flood members; the
+   ADR-0003 audience table limited metadata-update emails to `connectedBy`, which contradicts the story
+   AC "notifies users about the update".
+
+Additionally, the ADR-0003 audience table must be formally superseded for sync events by the decisions
+here.
+
+## Decision Drivers
+
+* The story ACs are authoritative and require **write** access to sync (a sync mutates the project's
+  linked snapshot) and notification of users on version updates.
+* InvenioRDM's concept (parent) recid always resolves to the latest published version — verified live:
+  `GET /api/records/{conceptRecid}` → `302` → `/api/records/{latestRecid}`; the HTTP client follows
+  `Redirect.NORMAL` on GET, so no client change is needed to follow the redirect.
+* Access links are created per record (`POST /api/records/{recordId}/access/links`), i.e. **tied to the
+  version**; collaborators must be able to reach the version shown in the snapshot, and stale links must
+  not linger.
+* Data integrity on our side: the local snapshot must never silently diverge from what the source
+  actually serves to the project (no partial "new version shown, old link" state).
+* Users must be able to see *why* a record could not be updated (insufficient rights, missing provider
+  configuration) — inline, per record.
+* Notification flooding must be avoided when several versions update in one trigger (Sync All).
+* Never-borrow-credentials ([ADR-0002](0002-invenio-rdm-api-client-credentials.md),
+  [ADR-0003](0003-connection-lifecycle-stewardship.md)) remains inviolable: a sync only ever uses the
+  invoking user's own token; public-metadata records need no token.
+* Credential status is only updated on explicit user verification (ADR-0002 §9): a failed sync must
+  never silently flip a credential to `INVALIDATED`.
+
+## Considered Options
+
+### Version following
+
+* [V1] Parent-recID resolution: keep the concrete record id as `external_handle`; sync resolves the
+  latest version via the concept recid (extra `GET` only when `is_latest == false`); persist
+  `parentHandle` on the metadata snapshot for stable future syncs
+* [V2] Store the concept recid as the handle at connect time so sync is a plain re-fetch
+* [V3] Same-record refresh only (no version following)
+
+### Sync permission
+
+* [P1] `WRITE` on the project (per story ACs — a sync is a write to the local snapshot)
+* [P2] `READ` on the project (per ADR-0003 §5 status quo)
+
+### Access-link integrity on restricted version bumps
+
+* [L1] Hard failure: if the new version's access link cannot be created, the snapshot update fails
+  atomically (create → commit → revoke old after commit; rollback new link on persistence failure)
+* [L2] Best-effort: metadata moves to the new version regardless; link refresh attempted, stale link
+  kept on 403
+
+### Notification aggregation
+
+* [N1] One summary domain event per sync trigger + one combined email per member (all collaborators
+  except the actor), sent only when ≥1 record changed; no emails on no-op or failure
+* [N2] Per-record events → per-record emails (flooding)
+* [N3] Time-window aggregation inside the notification directive (brittle timing/state)
+
+### Access determination
+
+* [A1] Per-record attempt is the source of truth; the HTTP call decides 401/403 per record; only a
+  local short-circuit for "metadata-restricted record with no configured credential"
+* [A2] Pre-flight per-instance token liveness check (`GET /api/users`) before per-record calls
+
+## Decision Outcome
+
+Chosen: **V1 + P1 + L1 + N1 + A1.**
+
+1. **Version following (V1):** sync resolves the latest published version via the InvenioRDM concept
+   recid. Adapter flow: `GET /records/{handle}`; if `versions.is_latest == true` return the record;
+   otherwise `GET /records/{parent.id}` (302 followed by the client) returns the latest record. The
+   snapshot, `external_handle`, and PID all move to the latest record; the concept recid is persisted as
+   `parentHandle` on `InvenioRdmResourceMetadata` (nullable, backward compatible — legacy rows resolve it
+   on first sync).
+2. **Sync permission (P1):** Sync and Sync All require `WRITE` on the parent project. This **amends**
+   ADR-0003 §5 (sync row: READ → WRITE). The story ACs are authoritative: a sync is a write operation on
+   the project's linked snapshot.
+3. **Access-link integrity (L1):** for restricted datasets, a version bump commits **only if** the new
+   shareable access link was created on the latest record. Order: create new link (must succeed) → update
+   snapshot → persist → revoke the old link afterwards (best-effort, failures logged). If persistence
+   fails after link creation, revoke the new link (rollback, mirroring the connect flow's
+   `revokeAccessLinkIfCreated`). This guarantees the project never shows a version its members cannot
+   reach via the snapshot's access link.
+4. **Notification aggregation (N1):** the application layer emits **one**
+   `AssociatedDatasetsSyncedEvent` per sync trigger, only when ≥1 record changed. A policy directive
+   sends **one** email per project collaborator (all roles, actor excluded, via JobRunr) listing all
+   updated records (title, PID, old→new version, access-status flips). No emails for no-op syncs and no
+   emails for failures (failures surface to the invoking user in the results sidecar). This **supersedes
+   the ADR-0003 audience table for sync events** ("sync succeeded (metadata updated) → only connectedBy"
+   becomes "all project members except the actor").
+5. **Access determination (A1):** per-record HTTP attempts are the source of truth for token validity on
+   a record (verified: per-record access is server-enforced; even anonymous search hides fully-restricted
+   records). The only free local short-circuit: a metadata-restricted snapshot
+   (`recordAccess != PUBLIC`) with no configured credential for the instance is reported as "provider
+   must be configured first" without an HTTP call. No per-instance liveness pre-flight in v1; 401/403
+   map to `CREDENTIAL_REQUIRED` / `CREDENTIAL_INSUFFICIENT` per-record outcomes. A failed sync never
+   mutates credential status (ADR-0002 §9).
+
+### Positive Consequences
+
+* The local snapshot always reflects the latest published version and is reachable by the project via a
+  fresh access link — no stale or unreachable "latest" state.
+* Version-following via the concept recid requires only a one-field parsing addition (`parent.id`) and
+  reuses the client's existing redirect handling; no migration of existing connections (nullable
+  `parentHandle`).
+* One combined email per trigger prevents floods while still notifying every member of version updates
+  (story AC-3).
+* Per-record outcomes keep the UI truthful: rows show exactly why a record could or could not be
+  updated.
+* The plan document
+  (`docs/plans/FEAT-DATSET-04-08-sync-connected-datasets.md`) pins the implementation surface.
+
+### Negative Consequences
+
+* Hard-fail link refresh means a restricted version bump is blocked until a user with link-creation
+  permission (record owner) syncs — a deliberate trade for integrity; the UI must explain it ("only the
+  record owner can refresh the access link").
+* Version-following costs one extra `GET` per sync only when the connected record is no longer the
+  latest (common after a version bump, rare otherwise).
+* The synced `external_handle` mutation requires care: the aggregate's handle is no longer immutable
+  after connect (it follows the version); the dup-PID guard (plan §Edge Cases) prevents duplicate
+  connections after a bump.
+* Amending ADR-0003 via this ADR introduces a supersession relationship that must be documented.
+
+## Pros and Cons of the Options
+
+### V1 — Parent-recID resolution
+
+* Good, because it keeps `external_handle` pointing at a concrete, version-anchored record — required
+  for version-tied access links.
+* Good, because the concept recid resolution is one redirect the client already follows.
+* Good, because V2 would break access-link creation (`POST /records/{conceptRecid}/access/links` would
+  hit the 302, and `Redirect.NORMAL` does not follow redirects on POST).
+* Bad, because it adds a small `parent.id` parsing surface and a nullable `parentHandle` field.
+
+### V2 — Concept recid as handle
+
+* Good, because sync becomes a plain re-fetch.
+* Bad, because it changes connect-time semantics for new connections only (dual semantics), requires a
+  migration story for existing rows, and **breaks access-link creation on the concept id** (POST
+  redirects are not followed).
+
+### V3 — Same-record refresh only
+
+* Good, because it is the simplest possible sync.
+* Bad, because it cannot satisfy story AC-3 (a new version is a new record; the stored handle would
+  return the superseded record with `is_latest=false`).
+
+### P1 — WRITE permission
+
+* Good, because it matches the story ACs and the semantics (sync writes the local snapshot).
+* Good, because it reuses the existing project ACL (`hasPermission WRITE`), same as connect/remove.
+* Bad, because it diverges from the earlier ADR-0003 note (handled via supersession).
+
+### L1 — Hard failure on link refresh
+
+* Good, because it guarantees local/remote consistency for collaborators.
+* Good, because it reuses the existing create/rollback link pattern.
+* Bad, because syncs of restricted version bumps can be blocked pending an owner — mitigated by explicit
+  per-row guidance.
+
+### N1 — Combined summary email
+
+* Good, because it satisfies "notifies users about the update" without flooding (Sync All).
+* Good, because aggregation happens where the batch outcome is known (deterministic, testable).
+* Bad, because a member receives one email even if they personally don't care — acceptable for version
+  updates of project data.
+
+### A1 — Per-record attempt as source of truth
+
+* Good, because per-record grants/ownership are unknowable locally (verified against the live API).
+* Good, because no additional API surface in v1.
+* Bad, because a sync with a dead token produces N per-record failures rather than one upfront warning —
+  accepted; each row still carries precise guidance.
+
+## Links
+
+* Refines [ADR-0002](0002-invenio-rdm-api-client-credentials.md) (credential handling, retry, D1 boundary)
+* Supersedes in part [ADR-0003](0003-connection-lifecycle-stewardship.md) (§5 sync permission row; sync
+  event audience mapping)
+* Depends on [ADR-0001](0001-associated-datasets-domain-model.md) (aggregate, soft delete, universal columns)
+* Implementation plan: [FEAT-DATSET-04-08-sync-connected-datasets](../plans/FEAT-DATSET-04-08-sync-connected-datasets.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ Where `NNNN` is a zero-padded, four-digit sequential number assigned in creation
 | [0003](0003-connection-lifecycle-stewardship.md) | Dataset connection lifecycle and data stewardship | approved | 2026-07-13 |
 | [0004](0004-fair-signposting-deferred.md) | FAIR Signposting integration deferred | approved | 2026-07-13 |
 | [0005](0005-developer-email-error-notifications.md) | Developer email notifications for log errors | approved | 2026-09-04 |
+| [0006](0006-associated-datasets-sync-semantics.md) | Associated dataset synchronisation semantics | approved | 2026-07-15 |
 
 *Update this table whenever a new ADR is added.*
 

--- a/docs/migrations/NEXT.md
+++ b/docs/migrations/NEXT.md
@@ -33,6 +33,36 @@ with apply / verify / rollback detail.
 *Document any new, removed, or renamed `application.properties` entries here.
 If there are none this release, delete this section.*
 
+### New routing property for the datasets view
+
+This release adds a new routing property used by the dataset notification
+emails (dataset connected / updated / removed):
+
+```properties
+# Route to the project's connected-datasets view (used by dataset notification emails)
+routing.projects.datasets.endpoint=/projects/%s/datasets
+```
+
+The emails previously linked to the project info page via
+`routing.projects.info.endpoint` (`/projects/%s/info`); they now link straight
+into the project's datasets view (`/projects/%s/datasets`, matching the
+`projects/:projectId?/datasets` Vaadin route).
+
+**This is a purely additive, non-breaking configuration change** — the
+`/projects/%s/info` property continues to be used for the project-access-grant
+email and is unchanged. The new property ships with the default value above
+and does not require an environment variable or secret.
+
+**Operator action:**
+
+1. Add the property above to your `application.properties` (or copy the
+   updated `application.properties.template`).
+2. Restart the application.
+3. Verify a dataset connect/sync/removal notification email links to
+   `…/projects/<project-id>/datasets` instead of `…/projects/<project-id>/info`.
+
+No schema migration is associated with this entry.
+
 ---
 
 ## Migration #<next>: <title>

--- a/docs/plans/FEAT-DATSET-04-08-sync-connected-datasets.md
+++ b/docs/plans/FEAT-DATSET-04-08-sync-connected-datasets.md
@@ -1,0 +1,265 @@
+# Implementation Plan: FEAT-DATSET-04 + FEAT-DATSET-08 — Sync Connected Datasets
+
+> **Stories:** [#1470](https://github.com/qbicsoftware/data-manager-app/issues/1470) (FEAT-DATSET-04, open) · [#1474](https://github.com/qbicsoftware/data-manager-app/issues/1474) (FEAT-DATSET-08, restricted)
+> **Parent Feature:** [#1466](https://github.com/qbicsoftware/data-manager-app/issues/1466) (FEAT-DATASET-CONNECTION)
+> **Requirement:** `DATA-R-05` (Connected-Dataset Synchronisation) — see Requirement ID Note below
+> **ADR references:** [ADR-0001](../adr/0001-associated-datasets-domain-model.md), [ADR-0002](../adr/0002-invenio-rdm-api-client-credentials.md), [ADR-0003](../adr/0003-connection-lifecycle-stewardship.md), [ADR-0006 (draft)](../adr/0006-associated-datasets-sync-semantics.md)
+
+---
+
+## Requirement ID Note
+
+The two story issues cite `DATA-R-02`, which was the **proposed** ID in the parent feature brief
+(#1466 §Proposed new requirements). The registry (`docs/requirements.md`) now contains the
+authoritative requirement for this work:
+
+> **DATA-R-05 — Connected-Dataset Synchronisation:** The system shall support synchronising connected
+> dataset metadata with the source InvenioRDM instance, so that locally stored connection records stay
+> consistent with upstream changes (e.g. new versions, embargoes lifted, titles corrected).
+
+Issues should be updated to reference `DATA-R-05` (governance cleanup). Additionally, the notification
+behavior shipped by this feature (per-trigger summary email to all project members) is not yet covered by
+a formal requirement — the parent feature proposed `COMM-R-01` (Project Change Notifications), which is
+**missing from the registry**. Adding it requires human approval (AGENTS.md §12, requirements changes) and
+is tracked as a governance item, not a blocker.
+
+---
+
+## Acceptance Criteria (merged — the stories are identical except for the access level)
+
+| # | DATSET-04 (open) | DATSET-08 (restricted) |
+|---|---|---|
+| AC-1 | User with **write** access, connected dataset, click **Sync** → sync with the host instance triggered for that dataset | Same, for a restricted dataset |
+| AC-2 | User with **write** access, several connected datasets, click **Sync All** → sync triggered for all connected datasets | Same, for all restricted datasets |
+| AC-3 | Synchronised dataset has a new version on source → after sync, local entry updated to the latest version and users notified | Same |
+| AC-4 | Sync successful → users informed about the number of updated datasets | Same |
+| AC-5 | Sync fails → users informed about the failure with guidance on next steps | Same |
+
+---
+
+## Locked Design Decisions (from the architecture interview)
+
+1. **Version-following (ADR-0006 §Decision 1):** sync does not just re-fetch the stored record. It
+   resolves the *latest published version* via the InvenioRDM concept (parent) recid:
+   - Adapter: `GET /api/records/{handle}` → if `versions.is_latest == true`, return as-is; otherwise
+     `GET /api/records/{parent.id}` — the client already follows the `302` (`Redirect.NORMAL`), so this
+     returns the latest record's metadata.
+   - On version bump the snapshot **and** `external_handle` **and** PID move to the latest record; the
+     concept recid (`parentHandle`) is persisted on `InvenioRdmResourceMetadata` for stable future syncs.
+   - Verified against the live Zenodo API: `GET /api/records/{conceptRecid}` → `302 → /api/records/{latestRecid}`.
+2. **Permission — WRITE on the project** for Sync and Sync All (per the story ACs). This *amends*
+   ADR-0003 §5, which listed sync as `READ`. Rationale (decider): in Data Manager, sync mutates the
+   project's linked snapshot — a write operation. Recorded in ADR-0006.
+3. **Never-borrow-credentials (ADR-0002/0003):** every sync uses the **invoking user's own** token.
+   Public-metadata records sync without a token (verified: anonymous `GET` on public-metadata/restricted-files
+   records returns 200). A metadata-restricted record without a configured credential is short-circuited
+   locally ("provider must be configured first"); with a token, the record GET is authoritative.
+4. **Access-link integrity on restricted version bumps (hard failure):** a version bump on a restricted
+   dataset commits **only if** a new shareable access link could be created on the latest record. Order:
+   create new link (must succeed) → update snapshot → persist → revoke the **old** link afterwards
+   (best-effort, logged). If persistence fails after link creation, the new link is revoked (rollback,
+   mirroring the existing `revokeAccessLinkIfCreated` connect pattern). No partial local state.
+5. **Notifications — one combined email per trigger:** a single summary domain event per sync trigger,
+   emitted **only when ≥1 record actually changed** (version bump or metadata/access change). A directive
+   sends **one** email per project member (all roles, excluding the actor via JobRunr) listing all updated
+   records (title, PID, old→new version, access-status flips). **No emails** for no-op ("already up to
+   date") syncs and **no emails on failure**. Supersedes the ADR-0003 audience table for sync events
+   (which limited metadata updates to `connectedBy`). Failures surface to the invoking user in the sidecar.
+6. **Per-record attempt is the source of truth for access:** no per-record pre-flight. The sidecar rows
+   flip live as the per-dataset `Flux` responses arrive (requestId-correlated, bounded parallelism 3 —
+   same as the connect flow). Token liveness / per-record grants are only determined by the HTTP call.
+7. **Result reporting via a dedicated sidecar** (`SyncResultsSidebar`, modeled on `ConnectDatasetSidebar`)
+   instead of toast text: live per-row status, summary header, inline guidance, "Done" action.
+
+---
+
+## Current State of the Codebase
+
+Already present and reusable:
+
+| Component | Location | Status |
+|---|---|---|
+| `AssociatedDataset` aggregate | `project-management/…/domain/model/associated_dataset/` | `updateMetadata()` + `lastSyncedAt` exist; emits no sync event yet |
+| `DatasetSource` port | `project-management/…/application/associated_dataset/` | `resolveMetadata`, `hasValidCredential`, `createAccessLink`, `revokeAccessLink` |
+| `InvenioRdmDatasetSource` | `project-management-infrastructure/…/external/invenio/` | Stateless adapter; token `char[]` zeroing in `finally` (ADR-0002 D1) |
+| `InvenioRdmClient` | same package | `RecordResponse` already parses `versions.is_latest`/`index`; `parent` block lacks `id`; HTTP client follows 302 (`Redirect.NORMAL`); bounded retry per ADR-0002 §7 |
+| `AssociatedDatasetService` | `project-management/…/application/associated_dataset/` | Connect/remove/list with `Result`, reactive `Flux` + `requestId` correlation, bounded parallelism 3 |
+| Error enums (`ConnectDatasetError`, `RemoveDatasetError`) | same package | Pattern to replicate for `SyncDatasetError` |
+| Policies + directives | `project-management/…/application/policy/{,directive}` | `AssociatedDatasetConnectedPolicy`, `InformProjectCollaboratorsAboutDatasetConnection` (JobRunr email) |
+| `ConnectedResourcesComponent` | `datamanager-app/…/views/projects/project/datasets/` | Cards with per-card actions (Remove); action bar with "Connect Datasets" — needs Sync + Sync All |
+| `ConnectDatasetSidebar` | same package | Sliding-panel pattern to model `SyncResultsSidebar` on |
+| Credential management UI | `datamanager-app/…/views/account/ExternalProvidersMain`, `VerificationSidebar` | FEAT-DATSET-14 shipped; sidecar guidance links here |
+| Message properties | `datamanager-app/src/main/resources/messages/toast-notifications.properties` | `dataset.connected.*` entries; `dataset.sync.*` missing |
+| `Messages` templates | `project-management/…/application/Messages.java` | `datasetConnectedToProject()` exists; combined-sync template missing |
+| Spock test conventions | `project-management/src/test/groovy/…/associated_dataset/` | `AssociatedDatasetServiceConnectSpec`, `AssociatedDatasetServiceRemoveSpec`, `AssociatedDatasetRemoveSpec` |
+
+---
+
+## Task Breakdown
+
+### Task 1 — Domain: version metadata plumbing
+
+**Module:** `project-management` (+ `project-management-infrastructure` for the client model)
+
+- `InvenioRdmClient.Parent`: add `@JsonProperty("id") String id` (concept recid) — single field; raw JSON already carries it.
+- `InvenioRdmResourceMetadata`: add nullable `String parentHandle` (concept recid). Backward compatible:
+  old persisted rows deserialize to `null`; `@JsonIgnoreProperties(ignoreUnknown = true)` protects future
+  reads. Keep the backward-compatible convenience constructor delegating with `parentHandle = null`.
+- `AssociatedDataset`: add change-diff support for sync — a method that reports what changed when applying
+  new metadata (version moved? access status changed? unchanged?) so the service can produce per-record
+  outcomes and the summary event payload. `updateMetadata(...)` is extended/kept for the commit step.
+
+### Task 2 — Domain: sync summary event
+
+**Module:** `project-management`
+
+- New event `AssociatedDatasetsSyncedEvent(projectId, actorUserId, List<UpdatedRecord>)` under
+  `…/domain/model/associated_dataset/event/` where
+  `UpdatedRecord(datasetId, title, pid, previousVersion, newVersion, accessStatusChanged)`.
+- One event per **sync trigger**, emitted by the application service after the batch completes — not by
+  the aggregate per dataset (aggregation lives where the batch outcome is known).
+
+### Task 3 — Port: latest-version resolution
+
+**Module:** `project-management` (port) + `project-management-infrastructure` (adapter)
+
+- `DatasetSource.resolveLatest(String externalHandle, InstanceConfig config, String actingUserId)`
+  → `Optional<ResourceMetadata>` / `throws DatasetResolveException`. Source-agnostic contract:
+  "current/latest state of the record identified by this handle".
+- `InvenioRdmDatasetSource` implementation:
+  - `GET /records/{handle}` (token rules per ADR-0002: public-metadata → no token required; restricted →
+    actor's token, decrypted/zeroed in `finally`).
+  - If `versions.is_latest == true` → return mapped metadata.
+  - Else → read `parent.id` → `GET /records/{parent.id}` (client follows the 302) → return mapped metadata.
+  - 404 → `Optional.empty()`; 401/403 → permanent `InvenioRdmPermanentException` (surfaced as
+    CREDENTIAL_REQUIRED / CREDENTIAL_INSUFFICIENT downstream); 5xx/429 → existing bounded retry.
+  - Preserve token handling: first call with token, second (parent) call reuses the same decrypted
+    `char[]` if a token was configured; zeroed once in the outer `finally`.
+
+### Task 4 — Application: sync orchestration
+
+**Module:** `project-management`
+
+- `SyncDatasetError` enum: `DATASET_NOT_FOUND`, `RECORD_NOT_FOUND`, `CREDENTIAL_REQUIRED`,
+  `CREDENTIAL_INSUFFICIENT`, `ACCESS_LINK_REFRESH_FAILED`, `SYNC_FAILED`.
+- Request/response records mirroring the connect flow: `SyncDatasetRequest(requestId, datasetId, userId)`,
+  `SyncDatasetResponse(requestId, SyncOutcome)` where `SyncOutcome` is a per-dataset status carrying the
+  outcome category (UPDATED, UP_TO_DATE, WARN_ACCESS, FAILED) + new version + user-facing message.
+- `syncDataset(datasetId, userId)` → `Result<SyncOutcome, SyncDatasetError>` (blocking core):
+  1. Load aggregate (DATASET_NOT_FOUND if absent/REMOVED).
+  2. WRITE-permission enforced via `@PreAuthorize` on the project (same ACL pattern as connect/remove).
+  3. Short-circuit: metadata-restricted snapshot (`recordAccess != PUBLIC`) + no valid credential for the
+     dataset's instance (`hasValidCredential`) → `CREDENTIAL_REQUIRED`.
+  4. `resolveLatest(handle, config, userId)` → map errors (404 → RECORD_NOT_FOUND; 401/403 relative to
+     credential presence → CREDENTIAL_REQUIRED / CREDENTIAL_INSUFFICIENT; transient → SYNC_FAILED).
+  5. Diff against stored snapshot (via Task 1 change-diff). Unchanged → UP_TO_DATE (no event row change).
+  6. Version changed **and** restricted → `createAccessLink` on the newest record (hard gate;
+     `ACCESS_LINK_REFRESH_FAILED` on exception; do **not** reach the snapshot write).
+  7. Commit: `updateMetadata(latest)` (+ handle + parentHandle) → save. On save failure → roll back the
+     newly created link (`revokeAccessLinkIfCreated` pattern), return SYNC_FAILED.
+  8. After successful commit: revoke the **old** link best-effort (log-only on failure).
+  9. Guard: if another active connection in the project already carries the target PID (new version's
+     DOI), do **not** duplicate — skip the update and surface a distinct outcome (edge case, see below).
+- Reactive wrappers: `syncDatasetAsync(...)` and `syncAllDatasets(projectId, userId)` — `Flux`, bounded
+  parallelism 3, per-request `requestId`, security-context propagation via
+  `ReactiveSecurityContextUtils` (copy of the connect flow).
+- After a trigger completes: if ≥1 UPDATED → collect and dispatch **one** `AssociatedDatasetsSyncedEvent`
+  (collect-during/forward-after pattern; dispatch failure logged, does not fail the sync).
+- `ConnectedDatasetView`: add `Instant lastSyncedAt` (populate from `AssociatedDataset.lastSyncedAt()`).
+
+### Task 5 — Infrastructure: access-link refresh orchestration
+
+**Module:** `project-management-infrastructure`
+
+- Wire Task 4 step 6–8 through the existing port methods (`createAccessLink`,
+  `revokeAccessLink`). No new port surface needed. Ensure the newest record's `instanceId` + link info
+  are carried into the new snapshot (`InvenioRdmResourceMetadata` fields already exist).
+
+### Task 6 — Notifications: combined summary email
+
+**Module:** `project-management`
+
+- `AssociatedDatasetsSyncedPolicy` (subscribes `AssociatedDatasetsSyncedEvent`).
+- `InformProjectCollaboratorsAboutDatasetSync` directive: resolve collaborators excluding the actor
+  (`projectAccessService.listCollaborators` — all roles), enqueue **one** JobRunr job per member that
+  renders a single email listing all `UpdatedRecord`s (title, PID, old→new version, access flips) + link
+  to the project (reuse `appContextProvider.urlToProject`).
+- `Messages`: add `datasetsSyncedToProject(addressee, projectTitle, List<UpdatedRecord>, projectUrl)`
+  template (mirror `datasetConnectedToProject`).
+
+### Task 7 — UI: buttons and write-gating
+
+**Module:** `datamanager-app`
+
+- `ConnectedResourcesComponent`: per-card **Sync** button (next to Remove; enabled for WRITE users only —
+  `userPermissions.editProject` already drives `setWriteAllowed`), **Sync All** button in the action bar
+  (WRITE-gated, hidden/disabled otherwise).
+
+### Task 8 — UI: `SyncResultsSidebar`
+
+**Module:** `datamanager-app`
+
+- New sliding-panel component modeled on `ConnectDatasetSidebar`:
+  - Opens as soon as a sync starts (single Sync or Sync All).
+  - One row per dataset; status flips live as `Flux` responses arrive (pending → UPDATED / UP_TO_DATE /
+    WARN_ACCESS / FAILED) with inline guidance text:
+    - CREDENTIAL_REQUIRED: "Provider must be configured first — add a *[instance]* token in External Providers."
+    - CREDENTIAL_INSUFFICIENT: "Cannot be synced — your token does not grant access to this restricted record."
+    - ACCESS_LINK_REFRESH_FAILED: "Cannot be synced — only the record owner can refresh the access link."
+    - RECORD_NOT_FOUND: "Record no longer exists on the source. Connection kept."
+    - SYNC_FAILED: generic transient failure (details logged).
+  - Updated rows show the new version; access-flip rows show the access change.
+  - Summary header: "X updated · Y up to date · Z not synced".
+  - Footer: "Done" (closes); a hint linking to account → External Providers for credential guidance.
+  - Fires `DatasetsSyncedEvent` on completion so `ConnectedDatasetsMain` refreshes the card list.
+- Toast properties `dataset.sync.*` in `toast-notifications.properties` (minimal — the sidecar carries
+  the detail; a toast only announces the sidecar outcome, e.g. failure to start).
+
+### Task 9 — Parameterization / properties
+
+- No new `application.properties` keys anticipated (instances already configured via
+  `qbic.external-service.invenio-rdm.instances`). Verify none needed at implementation time.
+
+### Task 10 — Tests (Spock, following existing specs)
+
+**Modules:** `project-management`, `project-management-infrastructure`, `datamanager-app`
+
+- `InvenioRdmDatasetSourceResolveLatestSpec.groovy` — 302/follow, is_latest true/false, 404 empty,
+  401/403 mapping, token zeroing, no-token public-metadata success.
+- `AssociatedDatasetServiceSyncSpec.groovy` — happy path, version bump restricted (link create/commit/
+  revoke-old), link-create failure (hard fail, nothing written), persist-failure rollback of new link,
+  no-token short-circuit, dup-PID guard, UP_TO_DATE no-op, error mapping.
+- `AssociatedDatasetsSyncedEventSpec` / directive spec — event emitted only when ≥1 changed; one email
+  per collaborator excluding actor; combined listing.
+- `AssociatedDatasetSyncSpec.groovy` (aggregate) — change-diff semantics.
+- UI: component test for SyncResultsSidebar row state transitions (per existing Vaadin test conventions).
+
+---
+
+## Edge Cases
+
+| Case | Handling |
+|---|---|
+| Record deleted on source (404) | Per-row failure "record no longer exists"; **connection kept** — user decides manually (no auto-removal) |
+| Version bump collides with a separately-connected version (dup PID) | Guard before commit: if another active connection carries the target PID, skip + distinct outcome (do not create duplicate connections) |
+| Concurrent syncs by two users (same dataset) | Last-write-wins; no `@Version` optimistic locking in v1 — acceptable at project scale (<100 datasets). Revisit if needed |
+| Legacy rows without `instanceId` / `parentHandle` / `accessLinkId` | First sync resolves `parent.id` from the stored record and persists `parentHandle`; link revocation skips null link ids (existing behavior) |
+| Embargo lifted / access-status flip | Counts as UPDATED; email notes the access change (AC-3 "notifies users about the update") |
+| Public-metadata record with restricted files | Syncs token-less (verified 200 anonymously); files remain gated by the access link on the source — out of scope for metadata sync |
+| Rate limiting (429 / 5xx) | Bounded retry per ADR-0002 §7; row only turns FAILED after retries exhaust |
+| UI session ends mid-sync | Reactive subscription cancelled via existing `UiHandle` detach pattern; sync itself runs on the server and the email may still be sent |
+| Actor == connectedBy | Actor excluded from the email recipient list (existing convention); they see the sidecar |
+
+---
+
+## Governance Items (require human decision/approval)
+
+1. **ADR-0006 (draft):** approve/amend — records version-following, WRITE permission amendment to
+   ADR-0003 §5, access-link hard-fail integrity, combined per-trigger summary email (supersedes the
+   ADR-0003 sync audience mapping), per-record attempt semantics.
+2. **Requirements registry:** stories cite `DATA-R-02` (stale proposal ID) → update issues to `DATA-R-05`.
+   Decide whether to add `COMM-R-01` (Project Change Notifications) for the shipped email behavior
+   (requires human approval + dedicated PR per AGENTS.md §12 / Requirement Edits).
+3. **ADR index (`docs/adr/README.md`):** add the approved ADR-0006 row (only after approval — this plan
+   references it as draft).
+4. **Story issue updates:** add implementation notes / link tasks to #1470 and #1474 by their stable IDs.

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/external/invenio/InvenioRdmClient.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/external/invenio/InvenioRdmClient.java
@@ -469,14 +469,24 @@ public interface InvenioRdmClient {
   ) {}
 
   /**
-   * Parent block (v12). Community membership is at
-   * {@code parent.communities.entries}, where each entry carries the
-   * community {@code slug} and {@code metadata.title}.
+   * Parent block (v12). {@code id} is the concept (parent) recid —
+   * resolving it yields the latest published version of the record;
+   * community membership is at {@code parent.communities.entries}.
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   record Parent(
+      @JsonProperty("id") String id,
       @JsonProperty("communities") ParentCommunities communities
-  ) {}
+  ) {
+
+    /**
+     * Backward-compatible constructor without the concept recid (legacy
+     * tests / call sites); delegates with {@code id = null}.
+     */
+    Parent(ParentCommunities communities) {
+      this(null, communities);
+    }
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   record ParentCommunities(

--- a/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/external/invenio/InvenioRdmDatasetSource.java
+++ b/project-management-infrastructure/src/main/java/life/qbic/projectmanagement/infrastructure/external/invenio/InvenioRdmDatasetSource.java
@@ -14,10 +14,12 @@ import life.qbic.projectmanagement.application.associated_dataset.AccessLinkCrea
 import life.qbic.projectmanagement.application.associated_dataset.AccessLinkRevocationException;
 import life.qbic.projectmanagement.application.associated_dataset.CreatedAccessLink;
 import life.qbic.projectmanagement.application.associated_dataset.CredentialEncryptor;
+import life.qbic.projectmanagement.application.associated_dataset.DatasetAccessDeniedException;
 import life.qbic.projectmanagement.application.associated_dataset.DatasetResolveException;
 import life.qbic.projectmanagement.application.associated_dataset.DatasetSearchException;
 import life.qbic.projectmanagement.application.associated_dataset.DatasetSource;
 import life.qbic.projectmanagement.application.associated_dataset.InstanceConfig;
+import life.qbic.projectmanagement.application.associated_dataset.ResolvedRecord;
 import life.qbic.projectmanagement.application.associated_dataset.SearchHit;
 import life.qbic.projectmanagement.application.associated_dataset.SearchQuery;
 import life.qbic.projectmanagement.application.associated_dataset.SearchResult;
@@ -121,6 +123,72 @@ public class InvenioRdmDatasetSource implements DatasetSource {
         Arrays.fill(token, '\0');
       }
     }
+  }
+
+  @Override
+  public Optional<ResolvedRecord> resolveLatest(
+      String externalHandleValue, InstanceConfig config,
+      String actingUserId) throws DatasetResolveException {
+    Objects.requireNonNull(externalHandleValue,
+        "externalHandleValue must not be null");
+    Objects.requireNonNull(config, "config must not be null");
+
+    char[] token = resolveTokenForUser(actingUserId, config.id());
+    try {
+      var record = client.getRecord(config.baseUrl(), externalHandleValue, token);
+      // Version-following (ADR-0006 V1): if the connected record is no
+      // longer the latest published version, resolve the concept (parent)
+      // recid — GET /records/{parentId} redirects (302) to the latest
+      // record, which the HTTP client follows transparently.
+      if (!isLatest(record)) {
+        String parentId = parentRecid(record);
+        if (parentId != null && !parentId.isBlank()) {
+          record = client.getRecord(config.baseUrl(), parentId, token);
+        }
+      }
+      InvenioRdmResourceMetadata metadata = mapRecordToResourceMetadata(
+          record, config.displayName());
+      return Optional.of(new ResolvedRecord(metadata, record.id()));
+    } catch (InvenioRdmClient.InvenioRdmPermanentException pe) {
+      if (pe.getStatusCode() == 404) {
+        return Optional.empty();
+      }
+      if (pe.getStatusCode() == 401 || pe.getStatusCode() == 403) {
+        // Access/credential problem — application layer maps this to
+        // CREDENTIAL_REQUIRED / CREDENTIAL_INSUFFICIENT (ADR-0006 A1).
+        log.error("Access denied resolving latest version of record {} on {}"
+            .formatted(externalHandleValue, config.displayName()));
+        throw new DatasetAccessDeniedException(
+            "Access denied to record " + externalHandleValue, pe);
+      }
+      log.error("Failed to resolve latest version of record {} on {}"
+          .formatted(externalHandleValue, config.displayName()));
+      throw new DatasetResolveException("Failed to resolve latest record", pe);
+    } catch (InvenioRdmClient.InvenioRdmException e) {
+      log.error("Failed to resolve latest version of record {} on {}"
+          .formatted(externalHandleValue, config.displayName()), e);
+      throw new DatasetResolveException("Failed to resolve latest record", e);
+    } finally {
+      if (token != null) {
+        Arrays.fill(token, '\0');
+      }
+    }
+  }
+
+  /**
+   * Whether the given record is the latest published version
+   * ({@code versions.is_latest}, v12). Missing version info is treated
+   * as "assume latest" — there is nothing to follow in that case.
+   */
+  private static boolean isLatest(InvenioRdmClient.RecordResponse record) {
+    return record.versions() == null || record.versions().isLatest();
+  }
+
+  /**
+   * The concept (parent) recid of a record, or null when absent.
+   */
+  private static String parentRecid(InvenioRdmClient.RecordResponse record) {
+    return record.parent() != null ? record.parent().id() : null;
   }
 
   @Override
@@ -283,6 +351,7 @@ public class InvenioRdmDatasetSource implements DatasetSource {
     String version = versionString(rec.versions());
     String accessLink = selfHtmlLink(rec.links());
     String community = community(rec.parent());
+    String parentHandle = rec.parent() != null ? rec.parent().id() : null;
 
     // v12 access block lives at the response top level.
     InvenioRdmAccessStatus recordAccess = recordAccessStatus(rec.access());
@@ -293,7 +362,8 @@ public class InvenioRdmDatasetSource implements DatasetSource {
         resourceProvider, creators, resourceType,
         community,
         publicationDate, description,
-        recordAccess, fileAccess
+        recordAccess, fileAccess,
+        null, null, parentHandle
     );
   }
 

--- a/project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/external/invenio/InvenioRdmDatasetSourceResolveLatestSpec.groovy
+++ b/project-management-infrastructure/src/test/groovy/life/qbic/projectmanagement/infrastructure/external/invenio/InvenioRdmDatasetSourceResolveLatestSpec.groovy
@@ -1,0 +1,160 @@
+package life.qbic.projectmanagement.infrastructure.external.invenio
+
+import life.qbic.projectmanagement.application.associated_dataset.CredentialEncryptor
+import life.qbic.projectmanagement.application.associated_dataset.DatasetAccessDeniedException
+import life.qbic.projectmanagement.application.associated_dataset.DatasetResolveException
+import life.qbic.projectmanagement.application.associated_dataset.InstanceConfig
+import life.qbic.projectmanagement.application.associated_dataset.ResolvedRecord
+import life.qbic.projectmanagement.domain.model.associated_dataset.AccessLevel
+import life.qbic.projectmanagement.domain.model.associated_dataset.InvenioRdmAccessStatus
+import life.qbic.projectmanagement.domain.model.associated_dataset.InvenioRdmResourceMetadata
+import life.qbic.projectmanagement.domain.model.associated_dataset.repository.UserExternalCredentialRepository
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link InvenioRdmDatasetSource#resolveLatest} — the
+ * version-following resolution used by dataset synchronisation
+ * (DATSET-04/08, ADR-0006 V1).
+ *
+ * <p>Hand-rolled Groovy interface coercions are used instead of Spock
+ * {@code Mock()} so the spec runs without the Mockito mock maker.</p>
+ *
+ * @since 1.13.0
+ */
+class InvenioRdmDatasetSourceResolveLatestSpec extends Specification {
+
+  private static final InstanceConfig CONFIG =
+      new InstanceConfig("zenodo", "Zenodo", "https://zenodo.org")
+
+  private static InvenioRdmClient.RecordResponse record(
+      String id, boolean isLatest, String parentId, int index) {
+    new InvenioRdmClient.RecordResponse(
+        id,
+        new InvenioRdmClient.HitLinks("https://zenodo.org/records/" + id),
+        new InvenioRdmClient.RecordMetadata("Title " + id, "2025-01-01", "desc", [], null),
+        "2025-01-01T10:00:00Z", "2025-01-01T10:00:00Z", true,
+        new InvenioRdmClient.RecordAccess("public", "public", "open"),
+        new InvenioRdmClient.Pids(new InvenioRdmClient.PidEntry("10.5281/zenodo." + id)),
+        new InvenioRdmClient.RecordVersions(isLatest, index),
+        parentId == null ? null : new InvenioRdmClient.Parent(parentId, null))
+  }
+
+  private static InvenioRdmDatasetSource createSource(InvenioRdmClient client) {
+    def credentialRepo = [
+        findByUserIdAndSourceTypeAndInstanceId: { u, st, iid -> Optional.empty() }
+    ] as UserExternalCredentialRepository
+    def encryptor = [decrypt: { token -> new char[0] }] as CredentialEncryptor
+    new InvenioRdmDatasetSource(client, credentialRepo, encryptor)
+  }
+
+  def "returns the record as-is when it is the latest version"() {
+    given:
+    def source = createSource([
+        getRecord: { url, id, token -> record("111", true, "parent-1", 1) }
+    ] as InvenioRdmClient)
+
+    when:
+    def resolved = source.resolveLatest("111", CONFIG, "user-1")
+
+    then:
+    resolved.isPresent()
+    def rr = resolved.get()
+    rr.externalHandleValue() == "111"
+    rr.metadata().title() == "Title 111"
+    rr.metadata().pid() == "10.5281/zenodo.111"
+    rr.metadata().version() == "v1"
+    rr.metadata() instanceof life.qbic.projectmanagement.domain.model.associated_dataset.InvenioRdmResourceMetadata
+  }
+
+  def "follows the parent recid when the stored record is superseded"() {
+    given:
+    def calls = []
+    def source = createSource([
+        getRecord: { url, id, token ->
+          calls.add(id)
+          id == "111"
+              ? record("111", false, "parent-1", 1)
+              : record("222", true, "parent-1", 2)
+        }
+    ] as InvenioRdmClient)
+
+    when:
+    def resolved = source.resolveLatest("111", CONFIG, "user-1")
+
+    then:
+    calls == ["111", "parent-1"]
+    def rr = resolved.get()
+    rr.externalHandleValue() == "222"
+    rr.metadata().pid() == "10.5281/zenodo.222"
+    rr.metadata().version() == "v2"
+    rr.metadata().title() == "Title 222"
+    (rr.metadata() as InvenioRdmResourceMetadata).parentHandle() == "parent-1"
+  }
+
+  def "returns empty when the record does not exist (404)"() {
+    given:
+    def source = createSource([
+        getRecord: { url, id, token ->
+          throw new InvenioRdmClient.InvenioRdmPermanentException("gone", 404, url)
+        }
+    ] as InvenioRdmClient)
+
+    expect:
+    source.resolveLatest("111", CONFIG, "user-1").isEmpty()
+  }
+
+  def "throws DatasetAccessDeniedException on 403"() {
+    given:
+    def source = createSource([
+        getRecord: { url, id, token ->
+          throw new InvenioRdmClient.InvenioRdmPermanentException("forbidden", 403, url)
+        }
+    ] as InvenioRdmClient)
+
+    when:
+    source.resolveLatest("111", CONFIG, "user-1")
+
+    then:
+    thrown(DatasetAccessDeniedException)
+  }
+
+  def "throws DatasetResolveException for transient failures after retries"() {
+    given:
+    def source = createSource([
+        getRecord: { url, id, token ->
+          throw new InvenioRdmClient.InvenioRdmTransientException(
+              "boom", 503, 3, new RuntimeException("x"), url)
+        }
+    ] as InvenioRdmClient)
+
+    when:
+    source.resolveLatest("111", CONFIG, "user-1")
+
+    then:
+    thrown(DatasetResolveException)
+  }
+
+  def "metadata access level is derived from the record access block"() {
+    given:
+    def source = createSource([
+        getRecord: { url, id, token ->
+          new InvenioRdmClient.RecordResponse(
+              "111",
+              new InvenioRdmClient.HitLinks("https://zenodo.org/records/111"),
+              new InvenioRdmClient.RecordMetadata("T", "2025-01-01", null, [], null),
+              "2025-01-01T10:00:00Z", "2025-01-01T10:00:00Z", true,
+              new InvenioRdmClient.RecordAccess("restricted", "restricted", "restricted"),
+              new InvenioRdmClient.Pids(new InvenioRdmClient.PidEntry("10.5281/zenodo.111")),
+              new InvenioRdmClient.RecordVersions(true, 1),
+              new InvenioRdmClient.Parent("parent-1", null))
+        }
+    ] as InvenioRdmClient)
+
+    when:
+    def resolved = source.resolveLatest("111", CONFIG, "user-1")
+
+    then:
+    (resolved.get().metadata() as InvenioRdmResourceMetadata)
+        .deriveAccessLevel() == AccessLevel.RESTRICTED
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/AppContextProvider.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/AppContextProvider.java
@@ -18,6 +18,16 @@ public interface AppContextProvider {
    */
 
   String urlToProject(String projectId);
+
+  /**
+   * Returns a resolvable URL to the target project's datasets page.
+   *
+   * @param projectId the project id
+   * @return a fully resolvable URL
+   * @since 1.13.0
+   */
+  String urlToDatasets(String projectId);
+
   /**
    * Returns a resolvable URL to the target project's sample page resource in the application.
    *

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/Messages.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/Messages.java
@@ -1,5 +1,8 @@
 package life.qbic.projectmanagement.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * <b>Messages</b>
  *
@@ -80,7 +83,7 @@ public class Messages {
    * @param projectTitle the title of the project the dataset was connected to
    * @param datasetTitle the human-readable title of the connected dataset
    * @param datasetPid   the persistent identifier (PID / DOI) of the dataset
-   * @param projectUri   a resolvable URL to the project in Data Manager
+   * @param projectUri   a resolvable URL to the project's datasets page in Data Manager
    * @return the filled out template message
    * @since 1.12.0
    */
@@ -108,7 +111,7 @@ public class Messages {
    * @param projectTitle the title of the project the dataset was removed from
    * @param datasetTitle the human-readable title of the dataset connection
    * @param datasetPid   the persistent identifier (PID / DOI) of the dataset
-   * @param projectUri   a resolvable URL to the project in Data Manager
+   * @param projectUri   a resolvable URL to the project's datasets page in Data Manager
    * @return the filled out template message
    * @since 1.12.0
    */
@@ -126,5 +129,71 @@ public class Messages {
 
         %s
         """, fullNameUser, projectTitle, datasetTitle, datasetPid, projectUri);
+  }
+
+  /**
+   * A pre-formatted message that informs a project collaborator that one
+   * or more connected datasets in a project were updated by a sync
+   * (DATSET-04/08, ADR-0006 N1).
+   *
+   * <p>One email is sent per sync trigger with <em>all</em> updated
+   * records listed — never one email per record — to avoid flooding
+   * members when several versions are updated in the same trigger.</p>
+   *
+   * @param fullNameUser    the full name of the recipient
+   * @param projectTitle    the title of the project the datasets were updated in
+   * @param updatedDatasets pre-rendered lines, one per updated record
+   *                        (see {@link #updatedRecordLine})
+   * @param projectUri      a resolvable URL to the project's datasets page in Data Manager
+   * @return the filled out template message
+   * @since 1.13.0
+   */
+  public static String datasetsSyncedToProject(String fullNameUser, String projectTitle,
+      List<String> updatedDatasets, String projectUri) {
+    String lines = updatedDatasets.stream()
+        .map(line -> "  - " + line)
+        .collect(Collectors.joining("\n"));
+    return String.format("""
+        Dear %s,
+
+        the following connected dataset(s) in the project '%s' have been updated:
+
+        %s
+
+        Please open the project to see the updated datasets:
+
+        %s
+        """, fullNameUser, projectTitle, lines, projectUri);
+  }
+
+  /**
+   * Renders one record line for the combined dataset-sync email.
+   *
+   * @param title              the record title
+   * @param pid                the persistent identifier (DOI)
+   * @param previousVersion    version before the sync, or null
+   * @param newVersion         version after the sync, or null
+   * @param accessStatusChanged whether the access level changed
+   *                            (e.g. embargo lifted or added)
+   * @return a single human-readable line, e.g.
+   *         {@code "My dataset (10.5281/zenodo.123): v1 -> v2 (access status changed)"}
+   * @since 1.13.0
+   */
+  public static String updatedRecordLine(
+      String title, String pid, String previousVersion, String newVersion,
+      boolean accessStatusChanged) {
+    String versionPart;
+    if (previousVersion != null && newVersion != null && !previousVersion.equals(newVersion)) {
+      // ASCII arrow (not Unicode →) — this string is serialized into
+      // JobRunr's jobAsJson column which may not support multi-byte chars.
+      versionPart = previousVersion + " -> " + newVersion;
+    } else if (newVersion != null) {
+      versionPart = newVersion;
+    } else {
+      // ASCII dash (not Unicode —) for the same JobRunr charset reason.
+      versionPart = "-";
+    }
+    String accessNote = accessStatusChanged ? " (access status changed)" : "";
+    return title + " (" + pid + "): " + versionPart + accessNote;
   }
 }

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/AssociatedDatasetService.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/AssociatedDatasetService.java
@@ -2,7 +2,6 @@ package life.qbic.projectmanagement.application.associated_dataset;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -10,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import life.qbic.application.commons.Result;
 import life.qbic.domain.concepts.DomainEvent;
@@ -31,6 +31,7 @@ import life.qbic.projectmanagement.domain.model.associated_dataset.ResourceMetad
 import life.qbic.projectmanagement.domain.model.associated_dataset.SourceType;
 import life.qbic.projectmanagement.domain.model.associated_dataset.event.AssociatedDatasetConnectedEvent;
 import life.qbic.projectmanagement.domain.model.associated_dataset.event.AssociatedDatasetRemovedEvent;
+import life.qbic.projectmanagement.domain.model.associated_dataset.event.AssociatedDatasetsSyncedEvent;
 import life.qbic.projectmanagement.domain.model.associated_dataset.repository.AssociatedDatasetRepository;
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
@@ -291,32 +292,43 @@ public class AssociatedDatasetService {
     //     subsequent step fails, the link is rolled back (revoked) instead
     //     of leaking an orphaned, unused shareable link on the source.
     CreatedAccessLink createdAccessLink = null;
-    if (finalMetadata instanceof InvenioRdmResourceMetadata inv
-        && inv.deriveAccessLevel() == AccessLevel.RESTRICTED) {
-      if (!datasetSource.hasValidCredential(connectedByUserId, config)) {
-        log.warn("Cannot connect restricted dataset %s — no valid credential "
-            + "for user %s on instance %s"
-            .formatted(externalHandleValue, connectedByUserId, instanceId));
-        return Result.fromError(ConnectDatasetError.CREDENTIAL_REQUIRED);
-      }
+    if (finalMetadata instanceof InvenioRdmResourceMetadata inv) {
+      if (inv.deriveAccessLevel() == AccessLevel.RESTRICTED) {
+        if (!datasetSource.hasValidCredential(connectedByUserId, config)) {
+          log.warn("Cannot connect restricted dataset %s — no valid credential "
+              + "for user %s on instance %s"
+              .formatted(externalHandleValue, connectedByUserId, instanceId));
+          return Result.fromError(ConnectDatasetError.CREDENTIAL_REQUIRED);
+        }
 
-      // Create sharable access link for project collaborators
-      try {
-        CreatedAccessLink link = datasetSource.createAccessLink(
-            externalHandleValue, config, connectedByUserId);
-        createdAccessLink = link;
-        // Update metadata with the instance, access link, and link id
-        // (the id is needed to revoke the link later).
+        // Create sharable access link for project collaborators
+        try {
+          CreatedAccessLink link = datasetSource.createAccessLink(
+              externalHandleValue, config, connectedByUserId);
+          createdAccessLink = link;
+          // Update metadata with the instance, access link, and link id
+          // (the id is needed to revoke the link later).
+          finalMetadata = new InvenioRdmResourceMetadata(
+              inv.title(), inv.pid(), inv.version(), link.url(),
+              inv.resourceProvider(), inv.creators(), inv.resourceType(),
+              inv.community(), inv.publicationDate(), inv.description(),
+              inv.recordAccess(), inv.fileAccess(),
+              instanceId, link.linkId(), inv.parentHandle());
+        } catch (AccessLinkCreationException e) {
+          log.error("Failed to create access link for restricted dataset %s on instance %s"
+              .formatted(externalHandleValue, instanceId), e);
+          return Result.fromError(ConnectDatasetError.ACCESS_LINK_CREATION_FAILED);
+        }
+      } else {
+        // Persist the instance id on public connections as well so that a
+        // later sync can resolve the source instance without heuristics
+        // (ADR-0006). The access link fields stay empty for public records.
         finalMetadata = new InvenioRdmResourceMetadata(
-            inv.title(), inv.pid(), inv.version(), link.url(),
+            inv.title(), inv.pid(), inv.version(), inv.accessLink(),
             inv.resourceProvider(), inv.creators(), inv.resourceType(),
             inv.community(), inv.publicationDate(), inv.description(),
             inv.recordAccess(), inv.fileAccess(),
-            instanceId, link.linkId());
-      } catch (AccessLinkCreationException e) {
-        log.error("Failed to create access link for restricted dataset %s on instance %s"
-            .formatted(externalHandleValue, instanceId), e);
-        return Result.fromError(ConnectDatasetError.ACCESS_LINK_CREATION_FAILED);
+            instanceId, null, inv.parentHandle());
       }
     }
 
@@ -366,10 +378,11 @@ public class AssociatedDatasetService {
       domainEventsCache.forEach(
           domainEvent -> DomainEventDispatcher.instance().dispatch(domainEvent));
     } catch (Exception e) {
-      log.warn("Event dispatch failed while forwarding domain event "
-          + "after dataset connection on project %s; the connection ".formatted(projectId)
+      log.warn(("Event dispatch failed while forwarding domain event "
+          + "after dataset connection on project %s; the connection "
           + "itself succeeded, but collaborators may not have been "
-          + "notified: %s".formatted(e.getMessage()));
+          + "notified: %s")
+          .formatted(projectId, e.getMessage()));
     }
 
     log.info("Dataset %s connected to project %s by user %s"
@@ -380,7 +393,6 @@ public class AssociatedDatasetService {
 
   // ── Reactive (non-blocking) connect ─────────────────────────────────────
 
-  private static final Duration PER_REQUEST_TIMEOUT = Duration.ofSeconds(30);
   private static final int BOUNDED_PARALLELISM = 3;
 
   /**
@@ -412,12 +424,25 @@ public class AssociatedDatasetService {
 
   /**
    * Reactive counterpart of {@link #connectDataset}. Runs the blocking
-   * call on a {@link Schedulers#boundedElastic()} worker thread, with a
-   * per-request 30s timeout. Errors (including timeout and network
-   * exceptions) are wrapped into a
-   * {@link ConnectDatasetError#CONNECT_FAILED} so the reactive stream
-   * never terminates in {@code onError} — enabling the UI to tally
-   * partial successes and failures independently.
+   * call on a {@link Schedulers#boundedElastic()} worker thread so the
+   * UI thread never blocks on HTTP/JPA work.
+   *
+   * <p>There is deliberately <em>no</em> reactive {@code timeout} on this
+   * pipeline: the blocking {@link #connectDataset} (HTTP + JPA) cannot be
+   * cancelled by a Reactor timeout or {@code Disposable}. A timeout would
+   * emit a failure to the UI while the underlying call keeps running and
+   * may {@code save()} the connection afterwards — violating the
+   * invariant that a failed connect must never persist a connection, and
+   * producing the confusing "failure reported, connection appears later"
+   * behaviour. The external HTTP client already bounds every call
+   * (connect/request timeouts, bounded retries), so a connect completes
+   * within a known upper bound and the UI always receives the true
+   * outcome.</p>
+   *
+   * <p>Errors (network exceptions, unexpected runtime exceptions) are
+   * wrapped into a {@link ConnectDatasetError#CONNECT_FAILED} so the
+   * reactive stream never terminates in {@code onError} — enabling the
+   * UI to tally partial successes and failures independently.</p>
    */
   @PreAuthorize(
       "hasPermission(#request.projectId(), 'life.qbic.projectmanagement.domain.model.project.Project', 'WRITE')")
@@ -436,16 +461,21 @@ public class AssociatedDatasetService {
                result.fold(value -> value, error -> null),
                result.fold(value -> null, error -> error));
          })
-        // Propagate caller's SecurityContext to the boundedElastic worker
-        // thread so Spring Security `@PreAuthorize` on connectDataset
-        // resolves correctly.
-        .contextWrite(ReactiveSecurityContextUtils.reactiveSecurity(securityContext))
+        // Bridge the caller's SecurityContext from the Reactor context to
+        // the ThreadLocal of the boundedElastic worker thread so Spring
+        // Security `@PreAuthorize` on connectDataset resolves correctly
+        // (same idiom as AsyncProjectServiceImpl).
+        .as(ReactiveSecurityContextUtils::applySecurityContext)
         .subscribeOn(Schedulers.boundedElastic())
-        .timeout(PER_REQUEST_TIMEOUT)
+        .contextWrite(ReactiveSecurityContextUtils.reactiveSecurity(securityContext))
+        // No .timeout(...) here — see javadoc: a reactive timeout cannot
+        // cancel the underlying blocking connect and would create a race
+        // where the UI reports failure but the connection is persisted
+        // once the blocking call completes.
         .onErrorResume(Throwable.class, t -> {
           // Safety net: any exception escaping connectDataset() (schema
-          // errors, unexpected runtime exceptions, timeouts) is converted
-          // into CONNECT_FAILED so the caller can tally partial failures.
+          // errors, unexpected runtime exceptions) is converted into
+          // CONNECT_FAILED so the caller can tally partial failures.
           // The log.error here is critical — without it, uncaught errors
           // become silent failures that the user can only see as a
           // generic toast with no entry in the application log.
@@ -576,9 +606,10 @@ public class AssociatedDatasetService {
       domainEventsCache.forEach(
           domainEvent -> DomainEventDispatcher.instance().dispatch(domainEvent));
     } catch (Exception e) {
-      log.warn("Event dispatch failed while forwarding removal domain event "
-          + "after dataset removal on project %s; the removal itself succeeded, ".formatted(dataset.projectId())
-          + "but collaborators may not have been notified: %s".formatted(e.getMessage()));
+      log.warn(("Event dispatch failed while forwarding removal domain event "
+          + "after dataset removal on project %s; the removal itself succeeded, "
+          + "but collaborators may not have been notified: %s")
+          .formatted(dataset.projectId(), e.getMessage()));
     }
 
     log.info("Dataset %s removed from project %s by user %s"
@@ -602,11 +633,13 @@ public class AssociatedDatasetService {
       String associatedDatasetId, String removedByUserId) {
     SecurityContext securityContext = SecurityContextHolder.getContext();
     return Mono.fromCallable(() -> removeDataset(associatedDatasetId, removedByUserId))
-        // Propagate the caller's SecurityContext to the boundedElastic
-        // worker thread so Spring Security {@code @PreAuthorize} on
-        // removeDataset resolves correctly.
-        .contextWrite(ReactiveSecurityContextUtils.reactiveSecurity(securityContext))
+        // Bridge the caller's SecurityContext from the Reactor context to
+        // the ThreadLocal of the boundedElastic worker thread so Spring
+        // Security {@code @PreAuthorize} on removeDataset resolves
+        // correctly (same idiom as AsyncProjectServiceImpl).
+        .as(ReactiveSecurityContextUtils::applySecurityContext)
         .subscribeOn(Schedulers.boundedElastic())
+        .contextWrite(ReactiveSecurityContextUtils.reactiveSecurity(securityContext))
         .onErrorResume(Throwable.class, t -> {
           // Safety net: any exception escaping removeDataset() (schema
           // errors, unexpected runtime exceptions, timeouts) is converted
@@ -618,6 +651,370 @@ public class AssociatedDatasetService {
               .formatted(associatedDatasetId, t.getMessage()), t);
           return Mono.just(Result.fromError(RemoveDatasetError.REMOVAL_FAILED));
         });
+  }
+
+  // ── Sync connected datasets ────────────────────────────────────────────
+
+  /**
+   * Synchronises the given connected datasets of a project with their
+   * source instances (DATSET-04/08, ADR-0006).
+   *
+   * <p>Each dataset is processed on a bounded-elastic worker thread with
+   * bounded parallelism (matching the connect flow). Responses are
+   * emitted as each per-dataset sync completes (completion order, not
+   * request order) — every {@link SyncDatasetResponse} carries its own
+   * {@code datasetId}, so callers map responses to rows by ID.</p>
+   *
+   * <p>There is no reactive {@code timeout} on the pipeline: a timeout
+   * cannot cancel the underlying blocking {@link #syncDatasetCore} and
+   * would create a race where the UI reports SYNC_FAILED while the sync
+   * continues and persists an updated snapshot afterwards. The external
+   * HTTP client already bounds every call, so each sync completes within
+   * a known upper bound and the UI always receives the true outcome.</p>
+   *
+   * <p>Requires {@code WRITE} permission on the project (story ACs — a
+   * sync updates the project's linked snapshot; amends ADR-0003 §5).</p>
+   *
+   * <p>After the trigger completes, a single
+   * {@link AssociatedDatasetsSyncedEvent} is dispatched — only when at
+   * least one dataset was actually updated — so the notification
+   * directive can send one combined email to the project members
+   * (ADR-0006 N1).</p>
+   *
+   * @param projectId the project the datasets belong to
+   * @param datasetIds the connections to sync (may be a single id)
+   * @param userId    the invoking user — the only identity whose
+   *                  credentials are used (never-borrow-credentials)
+   * @return per-dataset outcomes in request order
+   */
+  @PreAuthorize(
+      "hasPermission(#projectId, 'life.qbic.projectmanagement.domain.model.project.Project', 'WRITE')")
+  public Flux<SyncDatasetResponse> syncDatasets(
+      ProjectId projectId, List<AssociatedDatasetId> datasetIds, String userId) {
+    Objects.requireNonNull(projectId, "projectId must not be null");
+    Objects.requireNonNull(datasetIds, "datasetIds must not be null");
+    Objects.requireNonNull(userId, "userId must not be null");
+
+    SecurityContext securityContext = SecurityContextHolder.getContext();
+    List<SyncDatasetResponse> updated = new CopyOnWriteArrayList<>();
+    return Flux.fromIterable(datasetIds)
+        // flatMap (not flatMapSequential) — emits each SyncDatasetResponse
+        // as soon as its per-dataset Mono completes, regardless of input
+        // order. The UI maps responses to sidebar rows by datasetId, so
+        // arrival order does not matter. Using flatMapSequential would
+        // buffer fast-completing results until slower earlier items
+        // finish, making parallel sync appear sequential to the user.
+        .flatMap(id -> Mono.fromCallable(() ->
+                syncDatasetCore(projectId, id, userId))
+            // Bridge the caller's SecurityContext from the Reactor context
+            // to the ThreadLocal of the boundedElastic worker thread so
+            // Spring Security `@PreAuthorize` evaluations inside the sync
+            // pipeline resolve correctly (same idiom as AsyncProjectServiceImpl).
+            .as(ReactiveSecurityContextUtils::applySecurityContext)
+            .subscribeOn(Schedulers.boundedElastic())
+            .contextWrite(ReactiveSecurityContextUtils.reactiveSecurity(securityContext))
+            // No .timeout(...) here — see method javadoc: a reactive
+            // timeout cannot cancel the underlying blocking sync and
+            // would create a race where the UI reports failure but the
+            // snapshot is updated once the blocking call completes.
+            .onErrorResume(Throwable.class, t -> {
+              // Safety net: any exception escaping syncDatasetCore is
+              // converted into SYNC_FAILED so the caller can tally
+              // partial failures.
+              log.error("Async sync pipeline failed for dataset %s: %s"
+                  .formatted(id.value(), t.getMessage()), t);
+              return Mono.just(SyncDatasetResponse.failed(id, SyncDatasetError.SYNC_FAILED));
+            }), BOUNDED_PARALLELISM)
+        .doOnNext(response -> {
+          if (response.status() == SyncDatasetResponse.SyncStatus.UPDATED) {
+            updated.add(response);
+          }
+        })
+        // Dispatch the summary event as a terminal stream segment (instead of
+        // a doOnComplete callback): concatWith subscribes this mono on the
+        // thread that completes the main flux — a boundedElastic worker —
+        // where the applySecurityContext bridge then restores the caller's
+        // SecurityContext onto that thread's ThreadLocal before the
+        // notification directive's @PreAuthorize'd services run.
+        .concatWith(ReactiveSecurityContextUtils.applySecurityContext(
+                Mono.fromRunnable(() -> emitSyncSummaryEvent(projectId, userId, updated)))
+            .contextWrite(ReactiveSecurityContextUtils.reactiveSecurity(securityContext))
+            .cast(SyncDatasetResponse.class));
+  }
+
+  /**
+   * Blocking sync of one dataset (runs on a worker thread via
+   * {@link #syncDatasets}).
+   */
+  private SyncDatasetResponse syncDatasetCore(
+      ProjectId projectId, AssociatedDatasetId datasetId, String userId) {
+
+    // 1. Load the connection
+    Optional<AssociatedDataset> foundOpt;
+    try {
+      foundOpt = associatedDatasetRepository.findById(datasetId);
+    } catch (Exception e) {
+      log.error("Sync lookup failed for dataset %s".formatted(datasetId.value()), e);
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.SYNC_FAILED);
+    }
+    if (foundOpt.isEmpty() || !foundOpt.get().isConnected()) {
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.DATASET_NOT_FOUND);
+    }
+    var dataset = foundOpt.get();
+
+    // 2. Resolve the instance this dataset belongs to
+    InstanceConfig config;
+    try {
+      config = resolveInstanceConfigForDataset(dataset);
+    } catch (DatasetSourceNotFoundException e) {
+      log.warn("Cannot sync dataset %s — no configured instance matches"
+          .formatted(datasetId.value()));
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.SYNC_FAILED);
+    }
+
+    ResourceMetadata storedMetadata = dataset.resourceMetadata();
+    boolean storedRestricted = storedMetadata instanceof InvenioRdmResourceMetadata inv
+        && inv.deriveAccessLevel() == AccessLevel.RESTRICTED;
+
+    // 3. Short-circuit: metadata-restricted record without a usable
+    //    credential (ADR-0006 A1 — deterministic, no HTTP call needed)
+    if (storedRestricted && !datasetSource.hasValidCredential(userId, config)) {
+      log.info("Sync of restricted dataset %s skipped — no valid credential for user %s on instance %s"
+          .formatted(datasetId.value(), userId, config.id()));
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.CREDENTIAL_REQUIRED);
+    }
+
+    // 4. Resolve the latest state (follows the version chain)
+    Optional<ResolvedRecord> resolvedOpt;
+    try {
+      resolvedOpt = datasetSource.resolveLatest(
+          dataset.externalHandle().value(), config, userId);
+    } catch (DatasetAccessDeniedException e) {
+      boolean hasCredential = datasetSource.hasValidCredential(userId, config);
+      return SyncDatasetResponse.failed(datasetId, hasCredential
+          ? SyncDatasetError.CREDENTIAL_INSUFFICIENT
+          : SyncDatasetError.CREDENTIAL_REQUIRED);
+    } catch (DatasetResolveException e) {
+      log.error("Sync resolve failed for dataset %s".formatted(datasetId.value()), e);
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.SYNC_FAILED);
+    }
+    if (resolvedOpt.isEmpty()) {
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.RECORD_NOT_FOUND);
+    }
+    ResolvedRecord resolved = resolvedOpt.get();
+    if (!(resolved.metadata() instanceof InvenioRdmResourceMetadata latestMetadata)) {
+      log.error("Sync produced unsupported metadata type for dataset %s"
+          .formatted(datasetId.value()));
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.SYNC_FAILED);
+    }
+
+    // 5. Did the record move? (new version / new record id)
+    String storedVersion = storedMetadata.version();
+    boolean versionChanged = !Objects.equals(storedVersion, latestMetadata.version());
+    boolean handleChanged = !Objects.equals(
+        resolved.externalHandleValue(), dataset.externalHandle().value());
+    boolean recordChanged = versionChanged || handleChanged;
+
+    // 6. Duplicate guard: another active connection already carries the
+    //    target version's PID — do not create a duplicate (plan §Edge cases)
+    if (recordChanged && !Objects.equals(latestMetadata.pid(), storedMetadata.pid())
+        && associatedDatasetRepository.isActiveConnectionPresent(projectId, latestMetadata.pid())) {
+      log.info(("Sync of dataset %s skipped — a connection to version %s "
+          + "already exists in project %s")
+          .formatted(datasetId.value(), latestMetadata.pid(), projectId.value()));
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.ALREADY_CONNECTED);
+    }
+
+    // 7. Access-link refresh for restricted version bumps — hard gate
+    //    (ADR-0006 L1): the new version only commits if a fresh sharable
+    //    link could be created on the latest record.
+    CreatedAccessLink refreshedLink = null;
+    if (recordChanged && latestMetadata.deriveAccessLevel() == AccessLevel.RESTRICTED) {
+      try {
+        refreshedLink = datasetSource.createAccessLink(
+            resolved.externalHandleValue(), config, userId);
+      } catch (AccessLinkCreationException e) {
+        log.error("Sync of restricted dataset %s failed — cannot refresh the access link on the new version"
+            .formatted(datasetId.value()), e);
+        return SyncDatasetResponse.failed(datasetId, SyncDatasetError.ACCESS_LINK_REFRESH_FAILED);
+      }
+    }
+
+    // 8. Build the candidate snapshot with correct runtime fields
+    //    (instance id, access link, parent handle — see ADR-0006)
+    InvenioRdmResourceMetadata candidate =
+        buildCandidate(storedMetadata, latestMetadata, recordChanged, refreshedLink, config);
+
+    // 9. Apply + persist. No domain event is emitted by the aggregate
+    //    mutation — the summary event is emitted per trigger (step 10).
+    String oldHandle = dataset.externalHandle().value();
+    AssociatedDataset.SyncChange change;
+    try {
+      change = dataset.sync(candidate);
+      if (handleChanged) {
+        dataset.updateExternalHandle(new ExternalHandle(resolved.externalHandleValue()));
+      }
+      associatedDatasetRepository.save(dataset);
+    } catch (Exception e) {
+      log.error("Sync persist failed for dataset %s".formatted(datasetId.value()), e);
+      // Integrity rollback: the new access link must not linger unused.
+      if (refreshedLink != null && refreshedLink.linkId() != null) {
+        revokeAccessLinkBestEffort(refreshedLink.linkId(),
+            resolved.externalHandleValue(), config, userId);
+      }
+      return SyncDatasetResponse.failed(datasetId, SyncDatasetError.SYNC_FAILED);
+    }
+
+    // 10. Post-commit: revoke the stale access link of the previous
+    //     version (best-effort; failures are logged, not blocking).
+    if (refreshedLink != null && storedMetadata instanceof InvenioRdmResourceMetadata invStored
+        && invStored.accessLinkId() != null) {
+      revokeAccessLinkBestEffort(invStored.accessLinkId(), oldHandle, config, userId);
+    }
+
+    if (!change.metadataChanged()) {
+      return SyncDatasetResponse.upToDate(datasetId);
+    }
+    return SyncDatasetResponse.updated(
+        datasetId, change.previousVersion(), change.newVersion(),
+        change.accessStatusChanged(), dataset.title(), dataset.pid());
+  }
+
+  /**
+   * Builds the candidate snapshot for a sync, carrying the runtime fields
+   * that are <em>connection-local</em> rather than source facts:
+   * instance id, access link (identity/id), and parent handle.
+   *
+   * <ul>
+   *   <li>Record unchanged: preserve the stored runtime fields verbatim so
+   *       a no-op sync compares equal and is not misreported as updated.</li>
+   *   <li>Record changed: adopt the fresh metadata, replace the access link
+   *       (restricted → newly created link; public → new record's self
+   *       link), and keep the instance id (the dataset stays on its
+   *       instance).</li>
+   * </ul>
+   */
+  private InvenioRdmResourceMetadata buildCandidate(
+      ResourceMetadata storedMetadata,
+      InvenioRdmResourceMetadata latest,
+      boolean recordChanged,
+      @Nullable CreatedAccessLink refreshedLink,
+      InstanceConfig config) {
+
+    boolean restrictedLatest = latest.deriveAccessLevel() == AccessLevel.RESTRICTED;
+    String preservedInstanceId = null;
+    String preservedLink = null;
+    String preservedLinkId = null;
+    String preservedParentHandle = null;
+    if (storedMetadata instanceof InvenioRdmResourceMetadata invStored) {
+      preservedInstanceId = invStored.instanceId();
+      preservedLink = invStored.accessLink();
+      preservedLinkId = invStored.accessLinkId();
+      preservedParentHandle = invStored.parentHandle();
+    }
+
+    if (!recordChanged) {
+      // Same record — keep the stored runtime fields verbatim so a no-op
+      // sync compares equal and is reported as UP_TO_DATE. This includes a
+      // null parent handle on legacy connections: the parent handle is only
+      // adopted when a real version change commits (else the first sync of
+      // legacy rows would falsely count as "updated").
+      return new InvenioRdmResourceMetadata(
+          latest.title(), latest.pid(), latest.version(), preservedLink,
+          latest.resourceProvider(), latest.creators(), latest.resourceType(),
+          latest.community(), latest.publicationDate(), latest.description(),
+          latest.recordAccess(), latest.fileAccess(),
+          preservedInstanceId, preservedLinkId, preservedParentHandle);
+    }
+
+    if (restrictedLatest && refreshedLink != null) {
+      // New version of a restricted record — fresh access link.
+      return new InvenioRdmResourceMetadata(
+          latest.title(), latest.pid(), latest.version(), refreshedLink.url(),
+          latest.resourceProvider(), latest.creators(), latest.resourceType(),
+          latest.community(), latest.publicationDate(), latest.description(),
+          latest.recordAccess(), latest.fileAccess(),
+          config.id(), refreshedLink.linkId(), latest.parentHandle());
+    }
+
+    // New version of a public record (or restricted without a stored link
+    // path) — self link of the newest record; no access link id.
+    return new InvenioRdmResourceMetadata(
+        latest.title(), latest.pid(), latest.version(), latest.accessLink(),
+        latest.resourceProvider(), latest.creators(), latest.resourceType(),
+        latest.community(), latest.publicationDate(), latest.description(),
+        latest.recordAccess(), latest.fileAccess(),
+        config.id(), null, latest.parentHandle());
+  }
+
+  /**
+   * Dispatches one {@link AssociatedDatasetsSyncedEvent} after a sync
+   * trigger, only when at least one dataset was actually updated
+   * (ADR-0006 N1 — no emails for no-op syncs or failures). A dispatch
+   * failure is logged but never fails the sync itself.
+   */
+  private void emitSyncSummaryEvent(
+      ProjectId projectId, String userId, List<SyncDatasetResponse> updated) {
+    if (updated.isEmpty()) {
+      return;
+    }
+    List<AssociatedDatasetsSyncedEvent.UpdatedRecord> records = updated.stream()
+        .map(response -> new AssociatedDatasetsSyncedEvent.UpdatedRecord(
+            response.datasetId(), response.title(), response.pid(),
+            response.previousVersion(), response.newVersion(), response.accessStatusChanged()))
+        .toList();
+    var event = AssociatedDatasetsSyncedEvent.create(projectId, userId, records);
+    try {
+      DomainEventDispatcher.instance().dispatch(event);
+    } catch (Exception e) {
+      log.warn("Failed dispatching sync summary event for project %s: %s"
+          .formatted(projectId.value(), e.getMessage()));
+    }
+  }
+
+  /**
+   * Resolves the {@link InstanceConfig} a dataset belongs to. Primary
+   * source: the instance id persisted on the metadata snapshot. Legacy
+   * rows without an instance id fall back to matching the record's
+   * access link against the configured instance base URLs.
+   */
+  private InstanceConfig resolveInstanceConfigForDataset(AssociatedDataset dataset) {
+    if (dataset.resourceMetadata() instanceof InvenioRdmResourceMetadata inv
+        && inv.instanceId() != null && !inv.instanceId().isBlank()) {
+      return resolveInstanceConfig(inv.instanceId());
+    }
+    // Legacy fallback: best URL match
+    String accessLink = dataset.resourceMetadata() instanceof InvenioRdmResourceMetadata inv
+        ? inv.accessLink() : null;
+    if (accessLink != null && !accessLink.isBlank()) {
+      for (SourceInstanceDescriptor descriptor :
+          sourceInstanceRegistry.findBySourceType(SourceType.INVENIO_RDM)) {
+        if (accessLink.startsWith(descriptor.baseUrl())) {
+          return descriptor.toInstanceConfig();
+        }
+      }
+    }
+    throw new DatasetSourceNotFoundException();
+  }
+
+  /**
+   * Best-effort access-link revocation for sync lifecycle (stale link
+   * after a version bump, or rollback of a freshly created link after a
+   * persistence failure). Never throws — failures are logged so operators
+   * can clean up orphaned links manually.
+   */
+  private void revokeAccessLinkBestEffort(
+      String accessLinkId, String externalHandleValue,
+      InstanceConfig config, String actingUserId) {
+    try {
+      datasetSource.revokeAccessLink(accessLinkId, externalHandleValue, config, actingUserId);
+      log.info("Revoked access link %s on instance %s (sync lifecycle)"
+          .formatted(accessLinkId, config.id()));
+    } catch (Exception e) {
+      log.error(("Failed to revoke access link %s on instance %s during sync; "
+          + "the link may need manual clean-up")
+          .formatted(accessLinkId, config.id()), e);
+    }
   }
 
   // ── List connected datasets ─────────────────────────────────────────────
@@ -772,6 +1169,7 @@ public class AssociatedDatasetService {
         ds.connectedBy(),
         displayName,
         ds.connectedOn(),
+        ds.lastSyncedAt().orElse(null),
         ds.experimentId().map(ExperimentId::value).orElse(null),
         expDisplay,
         ds.sourceType().name()
@@ -820,14 +1218,14 @@ public class AssociatedDatasetService {
     try {
       datasetSource.revokeAccessLink(createdAccessLink.linkId(),
           externalHandleValue, config, actingUserId);
-      log.info("Revoked access link {} on instance {} after failed connect"
+      log.info("Revoked access link %s on instance %s after failed connect"
           .formatted(createdAccessLink.linkId(), config.id()));
     } catch (Exception e) {
       // Never mask the primary connect failure. Log so operators can
       // revoke the orphaned link manually.
-      log.error("Failed to revoke access link {} on instance {} after a "
-              + "failed connect; the link may be orphaned and needs manual clean-up"
-              .formatted(createdAccessLink.linkId(), config.id()), e);
+      log.error(("Failed to revoke access link %s on instance %s after a "
+          + "failed connect; the link may be orphaned and needs manual clean-up")
+          .formatted(createdAccessLink.linkId(), config.id()), e);
     }
   }
 
@@ -851,19 +1249,20 @@ public class AssociatedDatasetService {
     try {
       config = resolveInstanceConfig(inv.instanceId());
     } catch (Exception e) {
-      log.error("Cannot resolve instance config to revoke access link {} for "
-          + "dataset {}".formatted(inv.accessLinkId(), dataset.id()), e);
+      log.error(("Cannot resolve instance config to revoke access link %s for "
+          + "dataset %s")
+          .formatted(inv.accessLinkId(), dataset.id()), e);
       return;
     }
     try {
       datasetSource.revokeAccessLink(inv.accessLinkId(),
           dataset.externalHandle().value(), config, actingUserId);
-      log.info("Revoked access link {} on instance {} for removed dataset {}"
+      log.info("Revoked access link %s on instance %s for removed dataset %s"
           .formatted(inv.accessLinkId(), config.id(), dataset.id()));
     } catch (Exception e) {
-      log.error("Failed to revoke access link {} for removed dataset {}; "
-              + "the link may need manual clean-up"
-              .formatted(inv.accessLinkId(), dataset.id()), e);
+      log.error(("Failed to revoke access link %s for removed dataset %s; "
+          + "the link may need manual clean-up")
+          .formatted(inv.accessLinkId(), dataset.id()), e);
     }
   }
 

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/ConnectedDatasetView.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/ConnectedDatasetView.java
@@ -92,6 +92,14 @@ public record ConnectedDatasetView(
     Instant connectedOn,
 
     /**
+     * Timestamp of the last successful synchronisation with the source
+     * instance, or null if the dataset was never synced (DATSET-04/08).
+     *
+     * @since 1.13.0
+     */
+    Instant lastSyncedAt,
+
+    /**
      * Raw experiment ID (UUID string), or null if no experiment is linked.
      * Use as an opaque identifier; prefer {@link #experimentName} for display.
      */

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/DatasetAccessDeniedException.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/DatasetAccessDeniedException.java
@@ -1,0 +1,31 @@
+package life.qbic.projectmanagement.application.associated_dataset;
+
+import java.io.Serial;
+
+/**
+ * Thrown by {@link DatasetSource#resolveLatest(String, InstanceConfig, String)}
+ * when the source system denies access to the record (HTTP 401/403).
+ *
+ * <p>Distinguishes <em>access/credential</em> failures from transient
+ * infrastructure failures during sync (ADR-0006): the application layer
+ * maps this to {@link SyncDatasetError#CREDENTIAL_REQUIRED} (no usable
+ * credential configured) or {@link SyncDatasetError#CREDENTIAL_INSUFFICIENT}
+ * (a credential exists but does not grant access to the record). A record
+ * that does not exist (404) is still represented by
+ * {@link java.util.Optional#empty()}.</p>
+ *
+ * @since 1.13.0
+ */
+public final class DatasetAccessDeniedException extends DatasetResolveException {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  public DatasetAccessDeniedException(String message) {
+    super(message);
+  }
+
+  public DatasetAccessDeniedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/DatasetResolveException.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/DatasetResolveException.java
@@ -29,7 +29,7 @@ import life.qbic.application.commons.ApplicationException;
  *
  * @since 1.12.0
  */
-public final class DatasetResolveException extends ApplicationException {
+public class DatasetResolveException extends ApplicationException {
 
   @Serial
   private static final long serialVersionUID = 1L;

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/DatasetSource.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/DatasetSource.java
@@ -74,6 +74,39 @@ public interface DatasetSource {
       String actingUserId) throws DatasetResolveException;
 
   /**
+   * Resolves the current/latest state of the record identified by the
+   * given handle, on behalf of the given user.
+   *
+   * <p>Used when synchronising a connected dataset (DATSET-04/08,
+   * ADR-0006). Unlike {@link #resolveMetadata}, which returns the record
+   * under the given handle as-is, this method follows version chains:
+   * for versioned sources the returned {@link ResolvedRecord} carries the
+   * metadata of the <em>latest published version</em> together with the
+   * record identifier it was fetched from.</p>
+   *
+   * <p>Credential handling is identical to {@link #resolveMetadata}
+   * (ADR-0002 D1: token resolved in the adapter scope and zeroed after
+   * use). Access failures must be reported as
+   * {@link DatasetAccessDeniedException} so the application layer can
+   * distinguish "no usable credential" from "credential lacks access".</p>
+   *
+   * @param externalHandleValue the source-specific identifier to start
+   *                            resolution from (e.g. the connected record)
+   * @param config              the target instance
+   * @param actingUserId        the ID of the user performing the sync
+   * @return the latest record's metadata + effective handle, or empty if
+   *         the record (and its version chain) no longer exists
+   * @throws DatasetAccessDeniedException if access to the record is
+   *         denied (HTTP 401/403)
+   * @throws DatasetResolveException      for other resolve failures
+   *         (network error, rate limit, server error, …)
+   * @since 1.13.0
+   */
+  Optional<ResolvedRecord> resolveLatest(
+      String externalHandleValue, InstanceConfig config,
+      String actingUserId) throws DatasetResolveException;
+
+  /**
    * Returns whether the given user has a valid (non-invalidated)
    * credential configured for the specified instance.
    *

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/ResolvedRecord.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/ResolvedRecord.java
@@ -1,0 +1,27 @@
+package life.qbic.projectmanagement.application.associated_dataset;
+
+import java.util.Objects;
+import life.qbic.projectmanagement.domain.model.associated_dataset.ResourceMetadata;
+
+/**
+ * Result of resolving the current/latest state of a record on a source
+ * system (sync, DATSET-04/08).
+ *
+ * <p>Pairs the canonical {@link ResourceMetadata} snapshot with the
+ * <em>effective</em> external handle. For versioned sources (InvenioRDM)
+ * the effective handle may differ from the handle the caller resolved —
+ * when a new version was published the latest record lives under a new
+ * record id — and the connection must follow it (ADR-0006).</p>
+ *
+ * @param metadata            the latest metadata snapshot
+ * @param externalHandleValue the record identifier the snapshot was
+ *                            actually fetched from (the latest record)
+ * @since 1.13.0
+ */
+public record ResolvedRecord(ResourceMetadata metadata, String externalHandleValue) {
+
+  public ResolvedRecord {
+    Objects.requireNonNull(metadata, "metadata must not be null");
+    Objects.requireNonNull(externalHandleValue, "externalHandleValue must not be null");
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/SyncDatasetError.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/SyncDatasetError.java
@@ -1,0 +1,59 @@
+package life.qbic.projectmanagement.application.associated_dataset;
+
+/**
+ * Error codes for synchronising a connected dataset with its source
+ * instance (DATSET-04/08, ADR-0006).
+ *
+ * @since 1.13.0
+ */
+public enum SyncDatasetError {
+
+  /**
+   * The dataset connection does not exist or is already removed.
+   */
+  DATASET_NOT_FOUND,
+
+  /**
+   * The record (and its version chain) no longer exists on the source
+   * system. The connection is kept — the user decides whether to remove
+   * it manually.
+   */
+  RECORD_NOT_FOUND,
+
+  /**
+   * The dataset is access-restricted and the invoking user has no valid
+   * credential configured for the source instance. Guidance: configure
+   * the provider (add a token) first.
+   */
+  CREDENTIAL_REQUIRED,
+
+  /**
+   * The dataset is access-restricted and the invoking user's token does
+   * not grant access to the record on the source system.
+   */
+  CREDENTIAL_INSUFFICIENT,
+
+  /**
+   * A restricted dataset moved to a new version, but the shareable
+   * access link could not be created on the latest record. Per
+   * ADR-0006 (L1) the sync fails atomically — only the record owner can
+   * refresh the access link.
+   */
+  ACCESS_LINK_REFRESH_FAILED,
+
+  /**
+   * The target version (PID) of the sync is already connected to the
+   * project through another active connection. The connection is left
+   * untouched to avoid duplicates.
+   *
+   * @since 1.13.0
+   */
+  ALREADY_CONNECTED,
+
+  /**
+   * The sync could not be completed due to an unexpected or transient
+   * error (network, rate limit, persistence failure, …).
+   */
+  SYNC_FAILED;
+
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/SyncDatasetResponse.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/associated_dataset/SyncDatasetResponse.java
@@ -1,0 +1,61 @@
+package life.qbic.projectmanagement.application.associated_dataset;
+
+import life.qbic.projectmanagement.domain.model.associated_dataset.AssociatedDatasetId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Per-dataset outcome of a sync trigger (DATSET-04/08).
+ *
+ * <p>Exactly one {@link SyncStatus} is set; {@link #error()} is non-null
+ * only for {@link SyncStatus#FAILED}. For {@link SyncStatus#UPDATED} the
+ * post-sync {@link #title()} / {@link #pid()} and the new version string
+ * are carried so the UI and the summary notification can render the
+ * record without re-querying.</p>
+ *
+ * @param datasetId          the connection (aggregate) id
+ * @param status             the outcome category
+ * @param previousVersion    the version before the sync (UPDATED only)
+ * @param newVersion         the version after the sync, or null
+ * @param accessStatusChanged whether the coarse access level changed
+ * @param title              the record title after the sync (UPDATED only)
+ * @param pid                the persistent identifier after the sync (UPDATED only)
+ * @param error              the error code (FAILED only)
+ * @since 1.13.0
+ */
+public record SyncDatasetResponse(
+    AssociatedDatasetId datasetId,
+    SyncStatus status,
+    @Nullable String previousVersion,
+    @Nullable String newVersion,
+    boolean accessStatusChanged,
+    @Nullable String title,
+    @Nullable String pid,
+    @Nullable SyncDatasetError error) {
+
+  public enum SyncStatus {
+    /** The local snapshot was replaced with newer metadata from the source. */
+    UPDATED,
+    /** The source already matches the local snapshot (no-op). */
+    UP_TO_DATE,
+    /** The sync could not be completed; {@link SyncDatasetResponse#error()} is set. */
+    FAILED
+  }
+
+  public static SyncDatasetResponse updated(
+      AssociatedDatasetId datasetId, String previousVersion, String newVersion,
+      boolean accessStatusChanged, String title, String pid) {
+    return new SyncDatasetResponse(datasetId, SyncStatus.UPDATED, previousVersion,
+        newVersion, accessStatusChanged, title, pid, null);
+  }
+
+  public static SyncDatasetResponse upToDate(AssociatedDatasetId datasetId) {
+    return new SyncDatasetResponse(datasetId, SyncStatus.UP_TO_DATE, null,
+        null, false, null, null, null);
+  }
+
+  public static SyncDatasetResponse failed(
+      AssociatedDatasetId datasetId, SyncDatasetError error) {
+    return new SyncDatasetResponse(datasetId, SyncStatus.FAILED, null,
+        null, false, null, null, error);
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/policy/AssociatedDatasetsSyncedPolicy.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/policy/AssociatedDatasetsSyncedPolicy.java
@@ -1,0 +1,26 @@
+package life.qbic.projectmanagement.application.policy;
+
+import static java.util.Objects.requireNonNull;
+
+import life.qbic.domain.concepts.DomainEventDispatcher;
+import life.qbic.projectmanagement.application.policy.directive.InformProjectCollaboratorsAboutDatasetSync;
+
+/**
+ * <b>Policy: Associated Datasets Synced</b>
+ *
+ * <p>Business policy that needs to be executed after a sync trigger
+ * updated one or more connected datasets (DATSET-04/08, ADR-0006).
+ * Currently wires the email notification directive that informs every
+ * collaborator (except the actor) with a single combined email listing
+ * the updated records.</p>
+ *
+ * @since 1.13.0
+ */
+public class AssociatedDatasetsSyncedPolicy {
+
+  public AssociatedDatasetsSyncedPolicy(
+      InformProjectCollaboratorsAboutDatasetSync informCollaborators) {
+    DomainEventDispatcher.instance().subscribe(requireNonNull(informCollaborators,
+        "informCollaborators must not be null"));
+  }
+}

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/InformProjectCollaboratorsAboutDatasetConnection.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/InformProjectCollaboratorsAboutDatasetConnection.java
@@ -85,7 +85,10 @@ public class InformProjectCollaboratorsAboutDatasetConnection
         .orElseThrow(() -> new DirectiveExecutionException(
             "Project not found: " + event.projectId()));
 
-    String projectUrl = appContextProvider.urlToProject(event.projectId().value());
+    // The dataset notification emails link straight into the project's
+    // datasets view — not the project info page — so members reach the
+    // connected/updated datasets directly.
+    String projectUrl = appContextProvider.urlToDatasets(event.projectId().value());
     String actorId = event.actorUserId();
 
     List<RecipientInfo> recipients = resolveRecipientsExcludingActor(event.projectId(), actorId);

--- a/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/InformProjectCollaboratorsAboutDatasetSync.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/application/policy/directive/InformProjectCollaboratorsAboutDatasetSync.java
@@ -18,7 +18,7 @@ import life.qbic.projectmanagement.application.communication.Content;
 import life.qbic.projectmanagement.application.communication.EmailService;
 import life.qbic.projectmanagement.application.communication.Recipient;
 import life.qbic.projectmanagement.application.communication.Subject;
-import life.qbic.projectmanagement.domain.model.associated_dataset.event.AssociatedDatasetRemovedEvent;
+import life.qbic.projectmanagement.domain.model.associated_dataset.event.AssociatedDatasetsSyncedEvent;
 import life.qbic.projectmanagement.domain.model.project.Project;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
 import life.qbic.projectmanagement.domain.model.project.ProjectIntent;
@@ -29,23 +29,26 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 /**
- * <b>Directive: Inform project collaborators about dataset connection removal</b>
+ * <b>Directive: Inform project collaborators about a dataset sync</b>
  *
- * <p>After a user removes a dataset connection from a project, every other
- * collaborator on that project is notified by email. The actor who performed
- * the removal is deliberately excluded so they do not receive a
- * self-notification.</p>
+ * <p>After a sync trigger updated one or more connected datasets, every
+ * collaborator on that project is notified with a <em>single combined
+ * email</em> listing all updated records (ADR-0006 N1). The actor who
+ * triggered the sync is deliberately excluded so they do not receive a
+ * self-notification (they see the sync results sidecar instead).</p>
  *
- * <p>The actual email send runs inside a JobRunr background job so the
- * domain-event handler does not block on SMTP latency (ADR-0002 §12).</p>
+ * <p>The event is only emitted when at least one record actually changed;
+ * no-op syncs and failures never reach this directive. The actual email
+ * send runs inside a JobRunr background job so the domain-event handler
+ * does not block on SMTP latency.</p>
  *
- * @since 1.12.0
+ * @since 1.13.0
  */
 @Component
-public class InformProjectCollaboratorsAboutDatasetRemoval
-    implements DomainEventSubscriber<AssociatedDatasetRemovedEvent> {
+public class InformProjectCollaboratorsAboutDatasetSync
+    implements DomainEventSubscriber<AssociatedDatasetsSyncedEvent> {
 
-  private static final Logger log = logger(InformProjectCollaboratorsAboutDatasetRemoval.class);
+  private static final Logger log = logger(InformProjectCollaboratorsAboutDatasetSync.class);
 
   private final EmailService emailService;
   private final ProjectAccessService projectAccessService;
@@ -54,7 +57,7 @@ public class InformProjectCollaboratorsAboutDatasetRemoval
   private final AppContextProvider appContextProvider;
   private final JobScheduler jobScheduler;
 
-  public InformProjectCollaboratorsAboutDatasetRemoval(
+  public InformProjectCollaboratorsAboutDatasetSync(
       EmailService emailService,
       ProjectAccessService projectAccessService,
       UserInformationService userInformationService,
@@ -71,13 +74,13 @@ public class InformProjectCollaboratorsAboutDatasetRemoval
 
   @Override
   public Class<? extends DomainEvent> subscribedToEventType() {
-    return AssociatedDatasetRemovedEvent.class;
+    return AssociatedDatasetsSyncedEvent.class;
   }
 
   @Override
   @PreAuthorize(
       "hasPermission(#event.projectId(), 'life.qbic.projectmanagement.domain.model.project.Project', 'READ')")
-  public void handleEvent(AssociatedDatasetRemovedEvent event) {
+  public void handleEvent(AssociatedDatasetsSyncedEvent event) {
     String projectTitle = projectInformationService.find(event.projectId())
         .map(Project::getProjectIntent)
         .map(ProjectIntent::projectTitle)
@@ -91,9 +94,17 @@ public class InformProjectCollaboratorsAboutDatasetRemoval
     String projectUrl = appContextProvider.urlToDatasets(event.projectId().value());
     String actorId = event.actorUserId();
 
+    // Flatten the updated records into pre-rendered lines so the JobRunr
+    // job only carries plain strings (no domain types across serialization).
+    List<String> updatedRecordLines = event.updatedRecords().stream()
+        .map(record -> Messages.updatedRecordLine(
+            record.title(), record.pid(), record.previousVersion(),
+            record.newVersion(), record.accessStatusChanged()))
+        .toList();
+
     List<RecipientInfo> recipients = resolveRecipientsExcludingActor(event.projectId(), actorId);
     if (recipients.isEmpty()) {
-      log.info("No collaborators to notify for dataset removal on project %s".formatted(
+      log.info("No collaborators to notify for dataset sync on project %s".formatted(
           event.projectId()));
       return;
     }
@@ -101,15 +112,14 @@ public class InformProjectCollaboratorsAboutDatasetRemoval
     for (RecipientInfo recipient : recipients) {
       jobScheduler.enqueue(
           () -> notifyRecipient(recipient.email, recipient.fullName,
-              recipient.fullName, projectTitle, event.datasetTitle(), event.datasetPid(),
-              projectUrl));
+              recipient.fullName, projectTitle, updatedRecordLines, projectUrl));
     }
   }
 
   /**
    * Resolves all collaborators on the project, filtering out the actor
-   * who performed the removal. Silently skips users whose profile
-   * cannot be resolved (e.g. a deleted user account).
+   * who triggered the sync. Silently skips users whose profile cannot be
+   * resolved (e.g. a deleted user account).
    */
   private List<RecipientInfo> resolveRecipientsExcludingActor(ProjectId projectId, String actorId) {
     List<RecipientInfo> recipients = new ArrayList<>();
@@ -126,18 +136,17 @@ public class InformProjectCollaboratorsAboutDatasetRemoval
     return recipients;
   }
 
-  @Job(name = "Notify collaborator about dataset removal on project %3 for dataset %4")
+  @Job(name = "Notify collaborator about dataset sync on project %3")
   public void notifyRecipient(
       String emailAddress,
       String fullName,
       String addressee,
       String projectTitle,
-      String datasetTitle,
-      String datasetPid,
+      List<String> updatedRecordLines,
       String projectUrl) {
-    var subject = new Subject("Dataset connection removed from project");
-    var message = Messages.datasetRemovedFromProject(
-        addressee, projectTitle, datasetTitle, datasetPid, projectUrl);
+    var subject = new Subject("Connected datasets updated in project");
+    var message = Messages.datasetsSyncedToProject(
+        addressee, projectTitle, updatedRecordLines, projectUrl);
     emailService.send(subject,
         new Recipient(emailAddress, fullName),
         new Content(message));

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/associated_dataset/AssociatedDataset.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/associated_dataset/AssociatedDataset.java
@@ -18,6 +18,7 @@ import life.qbic.projectmanagement.domain.model.associated_dataset.event.Associa
 import life.qbic.projectmanagement.domain.model.experiment.ExperimentId;
 import life.qbic.projectmanagement.domain.model.project.ProjectId;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
@@ -230,10 +231,70 @@ public class AssociatedDataset {
    * @since 1.12.0
    */
   public void updateMetadata(ResourceMetadata metadata) {
+    sync(metadata);
+  }
+
+  /**
+   * Applies a metadata snapshot obtained by synchronising with the source
+   * system (DATSET-04/08, ADR-0006) and reports what changed.
+   *
+   * <p>Computes the change information <em>before</em> applying, so the
+   * caller can decide whether the sync actually updated the connection
+   * (and thus whether a notification is due). {@code lastSyncedAt} is
+   * updated whenever this method is invoked, regardless of whether the
+   * metadata itself changed.</p>
+   *
+   * @param metadata the latest metadata snapshot from the source
+   * @return the computed change information
+   * @since 1.13.0
+   */
+  public SyncChange sync(ResourceMetadata metadata) {
     Objects.requireNonNull(metadata, "metadata must not be null");
+    String previousVersion = this.version;
+    AccessLevel previousAccessLevel = this.accessLevel;
+    boolean metadataChanged = !Objects.equals(this.resourceMetadata, metadata);
     applyMetadata(metadata);
     this.lastSyncedAt = Instant.now();
+    boolean versionChanged = !Objects.equals(previousVersion, this.version);
+    boolean accessStatusChanged = previousAccessLevel != this.accessLevel;
+    return new SyncChange(versionChanged, accessStatusChanged, metadataChanged,
+        previousVersion, this.version);
   }
+
+  /**
+   * Moves the connection's external handle to a new record identifier.
+   *
+   * <p>Used by sync (ADR-0006): when a new version of the dataset is
+   * published, InvenioRDM creates a new record with a new recid. The
+   * connection follows the latest version, so the handle is updated to
+   * the new record's identifier after the sync committed.</p>
+   *
+   * @param externalHandle the new record identifier
+   * @throws NullPointerException if {@code externalHandle} is null
+   * @since 1.13.0
+   */
+  public void updateExternalHandle(ExternalHandle externalHandle) {
+    Objects.requireNonNull(externalHandle, "externalHandle must not be null");
+    this.externalHandle = externalHandle.value();
+  }
+
+  /**
+   * Outcome of a sync: what changed when applying a fresh metadata
+   * snapshot (see {@link #sync(ResourceMetadata)}).
+   *
+   * @param versionChanged     whether the version string changed
+   * @param accessStatusChanged whether the coarse access level changed
+   * @param metadataChanged    whether the full metadata snapshot differs
+   * @param previousVersion    the version string before the update, or null
+   * @param newVersion         the version string after the update, or null
+   * @since 1.13.0
+   */
+  public record SyncChange(
+      boolean versionChanged,
+      boolean accessStatusChanged,
+      boolean metadataChanged,
+      @Nullable String previousVersion,
+      @Nullable String newVersion) {}
 
   // ── Accessors ───────────────────────────────────────────────────────────
 
@@ -277,6 +338,15 @@ public class AssociatedDataset {
    */
   public String pid() {
     return pid;
+  }
+
+  /**
+   * High-priority universal column: version string of the dataset on the
+   * source (e.g. "v1"), extracted from {@link #resourceMetadata()} for
+   * efficient SQL sort/filter (ADR-0001).
+   */
+  public String version() {
+    return version;
   }
 
   public String connectedBy() {

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/associated_dataset/InvenioRdmResourceMetadata.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/associated_dataset/InvenioRdmResourceMetadata.java
@@ -88,7 +88,24 @@ public record InvenioRdmResourceMetadata(
      * this field existed deserialize to {@code null} and are simply skipped
      * by revocation.</p>
      */
-    String accessLinkId
+    String accessLinkId,
+    /**
+     * The InvenioRDM concept (parent) record identifier of the dataset,
+     * or null.
+     *
+     * <p>InvenioRDM publishes every version as a new record sharing one
+     * concept (parent) record. Resolving the parent recid via
+     * {@code GET /records/{parentId}} always yields the latest published
+     * version (HTTP 302 → latest record). Sync (FEAT-DATSET-04/08) uses
+     * this handle to follow version chains; see ADR-0006.</p>
+     *
+     * <p>Nullable and optional: legacy rows written before this field
+     * existed deserialize to {@code null} and resolve the parent from the
+     * stored record on their first sync.</p>
+     *
+     * @since 1.13.0
+     */
+    String parentHandle
 
 ) implements ResourceMetadata {
 
@@ -129,8 +146,51 @@ public record InvenioRdmResourceMetadata(
       InvenioRdmAccessStatus fileAccess) {
     this(title, pid, version, accessLink, resourceProvider, creators,
         resourceType, community, publicationDate, description,
-        recordAccess, fileAccess, null, null);
+        recordAccess, fileAccess, null, null, null);
   }
+
+  /**
+   * Backward-compatible constructor with link-lifecycle fields but without
+   * a parent handle (legacy schema / test helpers). Delegates with
+   * {@code parentHandle} unset ({@code null}).
+   *
+   * @param title            record title
+   * @param pid              persistent identifier
+   * @param version          version string or null
+   * @param accessLink       access URL or null
+   * @param resourceProvider display name of the instance
+   * @param creators         creator names (nullable → empty)
+   * @param resourceType     resource type or null
+   * @param community        community or null
+   * @param publicationDate  publication date (never null)
+   * @param description      abstract or null
+   * @param recordAccess     record access status (never null)
+   * @param fileAccess       file access status (never null)
+   * @param instanceId       the configured source instance, or null
+   * @param accessLinkId     the access-link id, or null
+   * @since 1.12.0 (extended 1.13.0)
+   */
+  public InvenioRdmResourceMetadata(
+      String title,
+      String pid,
+      String version,
+      String accessLink,
+      String resourceProvider,
+      List<String> creators,
+      String resourceType,
+      String community,
+      LocalDate publicationDate,
+      String description,
+      InvenioRdmAccessStatus recordAccess,
+      InvenioRdmAccessStatus fileAccess,
+      String instanceId,
+      String accessLinkId) {
+    this(title, pid, version, accessLink, resourceProvider, creators,
+        resourceType, community, publicationDate, description,
+        recordAccess, fileAccess, instanceId, accessLinkId, null);
+  }
+
+
 
   public InvenioRdmResourceMetadata {
     Objects.requireNonNull(title, "title must not be null");

--- a/project-management/src/main/java/life/qbic/projectmanagement/domain/model/associated_dataset/event/AssociatedDatasetsSyncedEvent.java
+++ b/project-management/src/main/java/life/qbic/projectmanagement/domain/model/associated_dataset/event/AssociatedDatasetsSyncedEvent.java
@@ -1,0 +1,100 @@
+package life.qbic.projectmanagement.domain.model.associated_dataset.event;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import java.io.Serial;
+import java.util.List;
+import java.util.Objects;
+import life.qbic.domain.concepts.DomainEvent;
+import life.qbic.projectmanagement.domain.model.associated_dataset.AssociatedDatasetId;
+import life.qbic.projectmanagement.domain.model.project.ProjectId;
+
+/**
+ * Domain event emitted once per sync trigger (single dataset or Sync All)
+ * after at least one connected dataset was updated with fresh metadata
+ * from the source platform (DATSET-04/08, ADR-0006).
+ *
+ * <p>Carries the list of records that were actually updated so the
+ * notification directive can send <em>one</em> combined email per project
+ * member instead of flooding recipients with per-record emails. The event
+ * is <strong>not</strong> emitted for no-op syncs ("already up to date")
+ * or for failures — those surface to the invoking user in the sync
+ * results sidecar.</p>
+ *
+ * @since 1.13.0
+ */
+public class AssociatedDatasetsSyncedEvent extends DomainEvent {
+
+  @Serial
+  private static final long serialVersionUID = 7426135049173920159L;
+
+  private final ProjectId projectId;
+  private final String actorUserId;
+  private final List<UpdatedRecord> updatedRecords;
+
+  private AssociatedDatasetsSyncedEvent(
+      ProjectId projectId,
+      String actorUserId,
+      List<UpdatedRecord> updatedRecords) {
+    this.projectId = Objects.requireNonNull(projectId, "projectId must not be null");
+    this.actorUserId = Objects.requireNonNull(actorUserId, "actorUserId must not be null");
+    this.updatedRecords = List.copyOf(
+        Objects.requireNonNull(updatedRecords, "updatedRecords must not be null"));
+  }
+
+  /**
+   * Creates the summary event for a sync trigger.
+   *
+   * @param projectId      the project the datasets belong to
+   * @param actorUserId    the user who triggered the sync
+   * @param updatedRecords the records updated during this trigger; must
+   *                       not be empty (callers skip emission otherwise)
+   * @return the event
+   */
+  public static AssociatedDatasetsSyncedEvent create(
+      ProjectId projectId,
+      String actorUserId,
+      List<UpdatedRecord> updatedRecords) {
+    return new AssociatedDatasetsSyncedEvent(projectId, actorUserId, updatedRecords);
+  }
+
+  @JsonGetter("projectId")
+  public ProjectId projectId() {
+    return projectId;
+  }
+
+  @JsonGetter("actorUserId")
+  public String actorUserId() {
+    return actorUserId;
+  }
+
+  @JsonGetter("updatedRecords")
+  public List<UpdatedRecord> updatedRecords() {
+    return updatedRecords;
+  }
+
+  /**
+   * A single record that was updated during a sync trigger.
+   *
+   * @param datasetId          the connection (aggregate) id
+   * @param title              the record title
+   * @param pid                the persistent identifier (DOI) after the update
+   * @param previousVersion    the version before the sync, or null
+   * @param newVersion         the version after the sync, or null
+   * @param accessStatusChanged whether the coarse access level changed
+   *                            (e.g. embargo lifted or added)
+   */
+  public record UpdatedRecord(
+      AssociatedDatasetId datasetId,
+      String title,
+      String pid,
+      String previousVersion,
+      String newVersion,
+      boolean accessStatusChanged) {
+
+    public UpdatedRecord {
+      Objects.requireNonNull(datasetId, "datasetId must not be null");
+      Objects.requireNonNull(title, "title must not be null");
+      Objects.requireNonNull(pid, "pid must not be null");
+    }
+  }
+}

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/MessagesSyncSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/MessagesSyncSpec.groovy
@@ -1,0 +1,49 @@
+package life.qbic.projectmanagement.application
+
+import spock.lang.Specification
+
+/**
+ * Unit tests for the combined dataset-sync email templates
+ * (DATSET-04/08, ADR-0006 N1).
+ *
+ * @since 1.13.0
+ */
+class MessagesSyncSpec extends Specification {
+
+  def "updatedRecordLine renders version progression"() {
+    expect:
+    Messages.updatedRecordLine("My Dataset", "10.5281/zenodo.1", "v1", "v2", false)
+        == "My Dataset (10.5281/zenodo.1): v1 -> v2"
+  }
+
+  def "updatedRecordLine annotates access status changes"() {
+    expect:
+    Messages.updatedRecordLine("My Dataset", "10.5281/zenodo.1", "v1", "v2", true)
+        == "My Dataset (10.5281/zenodo.1): v1 -> v2 (access status changed)"
+  }
+
+  def "updatedRecordLine handles missing versions"() {
+    expect:
+    Messages.updatedRecordLine("My Dataset", "10.5281/zenodo.1", null, null, false)
+        == "My Dataset (10.5281/zenodo.1): -"
+  }
+
+  def "datasetsSyncedToProject lists all updated records in one message"() {
+    given:
+    def records = [
+        Messages.updatedRecordLine("A", "10.5281/zenodo.a", "v1", "v2", false),
+        Messages.updatedRecordLine("B", "10.5281/zenodo.b", "v2", "v3", true)
+    ]
+
+    when:
+    def message = Messages.datasetsSyncedToProject("Grace Hopper", "My Project", records,
+        "https://datamanager.example/projects/1")
+
+    then:
+    message.contains("Dear Grace Hopper")
+    message.contains("in the project 'My Project'")
+    message.contains("A (10.5281/zenodo.a): v1 -> v2")
+    message.contains("B (10.5281/zenodo.b): v2 -> v3 (access status changed)")
+    message.contains("https://datamanager.example/projects/1")
+  }
+}

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/associated_dataset/AssociatedDatasetServiceConnectSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/associated_dataset/AssociatedDatasetServiceConnectSpec.groovy
@@ -92,6 +92,48 @@ class AssociatedDatasetServiceConnectSpec extends Specification {
     result instanceof Result.Value
   }
 
+  def "connectDataset does not persist a snapshot when access link creation fails"() {
+    given:
+    def projectId = ProjectId.parse(VALID_PROJECT_ID)
+    def userId = "user-1"
+    def config = new InstanceConfig("zenodo", "Zenodo", "https://zenodo.org")
+    def restrictedMetadata = createMetadata(InvenioRdmAccessStatus.RESTRICTED, InvenioRdmAccessStatus.RESTRICTED)
+
+    def source = Mock(DatasetSource) {
+      resolveMetadata("ext-1", config, userId) >> Optional.of(restrictedMetadata)
+      hasValidCredential(userId, config) >> true
+      createAccessLink("ext-1", config, userId) >> {
+        throw new AccessLinkCreationException(
+            "Only the dataset owner can create access links")
+      }
+    }
+    def repository = Mock(AssociatedDatasetRepository) {
+      isActiveConnectionPresent(projectId, _) >> false
+    }
+    def registry = Mock(SourceInstanceRegistry) {
+      find("zenodo") >> Optional.of(
+          new SourceInstanceDescriptor("zenodo", "Zenodo",
+              "https://zenodo.org", SourceType.INVENIO_RDM))
+    }
+    def service = createService(source, repository, registry)
+
+    LocalDomainEventDispatcher.instance().reset()
+
+    when:
+    def result = service.connectDataset(
+        projectId, SourceType.INVENIO_RDM, "zenodo",
+        "ext-1", null, userId)
+
+    then:
+    result instanceof Result.Error
+    result.getError() == ConnectDatasetError.ACCESS_LINK_CREATION_FAILED
+    // Invariant: a failed connect must never create a connection. The
+    // access-link step is a hard gate — the aggregate is neither created
+    // nor persisted, and nothing was created on the source to revoke.
+    0 * repository.save(_)
+    0 * source.revokeAccessLink(_, _, _, _)
+  }
+
   def "connectDataset revokes the access link when persistence fails after creation"() {
     given:
     def projectId = ProjectId.parse(VALID_PROJECT_ID)

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/application/associated_dataset/AssociatedDatasetServiceSyncSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/application/associated_dataset/AssociatedDatasetServiceSyncSpec.groovy
@@ -1,0 +1,475 @@
+package life.qbic.projectmanagement.application.associated_dataset
+
+import java.time.LocalDate
+import java.util.concurrent.CopyOnWriteArrayList
+import life.qbic.domain.concepts.DomainEvent
+import life.qbic.domain.concepts.DomainEventDispatcher
+import life.qbic.domain.concepts.DomainEventSubscriber
+import life.qbic.domain.concepts.LocalDomainEventDispatcher
+import life.qbic.identity.api.UserInformationService
+import life.qbic.projectmanagement.application.ProjectInformationService
+import life.qbic.projectmanagement.application.api.ProjectOverviewLookup
+import life.qbic.projectmanagement.application.experiment.ExperimentInformationService
+import life.qbic.projectmanagement.domain.model.associated_dataset.AccessLevel
+import life.qbic.projectmanagement.domain.model.associated_dataset.AssociatedDataset
+import life.qbic.projectmanagement.domain.model.associated_dataset.ExternalHandle
+import life.qbic.projectmanagement.domain.model.associated_dataset.InvenioRdmAccessStatus
+import life.qbic.projectmanagement.domain.model.associated_dataset.InvenioRdmResourceMetadata
+import life.qbic.projectmanagement.domain.model.associated_dataset.SourceType
+import life.qbic.projectmanagement.domain.model.associated_dataset.event.AssociatedDatasetsSyncedEvent
+import life.qbic.projectmanagement.domain.model.associated_dataset.repository.AssociatedDatasetRepository
+import life.qbic.projectmanagement.domain.model.project.ProjectId
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link AssociatedDatasetService#syncDatasets} —
+ * dataset synchronisation (DATSET-04/08, ADR-0006).
+ *
+ * <p>Stubs are hand-rolled Groovy interface coercions (no Spock
+ * {@code Mock()}) so the spec runs without the Mockito mock maker.</p>
+ *
+ * @since 1.13.0
+ */
+class AssociatedDatasetServiceSyncSpec extends Specification {
+
+  private static final String PROJECT_UUID = "0270ce7f-4092-40e3-9c4c-ce7adb688bf5"
+  private static final ProjectId PROJECT = ProjectId.parse(PROJECT_UUID)
+  private static final String USER = "user-1"
+  private static final String CONNECTOR = "connector-1"
+  private static final InstanceConfig CONFIG =
+      new InstanceConfig("zenodo", "Zenodo", "https://zenodo.org")
+
+  private static final List<AssociatedDatasetsSyncedEvent> SYNCED_EVENTS = new CopyOnWriteArrayList<>()
+
+  static {
+    DomainEventDispatcher.instance().subscribe(
+        new DomainEventSubscriber<AssociatedDatasetsSyncedEvent>() {
+          @Override
+          Class<? extends DomainEvent> subscribedToEventType() {
+            return AssociatedDatasetsSyncedEvent
+          }
+
+          @Override
+          void handleEvent(AssociatedDatasetsSyncedEvent event) {
+            SYNCED_EVENTS.add(event)
+          }
+        })
+  }
+
+  def setup() {
+    LocalDomainEventDispatcher.instance().reset()
+    SYNCED_EVENTS.clear()
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────
+
+  private static InvenioRdmResourceMetadata publicV1() {
+    new InvenioRdmResourceMetadata(
+        "Public Dataset", "10.5281/zenodo.1", "v1",
+        "https://zenodo.org/records/111", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 1, 1), null,
+        InvenioRdmAccessStatus.PUBLIC, InvenioRdmAccessStatus.PUBLIC,
+        "zenodo", null, "parent-1")
+  }
+
+  private static InvenioRdmResourceMetadata publicV2() {
+    new InvenioRdmResourceMetadata(
+        "Public Dataset", "10.5281/zenodo.2", "v2",
+        "https://zenodo.org/records/222", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 2, 1), null,
+        InvenioRdmAccessStatus.PUBLIC, InvenioRdmAccessStatus.PUBLIC,
+        null, null, "parent-1")
+  }
+
+  private static InvenioRdmResourceMetadata restrictedV1() {
+    new InvenioRdmResourceMetadata(
+        "Restricted Dataset", "10.5281/zenodo.11", "v1",
+        "https://zenodo.org/records/111?token=old", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 1, 1), null,
+        InvenioRdmAccessStatus.RESTRICTED, InvenioRdmAccessStatus.RESTRICTED,
+        "zenodo", "link-old", "parent-1")
+  }
+
+  private static InvenioRdmResourceMetadata restrictedV2() {
+    new InvenioRdmResourceMetadata(
+        "Restricted Dataset", "10.5281/zenodo.12", "v2",
+        "https://zenodo.org/records/222", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 2, 1), null,
+        InvenioRdmAccessStatus.RESTRICTED, InvenioRdmAccessStatus.RESTRICTED,
+        null, null, "parent-1")
+  }
+
+  private static AssociatedDataset connected(
+      InvenioRdmResourceMetadata metadata, String handle = "111") {
+    AssociatedDataset.connect(
+        PROJECT, SourceType.INVENIO_RDM,
+        new ExternalHandle(handle), metadata, CONNECTOR, null)
+  }
+
+  private AssociatedDatasetService createService(
+      DatasetSource source,
+      AssociatedDatasetRepository repository,
+      SourceInstanceRegistry registry = [
+          find: { id -> Optional.of(new SourceInstanceDescriptor("zenodo", "Zenodo",
+              "https://zenodo.org", SourceType.INVENIO_RDM)) },
+          findBySourceType: { st -> [new SourceInstanceDescriptor("zenodo", "Zenodo",
+              "https://zenodo.org", SourceType.INVENIO_RDM)] }
+      ] as SourceInstanceRegistry) {
+    // The sync path never queries these collaborators; they only need to
+    // satisfy the (NonNull) constructor. Map coercion cannot stub concrete
+    // classes, so stub the interface collaborators and pass nulls for the
+    // remaining constructor parameters.
+    def overviewLookup = [find: { p, f -> [] }] as ProjectOverviewLookup
+    def projectInfo = new ProjectInformationService(overviewLookup, null, null, null)
+    def userInfo = [findById: { id -> Optional.empty() }] as UserInformationService
+    def experimentInfo = new ExperimentInformationService(null, null, null)
+    new AssociatedDatasetService(source, repository, registry, projectInfo, userInfo,
+        experimentInfo)
+  }
+
+  private static SyncDatasetResponse runSync(AssociatedDatasetService service,
+      AssociatedDataset dataset) {
+    service.syncDatasets(PROJECT, [dataset.id()], USER).blockLast()
+  }
+
+  // ── scenarios ─────────────────────────────────────────────────────────
+
+  def "public dataset is updated when the source has a new version"() {
+    given:
+    def dataset = connected(publicV1())
+    def resolved = new ResolvedRecord(publicV2(), "222")
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.UPDATED
+    response.newVersion() == "v2"
+    response.title() == "Public Dataset"
+    response.pid() == "10.5281/zenodo.2"
+    saved != null
+    saved.externalHandle().value() == "222"
+    saved.version() == "v2"
+    SYNCED_EVENTS.size() == 1
+    SYNCED_EVENTS[0].updatedRecords().size() == 1
+    SYNCED_EVENTS[0].updatedRecords()[0].previousVersion() == "v1"
+    SYNCED_EVENTS[0].updatedRecords()[0].newVersion() == "v2"
+  }
+
+  def "no-op sync reports UP_TO_DATE and emits no notification event"() {
+    given:
+    def dataset = connected(publicV1())
+    // resolveLatest returns the same record (instance/link fields left null
+    // by the adapter — the service preserves the stored runtime fields).
+    def resolved = new ResolvedRecord(new InvenioRdmResourceMetadata(
+        "Public Dataset", "10.5281/zenodo.1", "v1",
+        "https://zenodo.org/records/111", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 1, 1), null,
+        InvenioRdmAccessStatus.PUBLIC, InvenioRdmAccessStatus.PUBLIC,
+        null, null, "parent-1"), "111")
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.UP_TO_DATE
+    saved != null
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "first sync of a legacy connection (no parent handle stored) is still UP_TO_DATE"() {
+    given: "a legacy public connection without parentHandle or instanceId"
+    def legacy = new InvenioRdmResourceMetadata(
+        "Public Dataset", "10.5281/zenodo.1", "v1",
+        "https://zenodo.org/records/111", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 1, 1), null,
+        InvenioRdmAccessStatus.PUBLIC, InvenioRdmAccessStatus.PUBLIC,
+        null, null, null)
+    def dataset = connected(legacy)
+    and: "the source now reports the same record but exposes the concept recid"
+    def resolved = new ResolvedRecord(new InvenioRdmResourceMetadata(
+        "Public Dataset", "10.5281/zenodo.1", "v1",
+        "https://zenodo.org/records/111", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 1, 1), null,
+        InvenioRdmAccessStatus.PUBLIC, InvenioRdmAccessStatus.PUBLIC,
+        null, null, "parent-1"), "111")
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.UP_TO_DATE
+    saved != null
+    (saved.resourceMetadata() as InvenioRdmResourceMetadata).parentHandle() == null
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "restricted dataset without a credential is short-circuited with CREDENTIAL_REQUIRED"() {
+    given:
+    def dataset = connected(restrictedV1())
+    def resolveCalls = 0
+    def source = [
+        resolveLatest: { handle, cfg, user -> resolveCalls++; Optional.empty() },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.FAILED
+    response.error() == SyncDatasetError.CREDENTIAL_REQUIRED
+    resolveCalls == 0
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "restricted dataset with insufficient rights resolves to CREDENTIAL_INSUFFICIENT"() {
+    given:
+    def dataset = connected(restrictedV1())
+    def source = [
+        resolveLatest: { handle, cfg, user ->
+          throw new DatasetAccessDeniedException("denied")
+        },
+        hasValidCredential: { u, cfg -> true }
+    ] as DatasetSource
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.FAILED
+    response.error() == SyncDatasetError.CREDENTIAL_INSUFFICIENT
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "record deleted on the source resolves to RECORD_NOT_FOUND and the connection is kept"() {
+    given:
+    def dataset = connected(publicV1())
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.empty() },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.FAILED
+    response.error() == SyncDatasetError.RECORD_NOT_FOUND
+    saved == null
+    dataset.isConnected()
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "restricted version bump refreshes the access link, updates the snapshot and revokes the stale link"() {
+    given:
+    def dataset = connected(restrictedV1())
+    def resolved = new ResolvedRecord(restrictedV2(), "222")
+    def revoked = new ArrayList<String>()
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> true },
+        createAccessLink: { handle, cfg, user ->
+          new CreatedAccessLink("https://zenodo.org/records/222?token=new", "link-new")
+        },
+        revokeAccessLink: { linkId, handle, cfg, user -> revoked.add(linkId) }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.UPDATED
+    response.newVersion() == "v2"
+    saved != null
+    saved.externalHandle().value() == "222"
+    (saved.resourceMetadata() as InvenioRdmResourceMetadata).accessLinkId() == "link-new"
+    (saved.resourceMetadata() as InvenioRdmResourceMetadata).parentHandle() == "parent-1"
+    revoked == ["link-old"]
+    SYNCED_EVENTS.size() == 1
+  }
+
+  def "restricted version bump fails atomically when the access link cannot be created"() {
+    given:
+    def dataset = connected(restrictedV1())
+    def resolved = new ResolvedRecord(restrictedV2(), "222")
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> true },
+        createAccessLink: { handle, cfg, user ->
+          throw new AccessLinkCreationException("not the owner")
+        }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.FAILED
+    response.error() == SyncDatasetError.ACCESS_LINK_REFRESH_FAILED
+    saved == null
+    dataset.version() == "v1"
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "persistence failure after link creation rolls the new access link back"() {
+    given:
+    def dataset = connected(restrictedV1())
+    def resolved = new ResolvedRecord(restrictedV2(), "222")
+    def revoked = new ArrayList<String>()
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> true },
+        createAccessLink: { handle, cfg, user ->
+          new CreatedAccessLink("https://zenodo.org/records/222?token=new", "link-rollback")
+        },
+        revokeAccessLink: { linkId, handle, cfg, user -> revoked.add(linkId) }
+    ] as DatasetSource
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> throw new RuntimeException("DB down") },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.FAILED
+    response.error() == SyncDatasetError.SYNC_FAILED
+    revoked == ["link-rollback"]
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "sync is skipped when the target version is already connected (duplicate guard)"() {
+    given:
+    def dataset = connected(publicV1())
+    def resolved = new ResolvedRecord(publicV2(), "222")
+    def source = [
+        resolveLatest: { handle, cfg, user -> Optional.of(resolved) },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(dataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> true }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def response = runSync(service, dataset)
+
+    then:
+    response.status() == SyncDatasetResponse.SyncStatus.FAILED
+    response.error() == SyncDatasetError.ALREADY_CONNECTED
+    saved == null
+    dataset.version() == "v1"
+    SYNCED_EVENTS.isEmpty()
+  }
+
+  def "a trigger with one update and one no-op emits a single summary event"() {
+    given:
+    def updatedDataset = connected(publicV1(), "111")
+    def unchangedDataset = connected(publicV1(), "121")
+    def ids = [updatedDataset.id(), unchangedDataset.id()]
+    def resolvedUpdate = new ResolvedRecord(publicV2(), "222")
+    def resolvedNoop = new ResolvedRecord(new InvenioRdmResourceMetadata(
+        "Public Dataset", "10.5281/zenodo.1", "v1",
+        "https://zenodo.org/records/121", "Zenodo", [], "Dataset", null,
+        LocalDate.of(2025, 1, 1), null,
+        InvenioRdmAccessStatus.PUBLIC, InvenioRdmAccessStatus.PUBLIC,
+        null, null, "parent-1"), "121")
+    def source = [
+        resolveLatest: { handle, cfg, user ->
+          handle == "111" ? Optional.of(resolvedUpdate) : Optional.of(resolvedNoop)
+        },
+        hasValidCredential: { u, cfg -> false }
+    ] as DatasetSource
+    AssociatedDataset saved
+    def repository = [
+        findById: { id -> Optional.of(id == ids[0] ? updatedDataset : unchangedDataset) },
+        save: { ds -> saved = ds },
+        isActiveConnectionPresent: { p, pid -> false }
+    ] as AssociatedDatasetRepository
+    def service = createService(source, repository)
+
+    when:
+    def responses = service.syncDatasets(
+        PROJECT, [updatedDataset.id(), unchangedDataset.id()], USER).collectList().block()
+
+    then:
+    responses.size() == 2
+    responses.count { it.status() == SyncDatasetResponse.SyncStatus.UPDATED } == 1
+    responses.count { it.status() == SyncDatasetResponse.SyncStatus.UP_TO_DATE } == 1
+    SYNCED_EVENTS.size() == 1
+    SYNCED_EVENTS[0].updatedRecords().size() == 1
+  }
+}

--- a/project-management/src/test/groovy/life/qbic/projectmanagement/domain/model/associated_dataset/AssociatedDatasetSyncSpec.groovy
+++ b/project-management/src/test/groovy/life/qbic/projectmanagement/domain/model/associated_dataset/AssociatedDatasetSyncSpec.groovy
@@ -1,0 +1,129 @@
+package life.qbic.projectmanagement.domain.model.associated_dataset
+
+import life.qbic.domain.concepts.LocalDomainEventDispatcher
+import life.qbic.projectmanagement.domain.model.project.ProjectId
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link AssociatedDataset#sync(ResourceMetadata)} — the
+ * change-diff used by dataset synchronisation (DATSET-04/08, ADR-0006).
+ *
+ * @since 1.13.0
+ */
+class AssociatedDatasetSyncSpec extends Specification {
+
+  private static final String PROJECT_UUID = "0270ce7f-4092-40e3-9c4c-ce7adb688bf5"
+  private static final ProjectId PROJECT = ProjectId.parse(PROJECT_UUID)
+
+  private static final String PARENT_HANDLE = "parent-1"
+
+  def setup() {
+    LocalDomainEventDispatcher.instance().reset()
+  }
+
+  private static AssociatedDataset connected(InvenioRdmResourceMetadata metadata) {
+    AssociatedDataset.connect(
+        PROJECT, SourceType.INVENIO_RDM,
+        new ExternalHandle("ext-1"),
+        metadata, "user-1", null)
+  }
+
+  private static InvenioRdmResourceMetadata metadata(
+      String version,
+      InvenioRdmAccessStatus recordAccess = InvenioRdmAccessStatus.PUBLIC,
+      InvenioRdmAccessStatus fileAccess = InvenioRdmAccessStatus.PUBLIC,
+      String pid = "10.5281/zenodo.1") {
+    new InvenioRdmResourceMetadata(
+        "Test Dataset", pid, version, "https://zenodo.org/records/123",
+        "Zenodo", [], "Dataset", null,
+        java.time.LocalDate.of(2025, 1, 15), null,
+        recordAccess, fileAccess, "zenodo", null, PARENT_HANDLE)
+  }
+
+  def "sync reports no change for an identical snapshot and stamps lastSyncedAt"() {
+    given:
+    def dataset = connected(metadata("v1"))
+
+    when:
+    def change = dataset.sync(metadata("v1"))
+
+    then:
+    !change.metadataChanged()
+    !change.versionChanged()
+    !change.accessStatusChanged()
+    change.previousVersion() == "v1"
+    change.newVersion() == "v1"
+    dataset.lastSyncedAt().isPresent()
+  }
+
+  def "sync reports a version change with previous and new version"() {
+    given:
+    def dataset = connected(metadata("v1"))
+
+    when:
+    def change = dataset.sync(metadata("v2", InvenioRdmAccessStatus.PUBLIC,
+        InvenioRdmAccessStatus.PUBLIC, "10.5281/zenodo.2"))
+
+    then:
+    change.metadataChanged()
+    change.versionChanged()
+    change.previousVersion() == "v1"
+    change.newVersion() == "v2"
+    dataset.version() == "v2"
+    dataset.pid() == "10.5281/zenodo.2"
+  }
+
+  def "sync reports an access status change"() {
+    given:
+    def dataset = connected(metadata("v1", InvenioRdmAccessStatus.RESTRICTED,
+        InvenioRdmAccessStatus.RESTRICTED))
+
+    when: "the embargo is lifted (restricted → public)"
+    def change = dataset.sync(metadata("v1", InvenioRdmAccessStatus.PUBLIC,
+        InvenioRdmAccessStatus.PUBLIC))
+
+    then:
+    change.metadataChanged()
+    change.accessStatusChanged()
+    dataset.accessLevel() == AccessLevel.PUBLIC
+  }
+
+  def "sync keeps universal columns in sync with the snapshot"() {
+    given:
+    def dataset = connected(metadata("v1"))
+
+    when:
+    dataset.sync(metadata("v3", InvenioRdmAccessStatus.RESTRICTED,
+        InvenioRdmAccessStatus.PUBLIC, "10.5281/zenodo.3"))
+
+    then:
+    dataset.title() == "Test Dataset"
+    dataset.pid() == "10.5281/zenodo.3"
+    dataset.version() == "v3"
+    dataset.accessLevel() == AccessLevel.RESTRICTED
+    dataset.resourceMetadata() instanceof InvenioRdmResourceMetadata
+  }
+
+  def "sync rejects null metadata"() {
+    given:
+    def dataset = connected(metadata("v1"))
+
+    when:
+    dataset.sync(null)
+
+    then:
+    thrown(NullPointerException)
+  }
+
+  def "updateMetadata delegates to sync and still updates lastSyncedAt"() {
+    given:
+    def dataset = connected(metadata("v1"))
+
+    when:
+    dataset.updateMetadata(metadata("v2"))
+
+    then:
+    dataset.version() == "v2"
+    dataset.lastSyncedAt().isPresent()
+  }
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR implements and why. Keep it to 2-3 sentences. -->

## Issue and Traceability

### Linked Task Issue
<!-- Every PR must implement a Task issue. Reference it here using the format: #123 -->
- **Closes:** #<!-- Task issue number -->

### Requirement IDs Addressed
<!-- List all functional (R) and non-functional (NFR) requirement IDs this PR addresses.
     Use the format: DOMAIN-TYPE-NN (e.g., SAMPLE-R-01, AUTH-NFR-02, API-R-03)
     Only R and NFR types are valid here. Constraint IDs (C) must NOT be listed.
     If no requirements are addressed, that may indicate missing requirement documentation.
-->
- [ ] Requirement IDs: <!-- e.g., PROJECT-R-01, PROJECT-R-02, SAMPLE-NFR-01 -->

## Requirement Update Status

<!-- Check one of the boxes below: either requirements were updated, or justify why not. -->

- [ ] **Requirements Updated:** The corresponding functional/non-functional requirements in `docs/requirements.md` have been updated to reflect this implementation.
- [ ] **Justification Provided:** This PR does not change externally observable behavior, so no requirement update is needed. (Provide brief justification below)

<!-- If you selected "Justification Provided", explain why no requirement update is necessary:
     Examples: "This is a refactoring with no behavioral change", "This is an internal optimization",
     "This fixes a bug but does not change the specification of the feature" -->
### Justification (if applicable)
<!-- Provide justification here if no requirement update is needed. -->

## Changes Summary

### Modified Areas
<!-- Indicate which parts of the codebase this PR touches. Check all that apply. -->
- [ ] Domain layer (`domain/model/`, domain events, aggregates)
- [ ] Application layer (`application/` services, use cases)
- [ ] Infrastructure layer (JPA repositories, external integrations, config)
- [ ] UI / Views (`views/` components, Vaadin routes)
- [ ] Database schema (`sql/`, DDL changes)
- [ ] Tests (unit, integration, or Spock specs)
- [ ] Documentation, CI/CD, or build configuration
- [ ] Other (describe): <!-- Provide details here -->

### Behavioral Changes
<!-- Does this PR change externally observable behavior? If yes, describe what changed and confirm it's covered by a requirement update above. -->
- [ ] No behavioral changes (internal refactoring, optimization, test addition, etc.)
- [ ] Yes, behavior changes: <!-- Describe the changes and confirm requirement update or justification above -->

## Sensitive Changes Requiring Review
<!-- If your PR touches any of these areas, flag it explicitly below so reviewers pay attention. -->
- [ ] **Database schema changes** (`sql/complete-schema.sql`, table/column DDL)
- [ ] **Spring Security configuration** (`security/`, ACL setup, authentication/authorization)
- [ ] **FAIR / RO-Crate export format** (`docs/fair/`, RO-Crate builder logic)
- [ ] **Artemis messaging topics** (JMS topic names, consumer configuration)
- [ ] **Requirement file edits** (`docs/requirements.md`)
- [ ] None of the above

## Pre-Submission Checklist

<!-- Complete all items before submitting. -->

- [ ] **Issue Linked:** PR references a Task issue (see "Linked Task Issue" section above)
- [ ] **Requirements Listed:** All functional (R) and non-functional (NFR) requirement IDs are listed above
- [ ] **No Constraint IDs:** No `C` (constraint) IDs are listed in the Requirement IDs section
- [ ] **Behavior vs. Requirements:** Requirement update confirmed OR explicit justification provided
- [ ] **Code Style:** Code follows Google Java Style Guide (run formatter before commit)
- [ ] **Tests:** New tests added or existing tests updated to cover changes
- [ ] **No Secrets:** No hardcoded credentials, API keys, passwords, or secrets committed
- [ ] **Documentation:** Updated relevant docs if the change affects user-facing behavior or public APIs

---

### Notes for Reviewers
<!-- Highlight any non-obvious decisions, trade-offs, or areas needing careful review. -->
